### PR TITLE
Feat: Use oracle for token price - added support for Pyth Orace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,4 +64,3 @@ deadpool-redis = "0.14.0"
 vaultrs = "0.7.3"
 tk-rs = { git = "https://github.com/pkxro/tk-rs.git" }
 pyth-sdk-solana = "0.10.3"
-lazy_static = "1.5.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,4 +65,3 @@ vaultrs = "0.7.3"
 tk-rs = { git = "https://github.com/pkxro/tk-rs.git" }
 pyth-sdk-solana = "0.10.3"
 lazy_static = "1.5.0"
-mockall = "0.13.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "crates/cli",
     "scripts",
 ]
+resolver = "2"
 
 [workspace.package]
 version = "0.1.0"
@@ -62,3 +63,6 @@ redis = { version = "0.24.0", features = ["tokio-comp", "connection-manager"] }
 deadpool-redis = "0.14.0"
 vaultrs = "0.7.3"
 tk-rs = { git = "https://github.com/pkxro/tk-rs.git" }
+pyth-sdk-solana = "0.10.3"
+lazy_static = "1.5.0"
+mockall = "0.13.1"

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -8,7 +8,7 @@ use kora_lib::{
     state::init_signer,
     transaction::{
         decode_b58_transaction, estimate_transaction_fee, sign_and_send_transaction,
-        sign_transaction, sign_transaction_if_paid, TokenPriceInfo,
+        sign_transaction, sign_transaction_if_paid,
     },
 };
 
@@ -39,8 +39,6 @@ enum Commands {
         transaction: String,
         #[arg(long)]
         margin: Option<f64>,
-        #[arg(long)]
-        token_price: Option<f64>,
     },
 }
 
@@ -123,7 +121,7 @@ async fn main() -> Result<(), KoraError> {
             let fee = estimate_transaction_fee(&rpc_client, &transaction).await?;
             println!("Estimated fee: {} lamports", fee);
         }
-        Some(Commands::SignIfPaid { transaction, margin, token_price }) => {
+        Some(Commands::SignIfPaid { transaction, margin }) => {
             let rpc_client = create_rpc_client(&cli.args.common.rpc_url).await?;
             let validation = config.validation;
 
@@ -132,16 +130,8 @@ async fn main() -> Result<(), KoraError> {
                 e
             })?;
 
-            let token_price_info = token_price.map(|price| TokenPriceInfo { price });
-
-            let (transaction, signed_tx) = sign_transaction_if_paid(
-                &rpc_client,
-                &validation,
-                transaction,
-                margin,
-                token_price_info,
-            )
-            .await?;
+            let (transaction, signed_tx) =
+                sign_transaction_if_paid(&rpc_client, &validation, transaction, margin).await?;
 
             println!("Signature: {}", transaction.signatures[0]);
             println!("Signed Transaction: {}", signed_tx);

--- a/crates/lib/Cargo.toml
+++ b/crates/lib/Cargo.toml
@@ -42,7 +42,6 @@ log = { workspace = true }
 clap = { workspace = true }
 pyth-sdk-solana = { workspace = true }
 lazy_static = { workspace = true }
-mockall = { workspace = true }
 
 [dev-dependencies]
 tempfile = "3.2"

--- a/crates/lib/Cargo.toml
+++ b/crates/lib/Cargo.toml
@@ -41,7 +41,6 @@ toml = { workspace = true }
 log = { workspace = true }
 clap = { workspace = true }
 pyth-sdk-solana = { workspace = true }
-lazy_static = { workspace = true }
 
 [dev-dependencies]
 tempfile = "3.2"

--- a/crates/lib/Cargo.toml
+++ b/crates/lib/Cargo.toml
@@ -40,6 +40,9 @@ redis = { workspace = true }
 toml = { workspace = true }
 log = { workspace = true }
 clap = { workspace = true }
+pyth-sdk-solana = { workspace = true }
+lazy_static = { workspace = true }
+mockall = { workspace = true }
 
 [dev-dependencies]
 tempfile = "3.2"

--- a/crates/lib/src/config.rs
+++ b/crates/lib/src/config.rs
@@ -1,5 +1,5 @@
 use serde::{Deserialize, Serialize};
-use std::{fs, path::Path};
+use std::{collections::HashMap, fs, path::Path};
 use toml;
 
 use solana_client::nonblocking::rpc_client::RpcClient;
@@ -20,6 +20,7 @@ pub struct ValidationConfig {
     pub allowed_tokens: Vec<String>,
     pub allowed_spl_paid_tokens: Vec<String>,
     pub disallowed_accounts: Vec<String>,
+    pub token_symbols: HashMap<String, String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -57,16 +58,17 @@ mod tests {
     #[test]
     fn test_load_valid_config() {
         let config_content = r#"
-            [validation]
-            max_allowed_lamports = 1000000000
-            max_signatures = 10
-            allowed_programs = ["program1", "program2"]
-            allowed_tokens = ["token1", "token2"]
-            allowed_spl_paid_tokens = ["token3"]
-            disallowed_accounts = ["account1"]
+        [validation]
+        max_allowed_lamports = 1000000000
+        max_signatures = 10
+        allowed_programs = ["program1", "program2"]
+        allowed_tokens = ["token1", "token2"]
+        allowed_spl_paid_tokens = ["token3"]
+        disallowed_accounts = ["account1"]
+        token_symbols = { "So11111111111111111111111111111111111111112" = "SOL", "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v" = "USDC", "Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB" = "USDT" }
 
-            [kora]
-            rate_limit = 100
+        [kora]
+        rate_limit = 100
         "#;
 
         let temp_file = NamedTempFile::new().unwrap();
@@ -81,6 +83,33 @@ mod tests {
         assert_eq!(config.validation.allowed_spl_paid_tokens, vec!["token3"]);
         assert_eq!(config.validation.disallowed_accounts, vec!["account1"]);
         assert_eq!(config.kora.rate_limit, 100);
+
+        let expected_symbols = {
+            let mut m = HashMap::new();
+            m.insert("So11111111111111111111111111111111111111112".to_string(), "SOL".to_string());
+            m.insert(
+                "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v".to_string(),
+                "USDC".to_string(),
+            );
+            m.insert(
+                "Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB".to_string(),
+                "USDT".to_string(),
+            );
+            m
+        };
+        assert_eq!(config.validation.token_symbols, expected_symbols);
+        assert_eq!(
+            config.validation.token_symbols.get("So11111111111111111111111111111111111111112"),
+            Some(&"SOL".to_string())
+        );
+        assert_eq!(
+            config.validation.token_symbols.get("EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"),
+            Some(&"USDC".to_string())
+        );
+        assert_eq!(
+            config.validation.token_symbols.get("Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB"),
+            Some(&"USDT".to_string())
+        );
     }
 
     #[test]
@@ -109,6 +138,7 @@ mod tests {
                 allowed_tokens: vec!["token1".to_string()],
                 allowed_spl_paid_tokens: vec!["token3".to_string()],
                 disallowed_accounts: vec!["account1".to_string()],
+                token_symbols: HashMap::new(),
             },
             kora: KoraConfig { rate_limit: 100 },
         };

--- a/crates/lib/src/constant.rs
+++ b/crates/lib/src/constant.rs
@@ -3,3 +3,4 @@ pub const NATIVE_SOL: &str = "11111111111111111111111111111111";
 pub const JUPITER_API_URL: &str = "https://quote-api.jup.ag/v6";
 pub const LAMPORTS_PER_SIGNATURE: u64 = 5000;
 pub const MIN_BALANCE_FOR_RENT_EXEMPTION: u64 = 2_039_280;
+pub const PYTH_PROGRAM_ID: &str = "FsJ3A3u2vn5cTVofAjvy6y5kwABJAqYWpe4975bi2epH";

--- a/crates/lib/src/error.rs
+++ b/crates/lib/src/error.rs
@@ -4,6 +4,8 @@ use solana_client::client_error::ClientError;
 use solana_sdk::signature::SignerError;
 use thiserror::Error;
 
+use crate::oracle::OracleError;
+
 #[derive(Error, Debug, PartialEq, Eq, Serialize, Deserialize, Clone)]
 pub enum KoraError {
     #[error("Account {0} not found")]
@@ -82,6 +84,12 @@ impl From<std::io::Error> for KoraError {
 impl From<Box<dyn std::error::Error>> for KoraError {
     fn from(e: Box<dyn std::error::Error>) -> Self {
         KoraError::InternalServerError(e.to_string())
+    }
+}
+
+impl From<OracleError> for KoraError {
+    fn from(err: OracleError) -> Self {
+        KoraError::InternalServerError(format!("Oracle error: {}", err))
     }
 }
 

--- a/crates/lib/src/mod.rs
+++ b/crates/lib/src/mod.rs
@@ -6,6 +6,7 @@ pub mod constant;
 pub mod error;
 pub mod jup;
 pub mod log;
+pub mod oracle;
 pub mod rpc;
 pub mod signer;
 pub mod solana;

--- a/crates/lib/src/oracle/mod.rs
+++ b/crates/lib/src/oracle/mod.rs
@@ -1,0 +1,21 @@
+mod pyth;
+mod types;
+
+use pyth::PythOracle;
+use solana_client::nonblocking::rpc_client::RpcClient;
+use solana_sdk::pubkey::Pubkey;
+pub use types::{OracleError, OracleProvider};
+
+pub struct OracleClient<'a> {
+    pyth: PythOracle<'a>,
+}
+
+impl<'a> OracleClient<'a> {
+    pub fn new(rpc_client: &'a RpcClient) -> Self {
+        Self { pyth: PythOracle::new(rpc_client) }
+    }
+
+    pub async fn get_token_price(&self, token_mint: &Pubkey) -> Result<f64, OracleError> {
+        self.pyth.get_price(token_mint).await
+    }
+}

--- a/crates/lib/src/oracle/mod.rs
+++ b/crates/lib/src/oracle/mod.rs
@@ -1,18 +1,28 @@
 mod pyth;
 mod types;
 
+use std::sync::Arc;
+
 use pyth::PythOracle;
 use solana_client::nonblocking::rpc_client::RpcClient;
 use solana_sdk::pubkey::Pubkey;
 pub use types::{OracleError, OracleProvider};
 
+use crate::config::ValidationConfig;
+
+#[derive(Clone)]
 pub struct OracleClient<'a> {
-    pyth: PythOracle<'a>,
+    pyth: Arc<PythOracle<'a>>,
 }
 
 impl<'a> OracleClient<'a> {
-    pub fn new(rpc_client: &'a RpcClient) -> Self {
-        Self { pyth: PythOracle::new(rpc_client) }
+    pub async fn new(
+        rpc_client: &'a RpcClient,
+        config: &ValidationConfig,
+    ) -> Result<Self, OracleError> {
+        let pyth = Arc::new(PythOracle::create(rpc_client, config).await?);
+
+        Ok(Self { pyth })
     }
 
     pub async fn get_token_price(&self, token_mint: &Pubkey) -> Result<f64, OracleError> {

--- a/crates/lib/src/oracle/pyth.rs
+++ b/crates/lib/src/oracle/pyth.rs
@@ -1,0 +1,169 @@
+use crate::oracle::types::{OracleError, OracleProvider};
+use async_trait::async_trait;
+use lazy_static::lazy_static;
+use pyth_sdk_solana::state::SolanaPriceAccount;
+use solana_client::nonblocking::rpc_client::RpcClient;
+use solana_sdk::pubkey::Pubkey;
+use std::{
+    collections::HashMap,
+    str::FromStr,
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+use tokio::time::{sleep, Duration};
+
+const MAX_RETRIES: u32 = 3;
+const RETRY_DELAY_MS: u64 = 1000;
+
+lazy_static! {
+    static ref PYTH_PRICE_ACCOUNTS: HashMap<&'static str, &'static str> = {
+        let mut m = HashMap::new();
+        // SOL/USD
+        m.insert(
+            "So11111111111111111111111111111111111111112",
+            "H6ARHf6YXhGYeQfUzQNGk6rDNnLBQKrenN712K4AQJEG"
+        );
+        m
+    };
+}
+
+pub struct PythOracle<'a> {
+    rpc_client: &'a RpcClient,
+    max_age_secs: u64,
+    max_retries: u32,
+    retry_delay: Duration,
+}
+
+impl<'a> PythOracle<'a> {
+    pub fn new(rpc_client: &'a RpcClient) -> Self {
+        Self {
+            rpc_client,
+            max_age_secs: 60,
+            max_retries: MAX_RETRIES,
+            retry_delay: Duration::from_millis(RETRY_DELAY_MS),
+        }
+    }
+
+    async fn get_price_with_retry(&self, token_mint: &Pubkey) -> Result<f64, OracleError> {
+        let price_key = self.get_price_account(token_mint)?;
+        let mut last_error = None;
+
+        for retry in 0..self.max_retries {
+            match self.fetch_price(&price_key).await {
+                Ok(price) => return Ok(price),
+                Err(e) => {
+                    if retry < self.max_retries - 1 {
+                        log::warn!("Price fetch attempt {} failed: {}, retrying...", retry + 1, e);
+                        sleep(self.retry_delay).await;
+                        last_error = Some(e);
+                    } else {
+                        last_error = Some(e);
+                    }
+                }
+            }
+        }
+
+        Err(last_error.unwrap_or(OracleError::NoPriceAvailable))
+    }
+
+    fn get_price_account(&self, token_mint: &Pubkey) -> Result<Pubkey, OracleError> {
+        let mint_str = token_mint.to_string();
+        let price_account = PYTH_PRICE_ACCOUNTS.get(mint_str.as_str()).ok_or_else(|| {
+            OracleError::OracleError(format!("No price feed found for token {}", mint_str))
+        })?;
+
+        Pubkey::from_str(price_account)
+            .map_err(|e| OracleError::OracleError(format!("Invalid price account pubkey: {}", e)))
+    }
+
+    async fn fetch_price(&self, price_key: &Pubkey) -> Result<f64, OracleError> {
+        let mut price_account =
+            self.rpc_client.get_account(price_key).await.map_err(|e| {
+                OracleError::RpcError(format!("Failed to get price account: {}", e))
+            })?;
+
+        let price_feed = SolanaPriceAccount::account_to_feed(price_key, &mut price_account)
+            .map_err(|e| OracleError::OracleError(format!("Failed to parse price feed: {}", e)))?;
+
+        let current_time = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map_err(|e| OracleError::OracleError(format!("Time error: {}", e)))?
+            .as_secs() as i64;
+
+        let price = price_feed
+            .get_price_no_older_than(current_time, self.max_age_secs)
+            .ok_or_else(|| OracleError::OracleError("Price unavailable or too old".to_string()))?;
+
+        Ok(price.price as f64 * 10f64.powi(price.expo))
+    }
+}
+
+#[async_trait]
+impl OracleProvider for PythOracle<'_> {
+    async fn get_price(&self, token_mint: &Pubkey) -> Result<f64, OracleError> {
+        self.get_price_with_retry(token_mint).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::constant::SOL_MINT;
+
+    use super::*;
+    use mockall::{mock, predicate::*};
+    use solana_sdk::commitment_config::CommitmentConfig;
+
+    // Create mock RpcClient for testing
+    mock! {
+        RpcClient {
+            fn get_account_data(&self, pubkey: &Pubkey) -> Result<Vec<u8>, solana_client::client_error::ClientError>;
+        }
+    }
+
+    #[tokio::test]
+    async fn test_get_price_success() {
+        let rpc_url = "https://pythnet.rpcpool.com".to_string();
+        let rpc_client = RpcClient::new_with_commitment(rpc_url, CommitmentConfig::confirmed());
+
+        let oracle = PythOracle::new(&rpc_client);
+        let sol_mint = Pubkey::from_str(SOL_MINT).unwrap();
+
+        let price = oracle.get_price(&sol_mint).await;
+        assert!(price.is_ok());
+
+        let price_value = price.unwrap();
+        assert!(price_value > 0.0);
+        println!("SOL price: {}", price_value);
+    }
+
+    #[tokio::test]
+    async fn test_get_price_invalid_token() {
+        let rpc_url = "https://pythnet.rpcpool.com".to_string();
+        let rpc_client = RpcClient::new_with_commitment(rpc_url, CommitmentConfig::confirmed());
+
+        let oracle = PythOracle::new(&rpc_client);
+        let invalid_mint = Pubkey::new_unique();
+
+        let result = oracle.get_price(&invalid_mint).await;
+        assert!(matches!(result, Err(OracleError::OracleError(_))));
+    }
+
+    #[tokio::test]
+    async fn test_price_feed_mapping() {
+        let rpc_url = "https://pythnet.rpcpool.com".to_string();
+        let rpc_client = RpcClient::new_with_commitment(rpc_url, CommitmentConfig::confirmed());
+
+        let oracle = PythOracle::new(&rpc_client);
+
+        // Test all supported tokens
+        let tokens = vec![
+            "So11111111111111111111111111111111111111112", // SOL
+        ];
+
+        for token in tokens {
+            let mint = Pubkey::from_str(token).unwrap();
+            let price_account = oracle.get_price_account(&mint);
+            assert!(price_account.is_ok());
+        }
+    }
+}

--- a/crates/lib/src/oracle/pyth.rs
+++ b/crates/lib/src/oracle/pyth.rs
@@ -1,7 +1,10 @@
-use crate::oracle::types::{OracleError, OracleProvider};
+use crate::{
+    config::ValidationConfig,
+    constant::PYTH_PROGRAM_ID,
+    oracle::types::{OracleError, OracleProvider},
+};
 use async_trait::async_trait;
-use lazy_static::lazy_static;
-use pyth_sdk_solana::state::SolanaPriceAccount;
+use pyth_sdk_solana::state::{load_product_account, SolanaPriceAccount};
 use solana_client::nonblocking::rpc_client::RpcClient;
 use solana_sdk::pubkey::Pubkey;
 use std::{
@@ -15,43 +18,90 @@ use tokio::time::{sleep, Duration};
 const MAX_RETRIES: u32 = 3;
 const RETRY_DELAY_MS: u64 = 1000;
 
-lazy_static! {
-    static ref PYTH_PRICE_ACCOUNTS: HashMap<&'static str, &'static str> = {
-        let mut m = HashMap::new();
-        // SOL/USD
-        m.insert(
-            "So11111111111111111111111111111111111111112",
-            "H6ARHf6YXhGYeQfUzQNGk6rDNnLBQKrenN712K4AQJEG"
-        );
-        // USDC/USD
-        m.insert(
-            "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
-            "Gnt27xtC473ZT2Mw5u8wZ68Z3gULkSTb5DuxJy7eJotD"
-        );
-        // USDT/USD
-        m.insert(
-            "Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB",
-            "3vxLXJqLqF3JG5TCbYycbKWRBbCJQLxQmBGCkyqEEefL"
-        );
-        m
-    };
-}
-
 pub struct PythOracle<'a> {
     rpc_client: &'a RpcClient,
     max_age_secs: u64,
     max_retries: u32,
     retry_delay: Duration,
+    price_mapping: HashMap<String, Pubkey>,
+    token_symbols: HashMap<String, String>,
 }
 
 impl<'a> PythOracle<'a> {
-    pub fn new(rpc_client: &'a RpcClient) -> Self {
-        Self {
+    pub async fn create(
+        rpc_client: &'a RpcClient,
+        config: &ValidationConfig,
+    ) -> Result<Self, OracleError> {
+        let price_mapping = Self::build_price_mapping(rpc_client).await?;
+
+        Ok(Self {
             rpc_client,
             max_age_secs: 60,
             max_retries: MAX_RETRIES,
             retry_delay: Duration::from_millis(RETRY_DELAY_MS),
+            price_mapping,
+            token_symbols: config.token_symbols.clone(),
+        })
+    }
+
+    async fn build_price_mapping(
+        rpc_client: &RpcClient,
+    ) -> Result<HashMap<String, Pubkey>, OracleError> {
+        let mut mapping = HashMap::new();
+
+        let pyth_program_id = Pubkey::from_str(PYTH_PROGRAM_ID)
+            .map_err(|e| OracleError::OracleError(format!("Invalid Pyth program ID: {}", e)))?;
+
+        let accounts = rpc_client.get_program_accounts(&pyth_program_id).await.map_err(|e| {
+            OracleError::OracleError(format!("Failed to get program accounts: {}", e))
+        })?;
+
+        for (pubkey, account) in accounts {
+            if let Ok(product) = load_product_account(&account.data) {
+                // First check if it's a crypto product
+                let is_crypto =
+                    product.iter().any(|(key, value)| key == "asset_type" && value == "Crypto");
+
+                if is_crypto {
+                    let mut base_symbol = None;
+                    let mut quote_currency = None;
+
+                    // Then get base and quote symbols
+                    for (key, value) in product.iter() {
+                        match key {
+                            "base" => base_symbol = Some(value),
+                            "quote_currency" => quote_currency = Some(value),
+                            _ => continue,
+                        }
+                    }
+
+                    // Only keep USD pairs
+                    if let (Some(base), Some(quote)) = (base_symbol, quote_currency) {
+                        if quote == "USD" && product.px_acc != Pubkey::default() {
+                            mapping.insert(base.to_string(), product.px_acc);
+                        }
+                    }
+                }
+            }
         }
+
+        Ok(mapping)
+    }
+
+    // Helper function to get token symbol from mint
+    fn get_token_symbol(&self, mint: &Pubkey) -> Result<String, OracleError> {
+        self.token_symbols
+            .get(&mint.to_string())
+            .cloned()
+            .ok_or_else(|| OracleError::OracleError(format!("Unknown token mint: {}", mint)))
+    }
+
+    fn get_price_account(&self, token_mint: &Pubkey) -> Result<Pubkey, OracleError> {
+        let symbol = self.get_token_symbol(token_mint)?;
+
+        self.price_mapping.get(&symbol).copied().ok_or_else(|| {
+            OracleError::OracleError(format!("No price feed found for token {}", symbol))
+        })
     }
 
     async fn get_price_with_retry(&self, token_mint: &Pubkey) -> Result<f64, OracleError> {
@@ -74,16 +124,6 @@ impl<'a> PythOracle<'a> {
         }
 
         Err(last_error.unwrap_or(OracleError::NoPriceAvailable))
-    }
-
-    fn get_price_account(&self, token_mint: &Pubkey) -> Result<Pubkey, OracleError> {
-        let mint_str = token_mint.to_string();
-        let price_account = PYTH_PRICE_ACCOUNTS.get(mint_str.as_str()).ok_or_else(|| {
-            OracleError::OracleError(format!("No price feed found for token {}", mint_str))
-        })?;
-
-        Pubkey::from_str(price_account)
-            .map_err(|e| OracleError::OracleError(format!("Invalid price account pubkey: {}", e)))
     }
 
     async fn fetch_price(&self, price_key: &Pubkey) -> Result<f64, OracleError> {
@@ -117,45 +157,90 @@ impl OracleProvider for PythOracle<'_> {
 
 #[cfg(test)]
 mod tests {
-    use crate::constant::SOL_MINT;
+    use std::fs;
+
+    use crate::{constant::SOL_MINT, load_config, Config};
 
     use super::*;
     use solana_sdk::commitment_config::CommitmentConfig;
+    use tempfile::NamedTempFile;
 
-    #[tokio::test]
-    async fn test_get_price_success() {
+    fn create_test_config() -> (Config, NamedTempFile) {
+        let config_content = r#"
+        [validation]
+        max_allowed_lamports = 1000000000
+        max_signatures = 10
+        allowed_programs = ["11111111111111111111111111111111"]
+        allowed_tokens = ["So11111111111111111111111111111111111111112", "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v","Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB"]
+        allowed_spl_paid_tokens = ["EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"]
+        disallowed_accounts = []
+        token_symbols = {"So11111111111111111111111111111111111111112" = "SOL", "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v" = "USDC","Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB" = "USDT"}
+
+        [kora]
+        rate_limit = 100
+        "#;
+
+        let temp_file = NamedTempFile::new().unwrap();
+        fs::write(&temp_file, config_content).unwrap();
+
+        let config = load_config(temp_file.path()).unwrap_or_else(|e| {
+            panic!("Failed to load test config: {}", e);
+        });
+
+        (config, temp_file)
+    }
+
+    fn create_test_rpc_client() -> RpcClient {
         let rpc_url = "https://pythnet.rpcpool.com".to_string();
-        let rpc_client = RpcClient::new_with_commitment(rpc_url, CommitmentConfig::confirmed());
-
-        let oracle = PythOracle::new(&rpc_client);
-        let sol_mint = Pubkey::from_str(SOL_MINT).unwrap();
-
-        let price = oracle.get_price(&sol_mint).await;
-        assert!(price.is_ok());
-
-        let price_value = price.unwrap();
-        assert!(price_value > 0.0);
-        println!("SOL price: {}", price_value);
+        RpcClient::new_with_commitment(rpc_url, CommitmentConfig::confirmed())
     }
 
     #[tokio::test]
-    async fn test_get_price_invalid_token() {
-        let rpc_url = "https://pythnet.rpcpool.com".to_string();
-        let rpc_client = RpcClient::new_with_commitment(rpc_url, CommitmentConfig::confirmed());
+    async fn test_get_price_success() -> Result<(), OracleError> {
+        let (config, _temp_file) = create_test_config();
+        let rpc_client = create_test_rpc_client();
 
-        let oracle = PythOracle::new(&rpc_client);
+        let oracle = PythOracle::create(&rpc_client, &config.validation).await?;
+        let sol_mint = Pubkey::from_str(SOL_MINT).unwrap();
+
+        let price = oracle.get_price(&sol_mint).await?;
+        assert!(price > 0.0);
+        println!("SOL price: {}", price);
+
+        let usdc_mint = Pubkey::from_str("EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v").unwrap();
+
+        let price = oracle.get_price(&usdc_mint).await?;
+        assert!(price > 0.0);
+        println!("USDC price: {}", price);
+
+        let usdt_mint = Pubkey::from_str("Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB").unwrap();
+
+        let price = oracle.get_price(&usdt_mint).await?;
+        assert!(price > 0.0);
+        println!("USDT price: {}", price);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_get_price_invalid_token() -> Result<(), OracleError> {
+        let (config, _temp_file) = create_test_config();
+        let rpc_client = create_test_rpc_client();
+
+        let oracle = PythOracle::create(&rpc_client, &config.validation).await?;
         let invalid_mint = Pubkey::new_unique();
 
         let result = oracle.get_price(&invalid_mint).await;
         assert!(matches!(result, Err(OracleError::OracleError(_))));
+        Ok(())
     }
 
     #[tokio::test]
-    async fn test_price_feed_mapping() {
-        let rpc_url = "https://pythnet.rpcpool.com".to_string();
-        let rpc_client = RpcClient::new_with_commitment(rpc_url, CommitmentConfig::confirmed());
+    async fn test_price_feed_mapping() -> Result<(), OracleError> {
+        let (config, _temp_file) = create_test_config();
+        let rpc_client = create_test_rpc_client();
 
-        let oracle = PythOracle::new(&rpc_client);
+        let oracle = PythOracle::create(&rpc_client, &config.validation).await?;
 
         // Test all supported tokens
         let tokens = vec![
@@ -169,5 +254,6 @@ mod tests {
             let price_account = oracle.get_price_account(&mint);
             assert!(price_account.is_ok());
         }
+        Ok(())
     }
 }

--- a/crates/lib/src/oracle/pyth.rs
+++ b/crates/lib/src/oracle/pyth.rs
@@ -23,6 +23,16 @@ lazy_static! {
             "So11111111111111111111111111111111111111112",
             "H6ARHf6YXhGYeQfUzQNGk6rDNnLBQKrenN712K4AQJEG"
         );
+        // USDC/USD
+        m.insert(
+            "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "Gnt27xtC473ZT2Mw5u8wZ68Z3gULkSTb5DuxJy7eJotD"
+        );
+        // USDT/USD
+        m.insert(
+            "Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB",
+            "3vxLXJqLqF3JG5TCbYycbKWRBbCJQLxQmBGCkyqEEefL"
+        );
         m
     };
 }
@@ -149,7 +159,9 @@ mod tests {
 
         // Test all supported tokens
         let tokens = vec![
-            "So11111111111111111111111111111111111111112", // SOL
+            "So11111111111111111111111111111111111111112",  // SOL
+            "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v", // USDC
+            "Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB", // USDT
         ];
 
         for token in tokens {

--- a/crates/lib/src/oracle/pyth.rs
+++ b/crates/lib/src/oracle/pyth.rs
@@ -110,15 +110,7 @@ mod tests {
     use crate::constant::SOL_MINT;
 
     use super::*;
-    use mockall::{mock, predicate::*};
     use solana_sdk::commitment_config::CommitmentConfig;
-
-    // Create mock RpcClient for testing
-    mock! {
-        RpcClient {
-            fn get_account_data(&self, pubkey: &Pubkey) -> Result<Vec<u8>, solana_client::client_error::ClientError>;
-        }
-    }
 
     #[tokio::test]
     async fn test_get_price_success() {

--- a/crates/lib/src/oracle/types.rs
+++ b/crates/lib/src/oracle/types.rs
@@ -1,0 +1,18 @@
+use async_trait::async_trait;
+use solana_sdk::pubkey::Pubkey;
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum OracleError {
+    #[error("Price not available")]
+    NoPriceAvailable,
+    #[error("Oracle error: {0}")]
+    OracleError(String),
+    #[error("RPC error: {0}")]
+    RpcError(String),
+}
+
+#[async_trait]
+pub trait OracleProvider {
+    async fn get_price(&self, token_mint: &Pubkey) -> Result<f64, OracleError>;
+}

--- a/crates/lib/src/transaction/validator.rs
+++ b/crates/lib/src/transaction/validator.rs
@@ -299,6 +299,8 @@ pub async fn validate_token_payment(
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
+
     use super::*;
     use solana_sdk::{message::Message, system_instruction};
 
@@ -312,6 +314,7 @@ mod tests {
             allowed_tokens: vec![],
             allowed_spl_paid_tokens: vec![],
             disallowed_accounts: vec![],
+            token_symbols: HashMap::new(),
         };
         let validator = TransactionValidator::new(fee_payer, &config).unwrap();
 
@@ -340,6 +343,7 @@ mod tests {
             allowed_tokens: vec![],
             allowed_spl_paid_tokens: vec![],
             disallowed_accounts: vec![],
+            token_symbols: HashMap::new(),
         };
         let validator = TransactionValidator::new(fee_payer, &config).unwrap();
         let sender = Pubkey::new_unique();
@@ -371,6 +375,7 @@ mod tests {
             allowed_tokens: vec![],
             allowed_spl_paid_tokens: vec![],
             disallowed_accounts: vec![],
+            token_symbols: HashMap::new(),
         };
         let validator = TransactionValidator::new(fee_payer, &config).unwrap();
         let sender = Pubkey::new_unique();
@@ -405,6 +410,7 @@ mod tests {
             allowed_tokens: vec![],
             allowed_spl_paid_tokens: vec![],
             disallowed_accounts: vec![],
+            token_symbols: HashMap::new(),
         };
         let validator = TransactionValidator::new(fee_payer, &config).unwrap();
         let sender = Pubkey::new_unique();
@@ -432,6 +438,7 @@ mod tests {
             allowed_tokens: vec![],
             allowed_spl_paid_tokens: vec![],
             disallowed_accounts: vec![],
+            token_symbols: HashMap::new(),
         };
         let validator = TransactionValidator::new(fee_payer, &config).unwrap();
         let sender = Pubkey::new_unique();
@@ -460,6 +467,7 @@ mod tests {
             allowed_tokens: vec![],
             allowed_spl_paid_tokens: vec![],
             disallowed_accounts: vec![],
+            token_symbols: HashMap::new(),
         };
         let validator = TransactionValidator::new(fee_payer, &config).unwrap();
 
@@ -479,6 +487,7 @@ mod tests {
             allowed_tokens: vec![],
             allowed_spl_paid_tokens: vec![],
             disallowed_accounts: vec!["hndXZGK45hCxfBYvxejAXzCfCujoqkNf7rk4sTB8pek".to_string()],
+            token_symbols: HashMap::new(),
         };
 
         let validator = TransactionValidator::new(fee_payer, &config).unwrap();

--- a/crates/rpc/src/method/sign_transaction_if_paid.rs
+++ b/crates/rpc/src/method/sign_transaction_if_paid.rs
@@ -2,7 +2,6 @@ use kora_lib::{
     config::ValidationConfig,
     transaction::{
         decode_b58_transaction, sign_transaction_if_paid as lib_sign_transaction_if_paid,
-        TokenPriceInfo,
     },
     KoraError,
 };
@@ -14,7 +13,6 @@ use std::sync::Arc;
 pub struct SignTransactionIfPaidRequest {
     pub transaction: String,
     pub margin: Option<f64>,
-    pub token_price_info: Option<TokenPriceInfo>,
 }
 
 #[derive(Debug, Serialize)]
@@ -29,14 +27,8 @@ pub async fn sign_transaction_if_paid(
     request: SignTransactionIfPaidRequest,
 ) -> Result<SignTransactionIfPaidResponse, KoraError> {
     let transaction = decode_b58_transaction(&request.transaction)?;
-    let (transaction, signed_transaction) = lib_sign_transaction_if_paid(
-        rpc_client,
-        validation,
-        transaction,
-        request.margin,
-        request.token_price_info,
-    )
-    .await?;
+    let (transaction, signed_transaction) =
+        lib_sign_transaction_if_paid(rpc_client, validation, transaction, request.margin).await?;
 
     Ok(SignTransactionIfPaidResponse {
         signature: transaction.signatures[0].to_string(),

--- a/kora.toml
+++ b/kora.toml
@@ -16,3 +16,8 @@ allowed_spl_paid_tokens = [
     "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU",  # USDC devnet
 ] 
 disallowed_accounts = []
+token_symbols = { 
+    "So11111111111111111111111111111111111111112" = "SOL",
+    "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v" = "USDC",
+    "Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB" = "USDT",
+}


### PR DESCRIPTION
This PR adds Pyth Oracle to get a real-time price from the Pyth network. Added test case and retry mechanism for the changes made.
. 
 This pull request was created for https://app.gib.work/bounties/9429edb4-175f-40c5-bc29-eb57e79b3a71 in an attempt to solve a bounty #12 . Payment for the bounty is immediately sent to the contributor after merge.