### PR TITLE
refactor: signer interfaces to accept Transaction objects

### DIFF
--- a/crates/lib/src/signer/signer.rs
+++ b/crates/lib/src/signer/signer.rs
@@ -57,12 +57,12 @@ impl super::Signer for KoraSigner {
             // Some signers expect the serialized message, others expect the message bytes
             KoraSigner::Memory(signer) => signer.sign(transaction).await,
             KoraSigner::Turnkey(signer) => {
-                let sig = signer.sign(&transaction.message_data()).await?;
+                let sig = signer.sign(transaction).await?;
                 Ok(super::Signature { bytes: sig, is_partial: false })
             }
             KoraSigner::Vault(signer) => signer.sign(transaction).await,
             KoraSigner::Privy(signer) => {
-                let sig = signer.sign(&bincode::serialize(&transaction)?).await?;
+                let sig = signer.sign(transaction).await?;
                 Ok(super::Signature { bytes: sig, is_partial: false })
             }
         }
@@ -77,12 +77,11 @@ impl super::Signer for KoraSigner {
             KoraSigner::Memory(signer) => signer.sign_solana(transaction).await,
             KoraSigner::Vault(signer) => signer.sign_solana(transaction).await,
             KoraSigner::Turnkey(signer) => {
-                signer.sign_solana(&transaction.message_data()).await.map_err(KoraError::from)
+                signer.sign_solana(transaction).await.map_err(KoraError::from)
             }
-            KoraSigner::Privy(signer) => signer
-                .sign_solana(&bincode::serialize(&transaction)?)
-                .await
-                .map_err(KoraError::from),
+            KoraSigner::Privy(signer) => {
+                signer.sign_solana(transaction).await.map_err(KoraError::from)
+            }
         }
     }
 }

--- a/crates/privy/src/types.rs
+++ b/crates/privy/src/types.rs
@@ -82,6 +82,7 @@ pub enum PrivyError {
     InvalidResponse,
     InvalidPublicKey,
     InvalidSignature,
+    SerializationError,
     RequestError(reqwest::Error),
     JsonError(serde_json::Error),
     Base64Error(base64::DecodeError),
@@ -93,17 +94,18 @@ pub enum PrivyError {
 impl std::fmt::Display for PrivyError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            PrivyError::MissingConfig(field) => write!(f, "Missing config: {}", field),
-            PrivyError::ApiError(status) => write!(f, "API error: {}", status),
+            PrivyError::MissingConfig(field) => write!(f, "Missing config: {field}"),
+            PrivyError::ApiError(status) => write!(f, "API error: {status}"),
             PrivyError::InvalidResponse => write!(f, "Invalid response"),
             PrivyError::InvalidPublicKey => write!(f, "Invalid public key"),
             PrivyError::InvalidSignature => write!(f, "Invalid signature"),
-            PrivyError::RequestError(e) => write!(f, "Request error: {}", e),
-            PrivyError::JsonError(e) => write!(f, "JSON error: {}", e),
-            PrivyError::Base64Error(e) => write!(f, "Base64 error: {}", e),
+            PrivyError::SerializationError => write!(f, "Serialization error"),
+            PrivyError::RequestError(e) => write!(f, "Request error: {e}"),
+            PrivyError::JsonError(e) => write!(f, "JSON error: {e}"),
+            PrivyError::Base64Error(e) => write!(f, "Base64 error: {e}"),
             PrivyError::InitializationError => write!(f, "Initialization error"),
             PrivyError::RuntimeError => write!(f, "Runtime error"),
-            PrivyError::Other(e) => write!(f, "{}", e),
+            PrivyError::Other(e) => write!(f, "{e}"),
         }
     }
 }

--- a/crates/turnkey/src/mod.rs
+++ b/crates/turnkey/src/mod.rs
@@ -7,6 +7,7 @@ use reqwest::Client;
 mod types;
 mod utils;
 
+use solana_sdk::transaction::Transaction;
 pub use types::*;
 pub use utils::*;
 
@@ -28,8 +29,8 @@ impl TurnkeySigner {
         })
     }
 
-    pub async fn sign(&self, message: &[u8]) -> Result<Vec<u8>, anyhow::Error> {
-        let hex_message = hex::encode(message);
+    pub async fn sign(&self, transaction: &Transaction) -> Result<Vec<u8>, anyhow::Error> {
+        let hex_message = hex::encode(transaction.message_data());
 
         let request = SignRequest {
             activity_type: "ACTIVITY_TYPE_SIGN_RAW_PAYLOAD_V2".to_string(),
@@ -95,9 +96,9 @@ impl TurnkeySigner {
 
     pub async fn sign_solana(
         &self,
-        message: &[u8],
+        transaction: &Transaction,
     ) -> Result<solana_sdk::signature::Signature, anyhow::Error> {
-        let sig = self.sign(message).await?;
+        let sig = self.sign(transaction).await?;
         let sig_bytes: [u8; 64] = sig.try_into().unwrap();
         Ok(solana_sdk::signature::Signature::from(sig_bytes))
     }


### PR DESCRIPTION
Updated PrivySigner and TurnkeySigner to accept &Transaction instead of raw message bytes for signing methods. Adjusted KoraSigner logic to pass Transaction objects directly, simplifying serialization and improving type safety. Added SerializationError to PrivyError for better error handling.

now all methods take `.sign_solana(transaction)`