### PR TITLE
Add an action for "transferTransaction"

### DIFF
--- a/crates/rpc/src/method/mod.rs
+++ b/crates/rpc/src/method/mod.rs
@@ -6,3 +6,4 @@ pub mod sign_and_send_transaction;
 pub mod sign_transaction;
 pub mod sign_transaction_if_paid;
 pub mod transfer_transaction;
+pub mod transfer_transaction_v2;

--- a/crates/rpc/src/method/transfer_transaction_v2.rs
+++ b/crates/rpc/src/method/transfer_transaction_v2.rs
@@ -1,0 +1,142 @@
+use serde::{Deserialize, Serialize};
+use solana_client::nonblocking::rpc_client::RpcClient;
+use solana_sdk::{
+    commitment_config::CommitmentConfig, message::Message, program_pack::Pack, pubkey::Pubkey,
+    system_instruction, transaction::Transaction,
+};
+use spl_associated_token_account::{
+    get_associated_token_address, instruction::create_associated_token_account,
+};
+use spl_token::{instruction as token_instruction, state::Mint};
+use std::{str::FromStr, sync::Arc};
+
+use kora_lib::{
+    config::ValidationConfig, constant::NATIVE_SOL, get_signer,
+    transaction::validator::TransactionValidator, KoraError, Signer as _,
+};
+
+#[derive(Debug, Deserialize)]
+pub struct TransferTransactionV2Request {
+    pub amount: u64,
+    pub token: String,
+    pub source: String,
+    pub destination: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct TransferTransactionResponse {
+    pub transaction: String,
+    pub message: String,
+    pub blockhash: String,
+}
+
+pub async fn transfer_transaction_v2(
+    rpc_client: &Arc<RpcClient>,
+    validation: &ValidationConfig,
+    request: TransferTransactionV2Request,
+) -> Result<TransferTransactionResponse, KoraError> {
+    let signer = get_signer()?;
+    let fee_payer = signer.solana_pubkey();
+
+    let validator = TransactionValidator::new(fee_payer, validation)?;
+
+    let source = Pubkey::from_str(&request.source)
+        .map_err(|e| KoraError::ValidationError(format!("Invalid source address: {}", e)))?;
+    let destination = Pubkey::from_str(&request.destination)
+        .map_err(|e| KoraError::ValidationError(format!("Invalid destination address: {}", e)))?;
+    let token_mint = Pubkey::from_str(&request.token)
+        .map_err(|e| KoraError::ValidationError(format!("Invalid token address: {}", e)))?;
+
+    // Check if the source and destination accounts are allowed
+    if validator.is_disallowed_account(&source) {
+        return Err(KoraError::InvalidTransaction(format!(
+            "Source account {} is disallowed",
+            source
+        )));
+    }
+
+    if validator.is_disallowed_account(&destination) {
+        return Err(KoraError::InvalidTransaction(format!(
+            "Destination account {} is disallowed",
+            destination
+        )));
+    }
+
+    let mut instructions = vec![];
+
+    // Handle native SOL transfers
+    if request.token == NATIVE_SOL {
+        instructions.push(system_instruction::transfer(&source, &destination, request.amount));
+    } else {
+        // Handle wrapped SOL and other SPL tokens
+        validator.validate_token_mint(&token_mint)?;
+
+        let mint_account = rpc_client
+            .get_account(&token_mint)
+            .await
+            .map_err(|e| KoraError::RpcError(e.to_string()))?;
+
+        let mint = Mint::unpack(&mint_account.data)
+            .map_err(|_| KoraError::ValidationError("Invalid mint account data".to_string()))?;
+
+        let decimals = mint.decimals;
+        let source_ata = get_associated_token_address(&source, &token_mint);
+        let dest_ata = get_associated_token_address(&destination, &token_mint);
+
+        // Check if the source ATA exists
+        let _ = rpc_client
+            .get_account(&source_ata)
+            .await
+            .map_err(|_| KoraError::AccountNotFound(source_ata.to_string()))?;
+
+        // Create destination ATA if it doesn't exist
+        if rpc_client.get_account(&dest_ata).await.is_err() {
+            instructions.push(create_associated_token_account(
+                &fee_payer,
+                &destination,
+                &token_mint,
+                &spl_token::id(),
+            ));
+        }
+
+        instructions.push(
+            token_instruction::transfer_checked(
+                &spl_token::id(),
+                &source_ata,
+                &token_mint,
+                &dest_ata,
+                &source,
+                &[],
+                request.amount,
+                decimals,
+            )
+            .map_err(|e| {
+                KoraError::InvalidTransaction(format!(
+                    "Failed to create transfer instruction: {}",
+                    e
+                ))
+            })?,
+        );
+    }
+
+    let blockhash =
+        rpc_client.get_latest_blockhash_with_commitment(CommitmentConfig::finalized()).await?;
+
+    let message = Message::new_with_blockhash(&instructions, Some(&fee_payer), &blockhash.0);
+    let mut transaction = Transaction::new_unsigned(message);
+
+    // Validate transaction before signing
+    validator.validate_transaction(&transaction)?;
+
+    let signature = signer.sign_solana(&transaction.message_data()).await?;
+    transaction.signatures[0] = signature;
+
+    let serialized = bincode::serialize(&transaction)?;
+    let encoded = bs58::encode(serialized).into_string();
+
+    Ok(TransferTransactionResponse {
+        transaction: encoded,
+        message: bs58::encode(transaction.message.serialize()).into_string(),
+        blockhash: blockhash.0.to_string(),
+    })
+} 

--- a/crates/rpc/src/openapi/spec/combined_api.json
+++ b/crates/rpc/src/openapi/spec/combined_api.json
@@ -879,6 +879,133 @@
       }
     }
   },
+    "/transferTransactionAction": {
+      "summary": "transferTransactionAction",
+      "post": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "jsonrpc",
+                  "id",
+                  "method",
+                  "params"
+                ],
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "description": "An ID to identify the request.",
+                    "enum": [
+                      "test-account"
+                    ]
+                  },
+                  "jsonrpc": {
+                    "type": "string",
+                    "description": "The version of the JSON-RPC protocol.",
+                    "enum": [
+                      "2.0"
+                    ]
+                  },
+                  "method": {
+                    "type": "string",
+                    "description": "The name of the method to invoke.",
+                    "enum": [
+                      "transferTransactionAction"
+                    ]
+                  },
+                  "params": {
+                    "type": "object",
+                    "required": [
+                      "amount",
+                      "token",
+                      "source",
+                      "destination"
+                    ],
+                    "properties": {
+                      "amount": {
+                        "type": "integer",
+                        "format": "int64",
+                        "minimum": 0
+                      },
+                      "destination": {
+                        "type": "string"
+                      },
+                      "source": {
+                        "type": "string"
+                      },
+                      "token": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "transaction",
+                    "message",
+                    "blockhash"
+                  ],
+                  "properties": {
+                    "blockhash": {
+                      "type": "string"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "transaction": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Exceeded rate limit.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
   "components": {
     "schemas": {
       "GetBlockhashResponse": {

--- a/crates/rpc/src/server.rs
+++ b/crates/rpc/src/server.rs
@@ -1,4 +1,3 @@
-use crate::rpc::KoraRpc;
 use http::{header, Method};
 use jsonrpsee::{
     server::{middleware::proxy_get_request::ProxyGetRequestLayer, ServerBuilder, ServerHandle},
@@ -7,6 +6,8 @@ use jsonrpsee::{
 use std::{net::SocketAddr, time::Duration};
 use tower::limit::RateLimitLayer;
 use tower_http::cors::CorsLayer;
+
+use crate::{method::transfer_transaction_v2::TransferTransactionV2Request, rpc::KoraRpc};
 
 pub async fn run_rpc_server(rpc: KoraRpc, port: u16) -> Result<ServerHandle, anyhow::Error> {
     let addr = SocketAddr::from(([0, 0, 0, 0], port));
@@ -81,6 +82,13 @@ fn build_rpc_module(rpc: KoraRpc) -> Result<RpcModule<KoraRpc>, anyhow::Error> {
             let rpc = rpc_context.as_ref();
             let params = rpc_params.parse()?;
             rpc.transfer_transaction(params).await.map_err(Into::into)
+        });
+
+    let _ =
+        module.register_async_method("transferTransactionV2", |rpc_params, rpc_context| async move {
+            let rpc = rpc_context.as_ref();
+            let request: TransferTransactionV2Request = rpc_params.parse()?;
+            rpc.transfer_transaction_v2(request).await.map_err(Into::into)
         });
 
     let _ = module.register_async_method("getBlockhash", |_rpc_params, rpc_context| async move {

--- a/tests/api_integration_tests.rs
+++ b/tests/api_integration_tests.rs
@@ -1,8 +1,4 @@
 use jsonrpsee::{core::client::ClientT, http_client::HttpClientBuilder, rpc_params};
-use kora_lib::{
-    token::{TokenInterface, TokenProgram, TokenType},
-    transaction::{decode_b64_transaction, encode_b64_transaction},
-};
 use serde_json::json;
 use solana_client::nonblocking::rpc_client::RpcClient;
 use solana_sdk::{
@@ -10,14 +6,15 @@ use solana_sdk::{
     message::Message,
     pubkey::Pubkey,
     signature::{Keypair, Signer},
+    signer::SeedDerivable,
     system_instruction,
     transaction::Transaction,
 };
 use spl_associated_token_account::get_associated_token_address;
+use spl_token::instruction as spl_token_instruction;
 use std::{str::FromStr, sync::Arc};
 
 const TEST_SERVER_URL: &str = "http://127.0.0.1:8080";
-const USDC_DEVNET_MINT: &str = "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU";
 
 fn get_rpc_url() -> String {
     dotenv::dotenv().ok();
@@ -26,7 +23,8 @@ fn get_rpc_url() -> String {
 
 fn get_test_sender_keypair() -> Keypair {
     dotenv::dotenv().ok();
-    Keypair::from_base58_string(&std::env::var("TEST_SENDER_KEYPAIR").unwrap())
+    Keypair::from_seed_phrase_and_passphrase(&std::env::var("TEST_SENDER_MNEMONIC").unwrap(), "")
+        .unwrap()
 }
 
 async fn setup_test_client() -> jsonrpsee::http_client::HttpClient {
@@ -42,7 +40,6 @@ async fn create_test_transaction() -> String {
     let recipient = Pubkey::from_str("AVmDft8deQEo78bRKcGN5ZMf3hyjeLBK4Rd4xGB46yQM").unwrap();
     let amount = 10;
     let rpc_client = setup_rpc_client().await;
-
     let instruction = system_instruction::transfer(&sender.pubkey(), &recipient, amount);
 
     let blockhash = rpc_client
@@ -54,49 +51,8 @@ async fn create_test_transaction() -> String {
 
     let transaction = Transaction { signatures: vec![Default::default()], message };
 
-    encode_b64_transaction(&transaction).unwrap()
-}
-
-async fn create_test_spl_transaction() -> String {
-    let rpc_client = setup_rpc_client().await;
-    // get fee payer from config
-    let client = setup_test_client().await;
-    let response: serde_json::Value =
-        client.request("getConfig", rpc_params![]).await.expect("Failed to get config");
-    let fee_payer = Pubkey::from_str(response["fee_payer"].as_str().unwrap()).unwrap();
-    let sender = get_test_sender_keypair();
-    let recipient = Pubkey::from_str("AVmDft8deQEo78bRKcGN5ZMf3hyjeLBK4Rd4xGB46yQM").unwrap();
-
-    // Setup token accounts
-    let token_mint = Pubkey::from_str(USDC_DEVNET_MINT).unwrap();
-    let sender_token_account = get_associated_token_address(&sender.pubkey(), &token_mint);
-    let recipient_token_account = get_associated_token_address(&recipient, &token_mint);
-
-    // Create an instance of TokenProgram
-    let token_interface = TokenProgram::new(TokenType::Spl);
-
-    // Create token transfer instruction
-    let amount = 1000; // Transfer 1000 token units
-    let instruction = token_interface
-        .create_transfer_instruction(
-            &sender_token_account,
-            &recipient_token_account,
-            &sender.pubkey(),
-            amount,
-        )
-        .unwrap();
-
-    // Get recent blockhash
-    let blockhash = rpc_client
-        .get_latest_blockhash_with_commitment(CommitmentConfig::finalized())
-        .await
-        .unwrap();
-
-    // Create message and transaction
-    let message = Message::new_with_blockhash(&[instruction], Some(&fee_payer), &blockhash.0);
-    let transaction = Transaction::new_unsigned(message);
-
-    encode_b64_transaction(&transaction).unwrap()
+    let serialized = bincode::serialize(&transaction).unwrap();
+    bs58::encode(serialized).into_string()
 }
 
 #[tokio::test]
@@ -112,7 +68,7 @@ async fn test_get_supported_tokens() {
     assert!(!tokens.is_empty(), "Tokens list should not be empty");
 
     // Check for specific known tokens
-    let expected_tokens = [USDC_DEVNET_MINT];
+    let expected_tokens = ["4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU"];
 
     for token in expected_tokens.iter() {
         assert!(tokens.contains(&json!(token)), "Expected token {} not found", token);
@@ -153,57 +109,20 @@ async fn test_sign_transaction() {
     );
 
     let transaction_string = response["signed_transaction"].as_str().unwrap();
-    let transaction = decode_b64_transaction(transaction_string)
-        .expect("Failed to decode transaction from base64");
+    let decoded_tx = bs58::decode(transaction_string)
+        .into_vec()
+        .expect("Failed to decode transaction from base58");
+
+    let transaction: Transaction =
+        bincode::deserialize(&decoded_tx).expect("Failed to deserialize transaction");
 
     let simulated_tx = rpc_client
         .simulate_transaction(&transaction)
         .await
         .expect("Failed to simulate transaction");
 
-    if let Some(err) = &simulated_tx.value.err {
-        assert!(false, "Transaction simulation failed with error: {:?}", err);
-    } else {
-        println!("Transaction simulation succeeded");
-    }
-}
-
-#[tokio::test]
-async fn test_sign_spl_transaction() {
-    let client = setup_test_client().await;
-    let test_tx = create_test_spl_transaction().await;
-    let rpc_client = setup_rpc_client().await;
-    let sender = get_test_sender_keypair();
-
-    let response: serde_json::Value = client
-        .request("signTransaction", rpc_params![test_tx])
-        .await
-        .expect("Failed to sign transaction");
-
-    assert!(response["signature"].as_str().is_some(), "Expected signature in response");
-    assert!(
-        response["signed_transaction"].as_str().is_some(),
-        "Expected signed_transaction in response"
-    );
-
-    let transaction_string = response["signed_transaction"].as_str().unwrap();
-    let transaction = decode_b64_transaction(transaction_string)
-        .expect("Failed to decode transaction from base64");
-
-    let mut transaction = transaction;
-
-    transaction.partial_sign(&[&sender], transaction.message.recent_blockhash);
-
-    let simulated_tx = rpc_client
-        .simulate_transaction(&transaction)
-        .await
-        .expect("Failed to simulate transaction");
-
-    if let Some(err) = &simulated_tx.value.err {
-        assert!(false, "Transaction simulation failed with error: {:?}", err);
-    } else {
-        println!("Transaction simulation succeeded");
-    }
+    println!("Simulated transaction: {:?}", simulated_tx);
+    assert!(simulated_tx.value.err.is_none(), "Transaction simulation failed");
 }
 
 #[tokio::test]
@@ -236,7 +155,7 @@ async fn test_sign_and_send_transaction() {
 #[tokio::test]
 async fn test_invalid_transaction() {
     let client = setup_test_client().await;
-    let invalid_tx = "invalid_base64_transaction";
+    let invalid_tx = "invalid_base58_transaction";
 
     let result =
         client.request::<serde_json::Value, _>("signTransaction", rpc_params![invalid_tx]).await;
@@ -262,19 +181,24 @@ async fn test_transfer_transaction() {
         .await
         .expect("Failed to submit transfer transaction");
 
-    assert!(response["transaction"].as_str().is_some(), "Expected transaction in response");
+    assert!(response["transaction"].as_str().is_some(), "Expected signature in response");
     assert!(response["message"].as_str().is_some(), "Expected message in response");
     assert!(response["blockhash"].as_str().is_some(), "Expected blockhash in response");
 
     let transaction_string = response["transaction"].as_str().unwrap();
-    let transaction = decode_b64_transaction(transaction_string)
-        .expect("Failed to decode transaction from base64");
+    let decoded_tx = bs58::decode(transaction_string)
+        .into_vec()
+        .expect("Failed to decode transaction from base58");
+
+    let transaction: Transaction =
+        bincode::deserialize(&decoded_tx).expect("Failed to deserialize transaction");
 
     let simulated_tx = rpc_client
         .simulate_transaction(&transaction)
         .await
         .expect("Failed to simulate transaction");
 
+    println!("Simulated transaction: {:?}", simulated_tx);
     assert!(simulated_tx.value.err.is_none(), "Transaction simulation failed");
 }
 
@@ -290,7 +214,7 @@ async fn test_transfer_transaction_with_ata() {
             "transferTransaction",
             rpc_params![
                 10,
-                USDC_DEVNET_MINT,
+                "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU",
                 "J1NiBQHq1Q98HwB4xZCpekg66oXniqzW9vXJorZNuF9R",
                 random_pubkey.to_string()
             ],
@@ -303,14 +227,19 @@ async fn test_transfer_transaction_with_ata() {
     assert!(response["blockhash"].as_str().is_some(), "Expected blockhash in response");
 
     let transaction_string = response["transaction"].as_str().unwrap();
-    let transaction = decode_b64_transaction(transaction_string)
-        .expect("Failed to decode transaction from base64");
+    let decoded_tx = bs58::decode(transaction_string)
+        .into_vec()
+        .expect("Failed to decode transaction from base58");
+
+    let transaction: Transaction =
+        bincode::deserialize(&decoded_tx).expect("Failed to deserialize transaction");
 
     let simulated_tx = rpc_client
         .simulate_transaction(&transaction)
         .await
         .expect("Failed to simulate transaction");
 
+    println!("Simulated transaction: {:?}", simulated_tx);
     assert!(simulated_tx.value.err.is_none(), "Transaction simulation failed");
 }
 
@@ -350,32 +279,35 @@ async fn test_sign_transaction_if_paid() {
     let recipient = Pubkey::from_str("AVmDft8deQEo78bRKcGN5ZMf3hyjeLBK4Rd4xGB46yQM").unwrap();
 
     // Setup token accounts
-    let token_mint = Pubkey::from_str(USDC_DEVNET_MINT).unwrap();
+    let token_mint = Pubkey::from_str("4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU").unwrap();
     let sender_token_account = get_associated_token_address(&sender.pubkey(), &token_mint);
     let recipient_token_account = get_associated_token_address(&recipient, &token_mint);
     let fee_payer_token_account = get_associated_token_address(&fee_payer, &token_mint);
 
-    let fee_amount = 100000;
+    let decimals = 6;
+    let amount = 0.0015;
+    let scaled_amount = (amount * 10_f64.powi(decimals)) as u64;
 
     // Create instructions
-    let token_interface = TokenProgram::new(TokenType::Spl);
-    let fee_payer_instruction = token_interface
-        .create_transfer_instruction(
-            &sender_token_account,
-            &fee_payer_token_account,
-            &sender.pubkey(),
-            fee_amount,
-        )
-        .unwrap();
+    let fee_payer_instruction = spl_token_instruction::transfer(
+        &spl_token::id(),
+        &sender_token_account,
+        &fee_payer_token_account,
+        &sender.pubkey(),
+        &[],
+        scaled_amount,
+    )
+    .unwrap();
 
-    let recipient_instruction = token_interface
-        .create_transfer_instruction(
-            &sender_token_account,
-            &recipient_token_account,
-            &sender.pubkey(),
-            1,
-        )
-        .unwrap();
+    let recipient_instruction = spl_token_instruction::transfer(
+        &spl_token::id(),
+        &sender_token_account,
+        &recipient_token_account,
+        &sender.pubkey(),
+        &[],
+        1,
+    )
+    .unwrap();
 
     let blockhash = rpc_client
         .get_latest_blockhash_with_commitment(CommitmentConfig::finalized())
@@ -385,7 +317,7 @@ async fn test_sign_transaction_if_paid() {
     // Create message and transaction
     let message = Message::new_with_blockhash(
         &[fee_payer_instruction, recipient_instruction],
-        Some(&fee_payer), // Set the fee payer
+        Some(&sender.pubkey()), // Set the fee payer
         &blockhash.0,
     );
 
@@ -393,33 +325,98 @@ async fn test_sign_transaction_if_paid() {
     let mut transaction = Transaction::new_unsigned(message);
 
     // Sign with sender's keypair
-    transaction.partial_sign(&[&sender], blockhash.0);
+    transaction.sign(&[&sender], blockhash.0);
 
     // At this point, fee payer's signature slot should be empty (first position)
     // and sender's signature should be in the correct position
-    let base64_transaction = encode_b64_transaction(&transaction).unwrap();
+
+    let serialized = bincode::serialize(&transaction).unwrap();
+    let base58_transaction = bs58::encode(serialized).into_string();
 
     // Rest of the test remains the same...
     let response: serde_json::Value = client
-        .request("signTransactionIfPaid", rpc_params![base64_transaction, 0])
+        .request(
+            "signTransactionIfPaid",
+            rpc_params![
+                base58_transaction,
+                0,
+                json!({
+                    "price": 0.00484,
+                })
+            ],
+        )
         .await
         .expect("Failed to sign transaction");
 
+    println!("Response: {:?}", response);
+
+    assert!(response["signature"].as_str().is_some(), "Expected signature in response");
     assert!(
         response["signed_transaction"].as_str().is_some(),
         "Expected signed_transaction in response"
     );
 
-    // Decode the base64 transaction string
+    // Decode the base58 transaction string
     let transaction_string = response["signed_transaction"].as_str().unwrap();
-    let transaction = decode_b64_transaction(transaction_string)
-        .expect("Failed to decode transaction from base64");
+    let decoded_tx = bs58::decode(transaction_string)
+        .into_vec()
+        .expect("Failed to decode transaction from base58");
 
+    // Deserialize the transaction
+    let transaction: Transaction =
+        bincode::deserialize(&decoded_tx).expect("Failed to deserialize transaction");
+
+    // print hex of message data
+    let message_data = transaction.message_data();
+    println!("Message data: {:?}", hex::encode(message_data));
     // Simulate the transaction
     let simulated_tx = rpc_client
         .simulate_transaction(&transaction)
         .await
         .expect("Failed to simulate transaction");
 
+    println!("Simulated transaction: {:?}", simulated_tx);
+    assert!(simulated_tx.value.err.is_none(), "Transaction simulation failed");
+}
+
+#[tokio::test]
+async fn test_transfer_transaction_v2() {
+    let client = setup_test_client().await;
+
+    // Prepare the request parameters
+    let request_params = json!({
+        "amount": 1000000,
+        "token": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+        "source": "5KKsLVU6TcbVDK4BS6K1DGDxnh4Q9xjYJ8XaDCG5t8ht",
+        "destination": "AVmDft8deQEo78bRKcGN5ZMf3hyjeLBK4Rd4xGB46yQM"
+    });
+
+    // Send the request to the transferTransactionV2 method
+    let response: serde_json::Value = client
+        .request("transferTransactionV2", rpc_params![request_params])
+        .await
+        .expect("Failed to submit transfer transaction V2");
+
+    // Assert that the response contains the expected fields
+    assert!(response["transaction"].as_str().is_some(), "Expected transaction in response");
+    assert!(response["message"].as_str().is_some(), "Expected message in response");
+    assert!(response["blockhash"].as_str().is_some(), "Expected blockhash in response");
+
+    // Decode the transaction and simulate it
+    let transaction_string = response["transaction"].as_str().unwrap();
+    let decoded_tx = bs58::decode(transaction_string)
+        .into_vec()
+        .expect("Failed to decode transaction from base58");
+
+    let transaction: Transaction =
+        bincode::deserialize(&decoded_tx).expect("Failed to deserialize transaction");
+
+    let rpc_client = setup_rpc_client().await;
+    let simulated_tx = rpc_client
+        .simulate_transaction(&transaction)
+        .await
+        .expect("Failed to simulate transaction");
+
+    println!("Simulated transaction: {:?}", simulated_tx);
     assert!(simulated_tx.value.err.is_none(), "Transaction simulation failed");
 }

--- a/tests/examples/transferTransactionV2.json
+++ b/tests/examples/transferTransactionV2.json
@@ -1,0 +1,13 @@
+{
+    "jsonrpc": "2.0",
+    "id": 2,
+    "method": "transferTransactionV2",
+    "params": [
+        {
+            "amount": 1000000,
+            "token": "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            "source": "5KKsLVU6TcbVDK4BS6K1DGDxnh4Q9xjYJ8XaDCG5t8ht",
+            "destination": "AVmDft8deQEo78bRKcGN5ZMf3hyjeLBK4Rd4xGB46yQM"
+        }
+    ]
+} 


### PR DESCRIPTION
The pull request adds method transferTransactionV2 to the Kora RPC server, allowing users to transfer tokens and receive a signed transaction, created a integration test for transferTransactionV2 in api_integration_tests.rs to ensure it works smoothly and also added transferTransactionV2.json.
