### PR TITLE
feat: (PRO-69) Implement API Key and HMAC Authentication for Kora RPC

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
         with:
-          components: rustfmt, clippy
+          components: rustfmt, clippy, llvm-tools-preview
       - uses: Swatinem/rust-cache@v2
       - name: Check formatting
         run: make check
@@ -50,6 +50,8 @@ jobs:
 
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
@@ -62,30 +64,22 @@ jobs:
       - name: Setup Solana test validator
         uses: ./.github/actions/setup-solana-validator
 
-      - name: Setup Kora RPC server
-        uses: ./.github/actions/setup-kora-rpc
-
-      - name: Setup test environment
-        run: |
-          echo "🔧 Setting up test environment..."
-          cargo run -p tests --bin setup-test-env
-
       - name: Install cargo-llvm-cov for coverage
         run: cargo install cargo-llvm-cov
 
-      - name: Run integration tests with coverage
+      - name: Run all tests with coverage
         run: |
-          echo "🧪 Running integration tests with coverage..."
+          echo "🧪 Running all tests with coverage..."
           # Clean previous coverage data
           cargo llvm-cov clean --workspace
 
-          # Run unit tests with coverage
+          # Run unit tests with coverage first
           echo "Running unit tests with coverage..."
-          cargo llvm-cov --workspace --no-report
+          cargo llvm-cov --lib --no-report
 
-          # Run integration tests with coverage
+          # Run integration tests with proper server setup
           echo "Running integration tests with coverage..."
-          cargo llvm-cov --workspace --tests --no-report
+          make test-integration-coverage
 
           # Generate reports
           echo "Generating coverage reports..."

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -86,14 +86,7 @@ jobs:
       - name: Run regular integration tests with coverage
         run: |
           echo "🧪 Running regular integration tests..."
-          # Find and run all test files except auth_integration_tests
-          for test_file in tests/*_test*.rs tests/*integration*.rs; do
-            if [[ -f "$test_file" && ! "$test_file" =~ auth_integration_tests ]]; then
-              test_name=$(basename "$test_file" .rs)
-              echo "Running test: $test_name"
-              cargo llvm-cov test --no-report --test "$test_name" || exit 1
-            fi
-          done
+          cargo llvm-cov test --no-report --tests -- --skip auth_integration_tests
 
       - name: Stop Kora RPC server
         run: |

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -67,22 +67,54 @@ jobs:
       - name: Install cargo-llvm-cov for coverage
         run: cargo install cargo-llvm-cov
 
-      - name: Run all tests with coverage
+      - name: Run unit tests with coverage
         run: |
-          echo "🧪 Running all tests with coverage..."
-          # Clean previous coverage data
+          echo "🧪 Running unit tests with coverage..."
           cargo llvm-cov clean --workspace
-
-          # Run unit tests with coverage first
-          echo "Running unit tests with coverage..."
           cargo llvm-cov --lib --no-report
 
-          # Run integration tests with proper server setup
-          echo "Running integration tests with coverage..."
-          make test-integration-coverage
+      - name: Setup test environment
+        run: |
+          echo "🔧 Setting up test environment..."
+          cargo run -p tests --bin setup-test-env
 
-          # Generate reports
-          echo "Generating coverage reports..."
+      - name: Setup Kora RPC server (regular config)
+        uses: ./.github/actions/setup-kora-rpc
+        with:
+          config-file: 'tests/kora-test.toml'
+
+      - name: Run regular integration tests with coverage
+        run: |
+          echo "🧪 Running regular integration tests..."
+          # Find and run all test files except auth_integration_tests
+          for test_file in tests/*_test*.rs tests/*integration*.rs; do
+            if [[ -f "$test_file" && ! "$test_file" =~ auth_integration_tests ]]; then
+              test_name=$(basename "$test_file" .rs)
+              echo "Running test: $test_name"
+              cargo llvm-cov test --no-report --test "$test_name" || exit 1
+            fi
+          done
+
+      - name: Stop Kora RPC server
+        run: |
+          if [ ! -z "$KORA_PID" ]; then
+            kill $KORA_PID || true
+          fi
+          sleep 2
+
+      - name: Setup Kora RPC server (auth config)
+        uses: ./.github/actions/setup-kora-rpc
+        with:
+          config-file: 'tests/fixtures/auth-test.toml'
+
+      - name: Run auth integration tests with coverage
+        run: |
+          echo "🧪 Running auth integration tests..."
+          cargo llvm-cov test --no-report --test integration auth_integration_tests
+
+      - name: Generate coverage reports
+        run: |
+          echo "📊 Generating coverage reports..."
           mkdir -p coverage
           cargo llvm-cov report --lcov --output-path coverage/lcov.info
           cargo llvm-cov report --html --output-dir coverage/html

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,18 @@ The repository consists of 5 main workspace crates:
 - `tests`: Integration tests for the entire workspace
 - `sdks/`: TypeScript SDKs for client integration
 
+## TL;DR - Authentication Methods
+
+Kora supports two authentication methods that can be used individually or together:
+
+1. **API Key Authentication**: Simple header-based auth using `x-api-key` header
+2. **HMAC Authentication**: Request signature auth using `x-timestamp` and `x-hmac-signature` headers
+
+**Testing:**
+```bash
+make test-integration           # Run all integration tests
+```
+
 ## Common Development Commands
 
 ### Build & Check
@@ -80,13 +92,18 @@ Integration tests require a local validator and test account setup:
    ```bash
    make test-integration
    ```
-    This will initialize a test environment (cargo run -p tests --bin setup-test-env):
-   - Verify test validator is running
-   - Create and fund test accounts
-   - Set up USDC mint and token accounts
-   - Display account summary
-
-   And run all integration tests (cargo test --test integration)
+   This will run all integration tests in two phases (fully self-contained):
+   
+   **Phase 1: Regular integration tests**
+   - Initialize test environment (cargo run -p tests --bin setup-test-env)
+   - Start Kora RPC server with regular configuration
+   - Run API and token integration tests
+   - Stop the regular server
+   
+   **Phase 2: Auth integration tests**
+   - Start Kora server with auth configuration (`tests/fixtures/auth-test.toml`)
+   - Run auth integration tests (API key and HMAC authentication)
+   - Clean up the auth server
 
 #### Customize Test Environment
 
@@ -514,6 +531,15 @@ Use structured logging throughout the codebase:
 - **Fail Secure**: Default to restrictive behavior when validation or authentication fails
 - **Secure Communication**: Use secure communication for remote signer APIs
 - **Rate Limiting & Authentication**: Implement proper rate limiting and authentication
+
+## Authentication Methods
+
+Kora supports two optional authentication methods:
+
+1. **API Key Auth** (`api_key` in kora.toml): Simple header-based auth using `x-api-key`
+2. **HMAC Auth** (`hmac_secret` in kora.toml): Secure signature-based auth using `x-timestamp` + `x-hmac-signature` (SHA256 of timestamp+body)
+
+Both skip `/liveness` endpoint and can be used simultaneously. Implementation uses async tower middleware for non-blocking concurrent requests.
 
 ### Testing Guidelines
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,3 +85,5 @@ vaultrs = "0.7.3"
 kora-turnkey = { path = "crates/turnkey", version = "1.0.2" }
 kora-privy = { path = "crates/privy", version = "1.0.2" }
 utoipa = { version = "4.2.0", features = ["yaml", "chrono"] }
+hmac = "0.12.1"
+sha2 = "0.10.9"

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: check fmt lint lint-fix test build run clean all regen-tk fix-all generate-ts-client setup-test-env test-integration test-integration-coverage coverage coverage-all
+.PHONY: check fmt lint lint-fix test build run clean all regen-tk fix-all generate-ts-client setup-test-env test-integration test-integration-coverage coverage
 
 # Common configuration
 TEST_PORT := 8080
@@ -57,7 +57,7 @@ define start_server
 	@pkill -f "kora-rpc.*--port $(TEST_PORT)" || true
 	@sleep 2
 	@echo "🚀 Starting Kora $(1) server..."
-	@env -u KORA_API_KEY -u KORA_HMAC_SECRET $(2) -p kora-rpc --bin kora-rpc $(3) -- --private-key $(TEST_PRIVATE_KEY) --config $(4) --rpc-url $(TEST_RPC_URL) --port $(TEST_PORT) $(QUIET_OUTPUT) &
+	@$(2) -p kora-rpc --bin kora-rpc $(3) -- --private-key $(TEST_PRIVATE_KEY) --config $(4) --rpc-url $(TEST_RPC_URL) --port $(TEST_PORT) $(QUIET_OUTPUT) &
 	@echo "⏳ Waiting for server to start..."
 	@sleep 5
 endef
@@ -171,17 +171,6 @@ coverage:
 	@mkdir -p coverage
 	cargo llvm-cov clean --workspace
 	cargo llvm-cov --lib --html --output-dir coverage/html
-	@echo "✅ HTML coverage report generated in coverage/html/"
-	@echo "📊 Open coverage/html/index.html in your browser"
-
-# Generate HTML coverage report (all tests including integration)
-coverage-all:
-	$(call check_coverage_tool)
-	@echo "🧪 Generating HTML coverage report (all tests)..."
-	@echo "⚠️  Note: Integration tests may fail if external services aren't available"
-	@mkdir -p coverage
-	cargo llvm-cov clean --workspace
-	cargo llvm-cov --workspace --html --output-dir coverage/html
 	@echo "✅ HTML coverage report generated in coverage/html/"
 	@echo "📊 Open coverage/html/index.html in your browser"
 

--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ define start_server
 	@pkill -f "kora-rpc.*--port $(TEST_PORT)" || true
 	@sleep 2
 	@echo "🚀 Starting Kora $(1) server..."
-	@$(2) -p kora-rpc --bin kora-rpc $(3) -- --private-key $(TEST_PRIVATE_KEY) --config $(4) --rpc-url $(TEST_RPC_URL) --port $(TEST_PORT) $(QUIET_OUTPUT) &
+	@env -u KORA_API_KEY -u KORA_HMAC_SECRET $(2) -p kora-rpc --bin kora-rpc $(3) -- --private-key $(TEST_PRIVATE_KEY) --config $(4) --rpc-url $(TEST_RPC_URL) --port $(TEST_PORT) $(QUIET_OUTPUT) &
 	@echo "⏳ Waiting for server to start..."
 	@sleep 5
 endef

--- a/Makefile
+++ b/Makefile
@@ -64,8 +64,7 @@ endef
 
 define run_regular_tests
 	@echo "🧪 Running regular integration tests..."
-	@$(1) --test api_integration $(2) $(TEST_OUTPUT_FILTER)
-	@$(1) --test token_integration $(2) $(TEST_OUTPUT_FILTER)
+	@$(1) --tests $(2) -- --skip auth_integration_tests $(TEST_OUTPUT_FILTER)
 endef
 
 define run_auth_tests

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,17 @@
-.PHONY: check fmt lint lint-fix test build run clean all regen-tk fix-all generate-ts-client setup-test-env test-integration coverage coverage-all
+.PHONY: check fmt lint lint-fix test build run clean all regen-tk fix-all generate-ts-client setup-test-env test-integration test-integration-coverage coverage coverage-all
+
+# Common configuration
+TEST_PORT := 8080
+TEST_PRIVATE_KEY := ./tests/testing-utils/local-keys/fee-payer-local.json
+TEST_RPC_URL := http://127.0.0.1:8899
+REGULAR_CONFIG := tests/kora-test.toml
+AUTH_CONFIG := tests/fixtures/auth-test.toml
+
+# Output control patterns
+QUIET_OUTPUT := >/dev/null 2>&1
+TEST_OUTPUT_FILTER := 2>&1 | grep -E "(test |running |ok$$|FAILED|failed|error:|Error:|ERROR)" || true
+SETUP_OUTPUT := >/dev/null 2>&1
+
 
 # Default target
 all: check test build
@@ -28,14 +41,66 @@ lint-fix:
 test:
 	cargo test --lib
 
+# Generate a random key that can be used as an API key or as an HMAC secret
+generate-key:
+	openssl rand -hex 32
+
+# Server lifecycle management functions
+define stop_server
+	@echo "🛑 Stopping $(1) server..."
+	@pkill -f "kora-rpc.*--port $(TEST_PORT)" || true
+	@sleep 2
+endef
+
+define start_server
+	@echo "🛑 Stopping any existing server..."
+	@pkill -f "kora-rpc.*--port $(TEST_PORT)" || true
+	@sleep 2
+	@echo "🚀 Starting Kora $(1) server..."
+	@$(2) -p kora-rpc --bin kora-rpc $(3) -- --private-key $(TEST_PRIVATE_KEY) --config $(4) --rpc-url $(TEST_RPC_URL) --port $(TEST_PORT) $(QUIET_OUTPUT) &
+	@echo "⏳ Waiting for server to start..."
+	@sleep 5
+endef
+
+define run_regular_tests
+	@echo "🧪 Running regular integration tests..."
+	@$(1) --test api_integration $(2) $(TEST_OUTPUT_FILTER)
+	@$(1) --test token_integration $(2) $(TEST_OUTPUT_FILTER)
+endef
+
+define run_auth_tests
+	@echo "🧪 Running auth integration tests..."
+	@$(1) --test integration auth_integration_tests $(2) -- --nocapture $(TEST_OUTPUT_FILTER)
+endef
+
+define run_integration_phase
+	@echo "📋 Phase $(1): $(2)"
+	$(call start_server,$(2),$(3),$(4),$(5))
+	$(6)
+	$(call stop_server,$(2))
+endef
+
 # Setup test environment
 setup-test-env:
 	cargo run -p tests --bin setup-test-env
 
-# Run integration tests
+# Run all integration tests (regular + auth)
 test-integration:
-	cargo run -p tests --bin setup-test-env
-	cargo test --test integration
+	@echo "🧪 Running all integration tests..."
+	@echo "🔧 Setting up test environment..."
+	@cargo run -p tests --bin setup-test-env $(SETUP_OUTPUT)
+	$(call run_integration_phase,1,regular tests,cargo run,,$(REGULAR_CONFIG),$(call run_regular_tests,cargo test,))
+	$(call run_integration_phase,2,auth tests,cargo run,,$(AUTH_CONFIG),$(call run_auth_tests,cargo test,))
+	@echo "✅ All integration tests completed"
+
+# Run all integration tests with coverage instrumentation (for CI)
+test-integration-coverage:
+	@echo "🧪 Running all integration tests with coverage..."
+	@echo "🔧 Setting up test environment..."
+	@cargo run -p tests --bin setup-test-env $(SETUP_OUTPUT)
+	$(call run_integration_phase,1,regular tests,cargo llvm-cov run,--no-report,$(REGULAR_CONFIG),$(call run_regular_tests,cargo llvm-cov test,--no-report))
+	$(call run_integration_phase,2,auth tests,cargo llvm-cov run,--no-report,$(AUTH_CONFIG),$(call run_auth_tests,cargo llvm-cov test,--no-report))
+	@echo "✅ All integration tests completed"
 
 # Build all binaries
 build:

--- a/README.md
+++ b/README.md
@@ -531,7 +531,7 @@ make test
 # Setup test environment (for integration tests)
 make setup-test-env
 
-# Run integration tests
+# Run integration tests (fully self-contained, includes both regular and auth tests)
 make test-integration
 ```
 
@@ -576,22 +576,22 @@ Integration tests require additional setup for test accounts and local validator
    solana-test-validator --reset
    ```
 
-2. **Start local Kora Server:**
-    ```bash
-    make run
-    ```
-
-3. **Run integration tests:**
+2. **Run integration tests:**
    ```bash
    make test-integration
    ```
-    This will initialize a test environment (cargo run -p tests --bin setup-test-env):
-   - Verify test validator is running
-   - Create and fund test accounts
-   - Set up USDC mint and token accounts
-   - Display account summary
-
-   And run all integration tests (cargo test --test integration)
+   This will run all integration tests in two phases (fully self-contained):
+   
+   **Phase 1: Regular integration tests**
+   - Initialize test environment (cargo run -p tests --bin setup-test-env)
+   - Start Kora RPC server with regular configuration
+   - Run API and token integration tests
+   - Stop the regular server
+   
+   **Phase 2: Auth integration tests**
+   - Start Kora server with auth configuration (`tests/fixtures/auth-test.toml`)
+   - Run auth integration tests (API key and HMAC authentication)
+   - Clean up the auth server
 
 #### Customize Test Environment
 

--- a/crates/lib/src/args.rs
+++ b/crates/lib/src/args.rs
@@ -9,6 +9,14 @@ pub struct CommonArgs {
     #[arg(long, env = "RPC_URL", default_value = "http://127.0.0.1:8899")]
     pub rpc_url: String,
 
+    /// API key for the Kora API
+    #[arg(long, env = "KORA_API_KEY")]
+    pub api_key: Option<String>,
+
+    /// HMAC secret for the Kora API
+    #[arg(long, env = "KORA_HMAC_SECRET")]
+    pub hmac_secret: Option<String>,
+
     /// Base58-encoded private key for signing
     #[arg(long, env = "KORA_PRIVATE_KEY", required_unless_present_any = ["skip_signer", "turnkey_signer", "vault_signer", "privy_signer"])]
     pub private_key: Option<String>,

--- a/crates/lib/src/config.rs
+++ b/crates/lib/src/config.rs
@@ -133,18 +133,16 @@ impl ValidationConfig {
         self.disallowed_accounts = accounts;
         self
     }
-
-    pub fn with_price(mut self, price: PriceConfig) -> Self {
-        self.price = price;
-        self
-    }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct KoraConfig {
     pub rate_limit: u64,
     #[serde(default)]
     pub enabled_methods: EnabledMethods,
+    pub api_key: Option<String>,
+    pub hmac_secret: Option<String>,
+    // pub redis_url: String,
 }
 
 pub fn load_config<P: AsRef<Path>>(path: P) -> Result<Config, KoraError> {
@@ -279,7 +277,12 @@ mod tests {
                 fee_payer_policy: FeePayerPolicy::default(),
                 price: PriceConfig::default(),
             },
-            kora: KoraConfig { rate_limit: 100, enabled_methods: EnabledMethods::default() },
+            kora: KoraConfig {
+                rate_limit: 100,
+                api_key: None,
+                hmac_secret: None,
+                enabled_methods: EnabledMethods::default(),
+            },
         };
 
         // Test empty tokens list

--- a/crates/lib/src/constant.rs
+++ b/crates/lib/src/constant.rs
@@ -3,6 +3,11 @@ pub const NATIVE_SOL: &str = "11111111111111111111111111111111";
 pub const LAMPORTS_PER_SIGNATURE: u64 = 5000;
 pub const MIN_BALANCE_FOR_RENT_EXEMPTION: u64 = 2_039_280;
 
+// HTTP Headers
+pub const X_API_KEY: &str = "x-api-key";
+pub const X_HMAC_SIGNATURE: &str = "x-hmac-signature";
+pub const X_TIMESTAMP: &str = "x-timestamp";
+
 // External Services
 pub const JUPITER_API_LITE_URL: &str = "https://lite-api.jup.ag";
 pub const JUPITER_API_PRO_URL: &str = "https://api.jup.ag";

--- a/crates/lib/src/transaction/tests.rs
+++ b/crates/lib/src/transaction/tests.rs
@@ -12,9 +12,19 @@ use solana_system_interface::instruction::transfer;
 
 use super::{decode_b64_transaction, estimate_transaction_fee};
 use crate::{
+    get_signer, init_signer,
     rpc::test_utils::setup_test_rpc_client,
+    signer::{KoraSigner, SolanaMemorySigner},
     token::{TokenInterface, TokenProgram, TokenType},
 };
+
+fn ensure_test_signer_initialized() {
+    if get_signer().is_err() {
+        let test_keypair = Keypair::new();
+        let signer = SolanaMemorySigner::new(test_keypair);
+        let _ = init_signer(KoraSigner::Memory(signer));
+    }
+}
 
 #[test]
 fn test_decode_b64_transaction() {
@@ -50,6 +60,7 @@ fn test_decode_b64_transaction_invalid_input() {
 
 #[tokio::test]
 async fn test_estimate_transaction_fee_basic() {
+    ensure_test_signer_initialized();
     let rpc_client = setup_test_rpc_client();
 
     // Create a simple transfer transaction
@@ -72,6 +83,7 @@ async fn test_estimate_transaction_fee_basic() {
 
 #[tokio::test]
 async fn test_estimate_transaction_fee_invalid_transaction() {
+    ensure_test_signer_initialized();
     let rpc_client = setup_test_rpc_client();
 
     // Create an invalid transaction (empty message)
@@ -86,6 +98,7 @@ async fn test_estimate_transaction_fee_invalid_transaction() {
 
 #[tokio::test]
 async fn test_estimate_transaction_fee_with_token_creation() {
+    ensure_test_signer_initialized();
     let rpc_client = setup_test_rpc_client();
 
     // Create a transaction that includes token account creation

--- a/crates/rpc/Cargo.toml
+++ b/crates/rpc/Cargo.toml
@@ -53,6 +53,11 @@ bincode = { workspace = true }
 bs58 = { workspace = true }
 utoipa.workspace = true
 dirs = "6.0.0"
+hmac = {workspace = true}
+sha2 = {workspace = true}
+hex = "0.4.3"
+http-body = "1.0.1"
+http-body-util = "0.1.3"
 
 [features]
 docs = []

--- a/crates/rpc/src/auth.rs
+++ b/crates/rpc/src/auth.rs
@@ -1,0 +1,436 @@
+use futures_util::TryStreamExt;
+use hmac::{Hmac, Mac};
+use http::{Request, Response, StatusCode};
+use jsonrpsee::server::logger::Body;
+use kora_lib::constant::{X_API_KEY, X_HMAC_SIGNATURE, X_TIMESTAMP};
+use sha2::Sha256;
+
+const MAX_TIMESTAMP_AGE: i64 = 300; // 5 minutes in seconds (could make this configurable?)
+
+pub async fn extract_parts_and_body_bytes(
+    request: Request<Body>,
+) -> (http::request::Parts, Vec<u8>) {
+    let (parts, body) = request.into_parts();
+    let body_bytes = body
+        .try_fold(Vec::new(), |mut acc, chunk| async move {
+            acc.extend_from_slice(&chunk);
+            Ok(acc)
+        })
+        .await
+        .unwrap_or_default();
+    (parts, body_bytes)
+}
+
+pub fn is_liveness_jsonrpc_call(body_bytes: &[u8]) -> bool {
+    match serde_json::from_slice::<serde_json::Value>(body_bytes) {
+        Ok(val) => val.get("method").and_then(|m| m.as_str()) == Some("liveness"),
+        Err(_) => false,
+    }
+}
+
+#[derive(Clone)]
+pub struct ApiKeyAuthLayer {
+    api_key: String,
+}
+
+impl ApiKeyAuthLayer {
+    pub fn new(api_key: String) -> Self {
+        Self { api_key }
+    }
+}
+
+#[derive(Clone)]
+pub struct ApiKeyAuthService<S> {
+    inner: S,
+    api_key: String,
+}
+
+impl<S> tower::Layer<S> for ApiKeyAuthLayer {
+    type Service = ApiKeyAuthService<S>;
+    fn layer(&self, inner: S) -> Self::Service {
+        ApiKeyAuthService { inner, api_key: self.api_key.clone() }
+    }
+}
+
+impl<S> tower::Service<Request<Body>> for ApiKeyAuthService<S>
+where
+    S: tower::Service<Request<Body>, Response = Response<Body>> + Clone + Send + 'static,
+    S::Future: Send + 'static,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = std::pin::Pin<
+        Box<dyn std::future::Future<Output = Result<Self::Response, Self::Error>> + Send>,
+    >;
+
+    fn poll_ready(
+        &mut self,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, request: Request<Body>) -> Self::Future {
+        let api_key = self.api_key.clone();
+        let mut inner = self.inner.clone();
+
+        Box::pin(async move {
+            let unauthorized_response =
+                Response::builder().status(StatusCode::UNAUTHORIZED).body(Body::empty()).unwrap();
+
+            let (parts, body_bytes) = extract_parts_and_body_bytes(request).await;
+            if is_liveness_jsonrpc_call(&body_bytes) {
+                let new_body = Body::from(body_bytes);
+                let new_request = Request::from_parts(parts, new_body);
+                return inner.call(new_request).await;
+            }
+
+            let req = Request::from_parts(parts, Body::from(body_bytes));
+            if let Some(provided_key) = req.headers().get(X_API_KEY) {
+                if provided_key.to_str().unwrap_or("") == api_key {
+                    return inner.call(req).await;
+                }
+            }
+
+            Ok(unauthorized_response)
+        })
+    }
+}
+
+#[derive(Clone)]
+pub struct HmacAuthLayer {
+    secret: String,
+}
+
+impl HmacAuthLayer {
+    pub fn new(secret: String) -> Self {
+        Self { secret }
+    }
+}
+
+impl<S> tower::Layer<S> for HmacAuthLayer {
+    type Service = HmacAuthService<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        HmacAuthService { inner, secret: self.secret.clone() }
+    }
+}
+
+#[derive(Clone)]
+pub struct HmacAuthService<S> {
+    inner: S,
+    secret: String,
+}
+
+impl<S> tower::Service<Request<Body>> for HmacAuthService<S>
+where
+    S: tower::Service<Request<Body>, Response = Response<Body>> + Clone + Send + 'static,
+    S::Future: Send + 'static,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = std::pin::Pin<
+        Box<dyn std::future::Future<Output = Result<Self::Response, Self::Error>> + Send>,
+    >;
+
+    fn poll_ready(
+        &mut self,
+        cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, request: Request<Body>) -> Self::Future {
+        let secret = self.secret.clone();
+        let mut inner = self.inner.clone();
+
+        Box::pin(async move {
+            let unauthorized_response =
+                Response::builder().status(StatusCode::UNAUTHORIZED).body(Body::empty()).unwrap();
+
+            let signature_header = request.headers().get(X_HMAC_SIGNATURE).cloned();
+            let timestamp_header = request.headers().get(X_TIMESTAMP).cloned();
+
+            // Since our proxy for get /liveness transforms the request in a POST, we need to check the liveness via the method in the body
+            let (parts, body_bytes) = extract_parts_and_body_bytes(request).await;
+            if is_liveness_jsonrpc_call(&body_bytes) {
+                let new_body = Body::from(body_bytes);
+                let new_request = Request::from_parts(parts, new_body);
+                return inner.call(new_request).await;
+            }
+
+            let (signature, timestamp) =
+                match (signature_header.as_ref(), timestamp_header.as_ref()) {
+                    (Some(sig), Some(ts)) => (sig, ts),
+                    _ => return Ok(unauthorized_response),
+                };
+
+            let signature = signature.to_str().unwrap_or("");
+            let timestamp = timestamp.to_str().unwrap_or("");
+
+            // Verify timestamp is within 5 minutes
+            let parsed_timestamp = timestamp.parse::<i64>();
+            if parsed_timestamp.is_err() {
+                return Ok(unauthorized_response);
+            }
+
+            let ts = parsed_timestamp.unwrap();
+            let now = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_secs() as i64;
+
+            if (now - ts).abs() > MAX_TIMESTAMP_AGE {
+                return Ok(unauthorized_response);
+            }
+
+            // Verify HMAC signature using timestamp + body
+            let message = format!("{}{}", timestamp, std::str::from_utf8(&body_bytes).unwrap());
+
+            let mut mac = match Hmac::<Sha256>::new_from_slice(secret.as_bytes()) {
+                Ok(mac) => mac,
+                Err(e) => {
+                    log::error!("Invalid HMAC secret: {e:?}");
+                    return Ok(unauthorized_response);
+                }
+            };
+
+            mac.update(message.as_bytes());
+            let expected_signature = hex::encode(mac.finalize().into_bytes());
+
+            if signature != expected_signature {
+                return Ok(unauthorized_response);
+            }
+
+            // Reconstruct the request with the consumed body
+            let new_body = Body::from(body_bytes);
+            let new_request = Request::from_parts(parts, new_body);
+
+            inner.call(new_request).await
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use hmac::{Hmac, Mac};
+    use http::Method;
+    use jsonrpsee::server::logger::Body;
+    use kora_lib::constant::{X_API_KEY, X_HMAC_SIGNATURE, X_TIMESTAMP};
+    use sha2::Sha256;
+    use std::{
+        future::Ready,
+        task::{Context, Poll},
+    };
+    use tower::{Layer, Service, ServiceExt};
+
+    // Mock service that always returns OK
+    #[derive(Clone)]
+    struct MockService;
+
+    impl tower::Service<Request<Body>> for MockService {
+        type Response = Response<Body>;
+        type Error = std::convert::Infallible;
+        type Future = Ready<Result<Self::Response, Self::Error>>;
+
+        fn poll_ready(&mut self, _: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn call(&mut self, _: Request<Body>) -> Self::Future {
+            std::future::ready(Ok(Response::builder().status(200).body(Body::empty()).unwrap()))
+        }
+    }
+
+    #[tokio::test]
+    async fn test_api_key_auth_valid_key() {
+        let layer = ApiKeyAuthLayer::new("test-key".to_string());
+        let mut service = layer.layer(MockService);
+        let request = Request::builder()
+            .uri("/test")
+            .header(X_API_KEY, "test-key")
+            .body(Body::empty())
+            .unwrap();
+
+        let response = service.ready().await.unwrap().call(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn test_api_key_auth_invalid_key() {
+        let layer = ApiKeyAuthLayer::new("test-key".to_string());
+        let mut service = layer.layer(MockService);
+        let request = Request::builder()
+            .uri("/test")
+            .header(X_API_KEY, "wrong-key")
+            .body(Body::empty())
+            .unwrap();
+
+        let response = service.ready().await.unwrap().call(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn test_api_key_auth_missing_header() {
+        let layer = ApiKeyAuthLayer::new("test-key".to_string());
+        let mut service = layer.layer(MockService);
+        let request = Request::builder().uri("/test").body(Body::empty()).unwrap();
+
+        let response = service.ready().await.unwrap().call(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn test_api_key_auth_liveness_bypass() {
+        let layer = ApiKeyAuthLayer::new("test-key".to_string());
+        let mut service = layer.layer(MockService);
+        let liveness_body = r#"{"jsonrpc":"2.0","method":"liveness","params":[],"id":1}"#;
+        let request = Request::builder()
+            .method(Method::POST)
+            .uri("/")
+            .body(Body::from(liveness_body))
+            .unwrap();
+
+        let response = service.ready().await.unwrap().call(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn test_hmac_auth_valid_signature() {
+        let secret = "test-secret";
+        let layer = HmacAuthLayer::new(secret.to_string());
+        let mut service = layer.layer(MockService);
+
+        let timestamp = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs()
+            .to_string();
+
+        let body = r#"{"jsonrpc":"2.0","method":"test","id":1}"#;
+        let message = format!("{timestamp}{body}");
+
+        let mut mac = Hmac::<Sha256>::new_from_slice(secret.as_bytes()).unwrap();
+        mac.update(message.as_bytes());
+        let signature = hex::encode(mac.finalize().into_bytes());
+
+        let request = Request::builder()
+            .method(Method::POST)
+            .uri("/test")
+            .header(X_TIMESTAMP, &timestamp)
+            .header(X_HMAC_SIGNATURE, &signature)
+            .body(Body::from(body))
+            .unwrap();
+
+        let response = service.ready().await.unwrap().call(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn test_hmac_auth_invalid_signature() {
+        let secret = "test-secret";
+        let layer = HmacAuthLayer::new(secret.to_string());
+        let mut service = layer.layer(MockService);
+
+        let timestamp = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs()
+            .to_string();
+
+        let body = r#"{"jsonrpc":"2.0","method":"test","id":1}"#;
+
+        let request = Request::builder()
+            .method(Method::POST)
+            .uri("/test")
+            .header(X_TIMESTAMP, &timestamp)
+            .header(X_HMAC_SIGNATURE, "invalid-signature")
+            .body(Body::from(body))
+            .unwrap();
+
+        let response = service.ready().await.unwrap().call(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn test_hmac_auth_missing_headers() {
+        let secret = "test-secret";
+        let layer = HmacAuthLayer::new(secret.to_string());
+        let mut service = layer.layer(MockService);
+
+        let request =
+            Request::builder().method(Method::POST).uri("/test").body(Body::from("test")).unwrap();
+
+        let response = service.ready().await.unwrap().call(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn test_hmac_auth_expired_timestamp() {
+        let secret = "test-secret";
+        let layer = HmacAuthLayer::new(secret.to_string());
+        let mut service = layer.layer(MockService);
+
+        // Timestamp from 10 minutes ago (expired)
+        let expired_timestamp =
+            (std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_secs()
+                - 600)
+                .to_string();
+
+        let body = r#"{"jsonrpc":"2.0","method":"test","id":1}"#;
+        let message = format!("{expired_timestamp}{body}");
+
+        let mut mac = Hmac::<Sha256>::new_from_slice(secret.as_bytes()).unwrap();
+        mac.update(message.as_bytes());
+        let signature = hex::encode(mac.finalize().into_bytes());
+
+        let request = Request::builder()
+            .method(Method::POST)
+            .uri("/test")
+            .header(X_TIMESTAMP, &expired_timestamp)
+            .header(X_HMAC_SIGNATURE, &signature)
+            .body(Body::from(body))
+            .unwrap();
+
+        let response = service.ready().await.unwrap().call(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn test_hmac_auth_liveness_bypass() {
+        let secret = "test-secret";
+        let layer = HmacAuthLayer::new(secret.to_string());
+        let mut service = layer.layer(MockService);
+
+        let liveness_body = r#"{"jsonrpc":"2.0","method":"liveness","params":[],"id":1}"#;
+        let request = Request::builder()
+            .method(Method::POST)
+            .uri("/")
+            .body(Body::from(liveness_body))
+            .unwrap();
+
+        let response = service.ready().await.unwrap().call(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn test_hmac_auth_malformed_timestamp() {
+        let secret = "test-secret";
+        let layer = HmacAuthLayer::new(secret.to_string());
+        let mut service = layer.layer(MockService);
+
+        let body = r#"{"jsonrpc":"2.0","method":"test","id":1}"#;
+
+        let request = Request::builder()
+            .method(Method::POST)
+            .uri("/test")
+            .header(X_TIMESTAMP, "not-a-number")
+            .header(X_HMAC_SIGNATURE, "some-signature")
+            .body(Body::from(body))
+            .unwrap();
+
+        let response = service.ready().await.unwrap().call(request).await.unwrap();
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+}

--- a/crates/rpc/src/lib.rs
+++ b/crates/rpc/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod auth;
 pub mod method;
 #[cfg(feature = "docs")]
 pub mod openapi;

--- a/crates/rpc/src/main.rs
+++ b/crates/rpc/src/main.rs
@@ -1,3 +1,4 @@
+mod auth;
 mod method;
 mod rpc;
 mod server;

--- a/crates/rpc/src/server.rs
+++ b/crates/rpc/src/server.rs
@@ -1,12 +1,21 @@
-use crate::rpc::KoraRpc;
+use crate::{
+    auth::{ApiKeyAuthLayer, HmacAuthLayer},
+    rpc::KoraRpc,
+};
 use http::{header, Method};
 use jsonrpsee::{
     server::{middleware::proxy_get_request::ProxyGetRequestLayer, ServerBuilder, ServerHandle},
     RpcModule,
 };
+use kora_lib::constant::{X_API_KEY, X_HMAC_SIGNATURE, X_TIMESTAMP};
 use std::{net::SocketAddr, time::Duration};
 use tower::limit::RateLimitLayer;
 use tower_http::cors::CorsLayer;
+
+// We'll always prioritize the environment variable over the config value
+fn get_value_by_priority(env_var: &str, config_value: Option<String>) -> Option<String> {
+    std::env::var(env_var).ok().or(config_value)
+}
 
 pub async fn run_rpc_server(rpc: KoraRpc, port: u16) -> Result<ServerHandle, anyhow::Error> {
     let addr = SocketAddr::from(([0, 0, 0, 0], port));
@@ -16,13 +25,28 @@ pub async fn run_rpc_server(rpc: KoraRpc, port: u16) -> Result<ServerHandle, any
     let cors = CorsLayer::new()
         .allow_origin(tower_http::cors::Any)
         .allow_methods([Method::POST, Method::GET])
-        .allow_headers([header::CONTENT_TYPE])
+        .allow_headers([
+            header::CONTENT_TYPE,
+            header::HeaderName::from_static(X_API_KEY),
+            header::HeaderName::from_static(X_HMAC_SIGNATURE),
+            header::HeaderName::from_static(X_TIMESTAMP),
+        ])
         .max_age(Duration::from_secs(3600));
 
     let middleware = tower::ServiceBuilder::new()
         .layer(ProxyGetRequestLayer::new("/liveness", "liveness")?)
         .layer(RateLimitLayer::new(rpc.config.rate_limit, Duration::from_secs(1)))
-        .layer(cors);
+        .layer(cors)
+        // Add authentication layer for API key if configured
+        .option_layer(
+            (get_value_by_priority("KORA_API_KEY", rpc.config.api_key.clone()))
+                .map(|key| ApiKeyAuthLayer::new(key.clone())),
+        )
+        // Add authentication layer for HMAC if configured
+        .option_layer(
+            (get_value_by_priority("KORA_HMAC_SECRET", rpc.config.hmac_secret.clone()))
+                .map(|secret| HmacAuthLayer::new(secret.clone())),
+        );
 
     // Configure and build the server with HTTP support
     let server = ServerBuilder::default()

--- a/docs/operators/AUTHENTICATION.md
+++ b/docs/operators/AUTHENTICATION.md
@@ -1,0 +1,196 @@
+# Kora Authentication
+
+Kora supports two optional authentication methods for securing your RPC endpoint: API Key and HMAC authentication. This guide covers setup, implementation, and security best practices.
+
+Authentication is optional but **strongly recommended** for production deployments. Without authentication, anyone who discovers your Kora endpoint can submit transactions and consume your SOL balance.
+
+| Method | Security Level | Use Case | Complexity |
+|--------|---------------|----------|------------|
+| **None** | ⚠️ None | Development, testing, high-margin pricing | None |
+| **API Key** | Basic | Internal apps, trusted clients | Low |
+| **HMAC** | High | Public APIs, untrusted networks | Medium |
+| **Both** | Maximum | High-security environments | Medium |
+
+In this document:
+
+- [API Key Authentication](#api-key-authentication)
+- [HMAC Authentication](#hmac-authentication)
+- [Combined Authentication](#combined-authentication)
+- [Security Best Practices](#security-best-practices)
+- [Exempt Endpoints](#exempt-endpoints)
+- [Troubleshooting](#troubleshooting)
+
+## API Key Authentication
+
+Simple shared secret authentication using HTTP headers. You can generate a new API key using the `openssl` command (or a similar command) in your terminal:
+
+```bash
+openssl rand -hex 32
+```
+
+### Server Configuration
+
+
+- Add a `KORA_API_KEY` to your .env (environment variables) (has priority)
+  or
+- Add an `api_key` to your `kora.toml`:
+
+```toml
+[kora]
+rate_limit = 100
+api_key = "kora_live_sk_1234567890abcdef"  # Use a strong, unique key
+```
+
+This key will be globally required for all requests to the Kora RPC endpoint.
+
+### Client Implementation
+
+Include the API key in the `x-api-key` header with every request:
+
+**cURL Example:**
+```bash
+curl -X POST http://localhost:8080 \
+  -H "Content-Type: application/json" \
+  -H "x-api-key: kora_live_sk_1234567890abcdef" \
+  -d '{"jsonrpc": "2.0", "method": "getConfig", "id": 1}'
+```
+
+**JavaScript Example:**
+<!-- TODO: Update after we have TS SDK with headers -->
+```javascript
+async function callKora(method, params = []) {
+  const response = await fetch('http://localhost:8080', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'x-api-key': process.env.KORA_API_KEY //'kora_live_sk_1234567890abcdef'
+    },
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      method,
+      params,
+      id: 1
+    })
+  });
+  
+  return response.json();
+}
+
+const config = await callKora('getConfig');
+console.log(config);
+```
+
+## HMAC Authentication
+
+Instead of sending an API key with every request, HMAC creates a unique cryptographic signature that proves you know a secret without revealing it. Each signature includes a timestamp and expires after 5 minutes, so intercepted requests can't be replayed. Attackers can't create new requests because they don't have your secret key.
+
+### Server Configuration
+
+- Add `KORA_HMAC_SECRET` to your .env (environment variables) (has priority)
+  or
+- Add a global `hmac_secret` to your `kora.toml` (minimum 32 characters--you can generate one with `openssl rand -hex 32` or similar):
+
+```toml
+[kora]
+rate_limit = 100
+hmac_secret = "kora_hmac_your-strong-hmac-secret-key"
+```
+
+### How HMAC Works
+
+1. Client creates a message by concatenating: `{timestamp}{request_body}`
+2. Client signs the message using HMAC-SHA256 with the shared secret
+3. Client sends the request with timestamp and signature headers
+4. Server validates the signature and timestamp (must be within 5 minutes)
+
+### Client Implementation
+
+To use HMAC client-side, you can use the `crypto` library in JavaScript:
+1. Create a timestamp
+2. Create the request body
+3. Create a message by concatenating the timestamp and body (e.g., `message = timestamp + body`)
+4. Create a signature by signing the message with the HMAC secret (using the `crypto.createHmac` method)
+5. Send the request with the timestamp (`x-timestamp`) and signature (`x-hmac-signature`) headers
+
+**JavaScript Example:**
+<!-- TODO: Update after we have TS SDK helper -->
+```javascript
+const crypto = require('crypto');
+
+async function callKoraHMAC(method, params = []) {
+  const timestamp = Math.floor(Date.now() / 1000).toString();
+  const body = JSON.stringify({
+    jsonrpc: '2.0',
+    method,
+    params,
+    id: 1
+  });
+  
+  // Create HMAC signature
+  const message = timestamp + body;
+  const signature = crypto
+    .createHmac('sha256', process.env.KORA_HMAC_SECRET) // kora_hmac_your-strong-hmac-secret-key
+    .update(message)
+    .digest('hex');
+  
+  const response = await fetch('http://localhost:8080', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'x-timestamp': timestamp,
+      'x-hmac-signature': signature
+    },
+    body: body
+  });
+  
+  return response.json();
+}
+
+const config = await callKoraHMAC('getConfig');
+console.log(config);
+```
+
+
+## Combined Authentication
+
+You can enable both authentication methods simultaneously for maximum security:
+
+```toml
+[kora]
+rate_limit = 100
+api_key = "kora_live_sk_1234567890abcdef"
+hmac_secret = "kora_hmac_your-strong-hmac-secret-key"
+```
+
+When both are configured, clients must send the `x-api-key`, `x-timestamp`, and `x-hmac-signature` headers.
+
+## Security Best Practices
+
+- **Use strong, random keys**: Minimum 32 characters with high entropy
+- **Rotate regularly**: Change keys periodically (monthly/quarterly)
+- **Secure storage**: Use environment variables or secrets management (Railway secrets, AWS Secrets Manager, etc.)
+- **Never hardcode**: Keep keys out of source code and logs
+- **Use HTTPS**: Always use TLS in production to protect keys in transit
+- **Monitor access**: Watch for unusual authentication patterns or repeated failures
+
+## Exempt Endpoints
+
+The `/liveness` endpoint is always exempt from authentication to allow health checks:
+
+```bash
+# This works even with authentication enabled
+curl http://localhost:8080/liveness
+```
+
+## Troubleshooting
+
+**401 Unauthorized with API Key:**
+- Verify the API key is correct and matches server configuration
+- Check that the `x-api-key` header is being sent
+- Ensure no extra whitespace in the key
+
+**401 Unauthorized with HMAC:**
+- Verify timestamp is current (within 5 minutes)
+- Check that message construction matches: `{timestamp}{body}`
+- Ensure HMAC secret matches server configuration
+- Verify signature is lowercase hex

--- a/docs/operators/README.md
+++ b/docs/operators/README.md
@@ -103,9 +103,14 @@ Every Kora RPC node must be configured with at least:
 - a Solana signer (specified via the `--private-key` or `KORA_PRIVATE_KEY=` environment variable) (Check out the **[Signers Documentation](./SIGNERS.md)** for signing with a key management provider)
 - a config file, `kora.toml` (specified via the `--config path/to/kora.toml` flag)
 
-### kora.toml
+**kora.toml**
 
 Before deploying, you'll need to create and configure a `kora.toml` to specify: payment tokens, security rules, rate limits, fee payer protections, and pricing oracle. Begin with tight limits, then gradually expand based on your application's needs.
+Your `kora.toml` should live in the same directory as your deployment or be specified via the `--config` flag when starting the server.
+
+<!-- **[→ Complete Kora.toml Configuration Reference](CONFIGURATION.md)** -->
+**[→ Sample kora.toml](./deploy/sample/kora.toml)**
+
 
 
 ### 1. Rate Limiting
@@ -165,10 +170,12 @@ allow_token2022_transfers = true # Allow fee payer to be source in Token2022 tra
 allow_assign = true             # Allow fee payer to use Assign instruction
 ```
 
-<!-- **[→ Complete Kora.toml Configuration Reference](CONFIGURATION.md)** -->
-**[→ Sample kora.toml](./deploy/sample/kora.toml)**
+### 6. User Authentication
 
-Your `kora.toml` should live in the same directory as your deployment or be specified via the `--config` flag when starting the server.
+Kora supports two optional authentication methods for securing your RPC endpoint: a global API key for all users or [HMAC authentication](https://en.wikipedia.org/wiki/HMAC) with replay protection. If neither is configured, no authentication is required to use the RPC endpoint. You can use both methods simultaneously for maximum security.
+
+<!-- **[→ Complete Kora.toml Configuration Reference](CONFIGURATION.md)** -->
+For more information on authentication, see [Kora Authentication](./AUTHENTICATION.md)
 
 ## Deployment 
 

--- a/docs/operators/deploy/sample/kora.toml
+++ b/docs/operators/deploy/sample/kora.toml
@@ -1,5 +1,9 @@
 [kora]
 rate_limit = 100
+# Optional: API key for simple authentication
+# api_key = "your-api-key-here"
+# Optional: HMAC secret for signed requests
+# hmac_secret = "your-hmac-secret-here"
 
 [validation]
 price_source = "Mock"

--- a/sdks/ts/README.md
+++ b/sdks/ts/README.md
@@ -76,7 +76,7 @@ All environment variables are optional and have sensible defaults.
 import { KoraClient } from '@kora/sdk';
 
 // Initialize the client with your RPC endpoint
-const client = new KoraClient('http://localhost:8080');
+const client = new KoraClient({ rpcUrl: 'http://localhost:8080' });
 
 // Example: Transfer tokens
 const signature = await client.transferTransaction({

--- a/sdks/ts/examples/basic-usage.ts
+++ b/sdks/ts/examples/basic-usage.ts
@@ -32,7 +32,7 @@ async function main() {
   // Initialize the client with your RPC endpoint
   const rpcUrl = process.env.KORA_RPC_URL!;
   const usdcMint = process.env.USDC_MINT!;
-  const client = new KoraClient(rpcUrl);
+  const client = new KoraClient({ rpcUrl });
 
   try {
     // Get supported tokens

--- a/sdks/ts/src/types/index.ts
+++ b/sdks/ts/src/types/index.ts
@@ -21,8 +21,8 @@ export interface SignTransactionIfPaidRequest {
 }
 
 export interface EstimateTransactionFeeRequest {
-    transaction: string;
-    fee_token: string;
+  transaction: string;
+  fee_token: string;
 }
 
 /**
@@ -71,7 +71,7 @@ export interface TokenPriceInfo {
 export interface ValidationConfig {
   max_allowed_lamports: number;
   max_signatures: number;
-  price_source: 'Jupiter' | 'Mock';
+  price_source: "Jupiter" | "Mock";
   allowed_programs: string[];
   allowed_tokens: string[];
   allowed_spl_paid_tokens: string[];
@@ -81,9 +81,9 @@ export interface ValidationConfig {
 }
 
 export type PriceModel =
-  | { type: 'margin'; margin: number }
-  | { type: 'fixed'; amount: number; token: string }
-  | { type: 'free' };
+  | { type: "margin"; margin: number }
+  | { type: "fixed"; amount: number; token: string }
+  | { type: "free" };
 
 export type PriceConfig = PriceModel;
 
@@ -105,11 +105,24 @@ export interface FeePayerPolicy {
 export interface RpcError {
   code: number;
   message: string;
-} 
+}
 
 export interface RpcRequest<T> {
-    jsonrpc: '2.0';
-    id: number;
-    method: string;
-    params: T;
+  jsonrpc: "2.0";
+  id: number;
+  method: string;
+  params: T;
+}
+// Authentication Types
+export interface AuthenticationHeaders {
+  "x-api-key"?: string;
+  "x-timestamp"?: string;
+  "x-hmac-signature"?: string;
+}
+
+// Client Types
+export interface KoraClientOptions {
+  rpcUrl: string;
+  apiKey?: string;
+  hmacSecret?: string;
 }

--- a/sdks/ts/test/setup.ts
+++ b/sdks/ts/test/setup.ts
@@ -329,7 +329,7 @@ async function setupTestSuit(): Promise<TestSuite> {
   });
 
   return {
-    koraClient: new KoraClient(koraRpcUrl),
+    koraClient: new KoraClient({rpcUrl: koraRpcUrl}),
     testWallet,
     usdcMint: usdcMint.address,
     destinationAddress,

--- a/sdks/ts/test/unit.test.ts
+++ b/sdks/ts/test/unit.test.ts
@@ -1,280 +1,303 @@
-import { KoraClient } from '../src/client.js';
+import { KoraClient } from "../src/client.js";
 import {
-    Config,
-    EstimateTransactionFeeRequest,
-    GetBlockhashResponse,
-    GetSupportedTokensResponse,
-    SignTransactionRequest,
-    SignTransactionResponse,
-    SignAndSendTransactionRequest,
-    SignAndSendTransactionResponse,
-    SignTransactionIfPaidRequest,
-    SignTransactionIfPaidResponse,
-    TransferTransactionRequest,
-    TransferTransactionResponse,
-    EstimateTransactionFeeResponse,
-} from '../src/types/index.js';
+  Config,
+  EstimateTransactionFeeRequest,
+  GetBlockhashResponse,
+  GetSupportedTokensResponse,
+  SignTransactionRequest,
+  SignTransactionResponse,
+  SignAndSendTransactionRequest,
+  SignAndSendTransactionResponse,
+  SignTransactionIfPaidRequest,
+  SignTransactionIfPaidResponse,
+  TransferTransactionRequest,
+  TransferTransactionResponse,
+  EstimateTransactionFeeResponse,
+} from "../src/types/index.js";
 
 // Mock fetch globally
 const mockFetch = jest.fn();
 global.fetch = mockFetch;
 
-describe('KoraClient Unit Tests', () => {
-    let client: KoraClient;
-    const mockRpcUrl = 'http://localhost:8080';
+describe("KoraClient Unit Tests", () => {
+  let client: KoraClient;
+  const mockRpcUrl = "http://localhost:8080";
 
-    // Helper Functions
-    const mockSuccessfulResponse = (result: any) => {
-        mockFetch.mockResolvedValueOnce({
-            json: jest.fn().mockResolvedValueOnce({
-                jsonrpc: '2.0',
-                id: 1,
-                result,
-            }),
-        });
+  // Helper Functions
+  const mockSuccessfulResponse = (result: any) => {
+    mockFetch.mockResolvedValueOnce({
+      json: jest.fn().mockResolvedValueOnce({
+        jsonrpc: "2.0",
+        id: 1,
+        result,
+      }),
+    });
+  };
+
+  const mockErrorResponse = (error: any) => {
+    mockFetch.mockResolvedValueOnce({
+      json: jest.fn().mockResolvedValueOnce({
+        jsonrpc: "2.0",
+        id: 1,
+        error,
+      }),
+    });
+  };
+
+  const expectRpcCall = (method: string, params: any = undefined) => {
+    expect(mockFetch).toHaveBeenCalledWith(mockRpcUrl, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method,
+        params,
+      }),
+    });
+  };
+
+  const testSuccessfulRpcMethod = async (
+    methodName: string,
+    clientMethod: () => Promise<any>,
+    expectedResult: any,
+    params: any = undefined
+  ) => {
+    mockSuccessfulResponse(expectedResult);
+    const result = await clientMethod();
+    expect(result).toEqual(expectedResult);
+    expectRpcCall(methodName, params);
+  };
+
+  beforeEach(() => {
+    client = new KoraClient({ rpcUrl: mockRpcUrl });
+    mockFetch.mockClear();
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe("Constructor", () => {
+    it("should create KoraClient instance with provided RPC URL", () => {
+      const testUrl = "https://api.example.com";
+      const testClient = new KoraClient({ rpcUrl: testUrl });
+      expect(testClient).toBeInstanceOf(KoraClient);
+    });
+  });
+
+  describe("RPC Request Handling", () => {
+    it("should handle successful RPC responses", async () => {
+      const mockResult = { value: "test" };
+      await testSuccessfulRpcMethod(
+        "getConfig",
+        () => client.getConfig(),
+        mockResult
+      );
+    });
+
+    it("should handle RPC error responses", async () => {
+      const mockError = { code: -32601, message: "Method not found" };
+      mockErrorResponse(mockError);
+      await expect(client.getConfig()).rejects.toThrow(
+        "RPC Error -32601: Method not found"
+      );
+    });
+
+    it("should handle network errors", async () => {
+      mockFetch.mockRejectedValueOnce(new Error("Network error"));
+      await expect(client.getConfig()).rejects.toThrow("Network error");
+    });
+  });
+
+  describe("getConfig", () => {
+    it("should return configuration", async () => {
+      const mockConfig: Config = {
+        fee_payer: "test_fee_payer_address",
+        validation_config: {
+          max_allowed_lamports: 1000000,
+          max_signatures: 10,
+          price_source: "Jupiter",
+          allowed_programs: ["program1", "program2"],
+          allowed_tokens: ["token1", "token2"],
+          allowed_spl_paid_tokens: ["spl_token1"],
+          disallowed_accounts: ["account1"],
+          fee_payer_policy: {
+            allow_sol_transfers: true,
+            allow_spl_transfers: true,
+            allow_token2022_transfers: false,
+            allow_assign: true,
+          },
+          price: {
+            type: "margin",
+            margin: 0.1,
+          },
+        },
+      };
+
+      await testSuccessfulRpcMethod(
+        "getConfig",
+        () => client.getConfig(),
+        mockConfig
+      );
+    });
+  });
+
+  describe("getBlockhash", () => {
+    it("should return blockhash", async () => {
+      const mockResponse: GetBlockhashResponse = {
+        blockhash: "test_blockhash_value",
+      };
+
+      await testSuccessfulRpcMethod(
+        "getBlockhash",
+        () => client.getBlockhash(),
+        mockResponse
+      );
+    });
+  });
+
+  describe("getSupportedTokens", () => {
+    it("should return supported tokens list", async () => {
+      const mockResponse: GetSupportedTokensResponse = {
+        tokens: ["SOL", "USDC", "USDT"],
+      };
+
+      await testSuccessfulRpcMethod(
+        "getSupportedTokens",
+        () => client.getSupportedTokens(),
+        mockResponse
+      );
+    });
+  });
+
+  describe("estimateTransactionFee", () => {
+    it("should estimate transaction fee", async () => {
+      const request: EstimateTransactionFeeRequest = {
+        transaction: "base64_encoded_transaction",
+        fee_token: "SOL",
+      };
+      const mockResponse: EstimateTransactionFeeResponse = {
+        fee_in_lamports: 5000,
+      };
+
+      await testSuccessfulRpcMethod(
+        "estimateTransactionFee",
+        () => client.estimateTransactionFee(request),
+        mockResponse,
+        request
+      );
+    });
+  });
+
+  describe("signTransaction", () => {
+    it("should sign transaction", async () => {
+      const request: SignTransactionRequest = {
+        transaction: "base64_encoded_transaction",
+      };
+      const mockResponse: SignTransactionResponse = {
+        signature: "test_signature",
+        signed_transaction: "base64_signed_transaction",
+      };
+
+      await testSuccessfulRpcMethod(
+        "signTransaction",
+        () => client.signTransaction(request),
+        mockResponse,
+        request
+      );
+    });
+  });
+
+  describe("signAndSendTransaction", () => {
+    it("should sign and send transaction", async () => {
+      const request: SignAndSendTransactionRequest = {
+        transaction: "base64_encoded_transaction",
+      };
+      const mockResponse: SignAndSendTransactionResponse = {
+        signature: "test_signature",
+        signed_transaction: "base64_signed_transaction",
+      };
+
+      await testSuccessfulRpcMethod(
+        "signAndSendTransaction",
+        () => client.signAndSendTransaction(request),
+        mockResponse,
+        request
+      );
+    });
+  });
+
+  describe("signTransactionIfPaid", () => {
+    const testSignTransactionIfPaid = async (margin?: number) => {
+      const request: SignTransactionIfPaidRequest = {
+        transaction: "base64_encoded_transaction",
+        ...(margin !== undefined && { margin }),
+      };
+      const mockResponse: SignTransactionIfPaidResponse = {
+        transaction: "base64_encoded_transaction",
+        signed_transaction: "base64_signed_transaction",
+      };
+
+      await testSuccessfulRpcMethod(
+        "signTransactionIfPaid",
+        () => client.signTransactionIfPaid(request),
+        mockResponse,
+        request
+      );
     };
 
-    const mockErrorResponse = (error: any) => {
-        mockFetch.mockResolvedValueOnce({
-            json: jest.fn().mockResolvedValueOnce({
-                jsonrpc: '2.0',
-                id: 1,
-                error,
-            }),
-        });
-    };
+    it("should sign transaction if paid", () => testSignTransactionIfPaid(10));
+    it("should handle request without margin", () =>
+      testSignTransactionIfPaid());
+  });
 
-    const expectRpcCall = (method: string, params: any = undefined) => {
-        expect(mockFetch).toHaveBeenCalledWith(mockRpcUrl, {
-            method: 'POST',
-            headers: {
-                'Content-Type': 'application/json',
-            },
-            body: JSON.stringify({
-                jsonrpc: '2.0',
-                id: 1,
-                method,
-                params,
-            }),
-        });
-    };
+  describe("transferTransaction", () => {
+    it("should create transfer transaction", async () => {
+      const request: TransferTransactionRequest = {
+        amount: 1000000,
+        token: "SOL",
+        source: "source_address",
+        destination: "destination_address",
+      };
+      const mockResponse: TransferTransactionResponse = {
+        transaction: "base64_encoded_transaction",
+        message: "Transfer transaction created",
+        blockhash: "test_blockhash",
+      };
 
-    const testSuccessfulRpcMethod = async (
-        methodName: string,
-        clientMethod: () => Promise<any>,
-        expectedResult: any,
-        params: any = undefined
-    ) => {
-        mockSuccessfulResponse(expectedResult);
-        const result = await clientMethod();
-        expect(result).toEqual(expectedResult);
-        expectRpcCall(methodName, params);
-    };
+      await testSuccessfulRpcMethod(
+        "transferTransaction",
+        () => client.transferTransaction(request),
+        mockResponse,
+        request
+      );
+    });
+  });
 
-    beforeEach(() => {
-        client = new KoraClient(mockRpcUrl);
-        mockFetch.mockClear();
+  describe("Error Handling Edge Cases", () => {
+    it("should handle malformed JSON responses", async () => {
+      mockFetch.mockResolvedValueOnce({
+        json: jest.fn().mockRejectedValueOnce(new Error("Invalid JSON")),
+      });
+      await expect(client.getConfig()).rejects.toThrow("Invalid JSON");
     });
 
-    afterEach(() => {
-        jest.resetAllMocks();
+    it("should handle responses with an error object", async () => {
+      const mockError = { code: -32602, message: "Invalid params" };
+      mockErrorResponse(mockError);
+      await expect(client.getConfig()).rejects.toThrow(
+        "RPC Error -32602: Invalid params"
+      );
     });
 
-    describe('Constructor', () => {
-        it('should create KoraClient instance with provided RPC URL', () => {
-            const testUrl = 'https://api.example.com';
-            const testClient = new KoraClient(testUrl);
-            expect(testClient).toBeInstanceOf(KoraClient);
-        });
+    it("should handle empty error object", async () => {
+      mockErrorResponse({});
+      await expect(client.getConfig()).rejects.toThrow(
+        "RPC Error undefined: undefined"
+      );
     });
-
-    describe('RPC Request Handling', () => {
-        it('should handle successful RPC responses', async () => {
-            const mockResult = { value: 'test' };
-            await testSuccessfulRpcMethod('getConfig', () => client.getConfig(), mockResult);
-        });
-
-        it('should handle RPC error responses', async () => {
-            const mockError = { code: -32601, message: 'Method not found' };
-            mockErrorResponse(mockError);
-            await expect(client.getConfig()).rejects.toThrow('RPC Error -32601: Method not found');
-        });
-
-        it('should handle network errors', async () => {
-            mockFetch.mockRejectedValueOnce(new Error('Network error'));
-            await expect(client.getConfig()).rejects.toThrow('Network error');
-        });
-    });
-
-    describe('getConfig', () => {
-        it('should return configuration', async () => {
-            const mockConfig: Config = {
-                fee_payer: 'test_fee_payer_address',
-                validation_config: {
-                    max_allowed_lamports: 1000000,
-                    max_signatures: 10,
-                    price_source: 'Jupiter',
-                    allowed_programs: ['program1', 'program2'],
-                    allowed_tokens: ['token1', 'token2'],
-                    allowed_spl_paid_tokens: ['spl_token1'],
-                    disallowed_accounts: ['account1'],
-                    fee_payer_policy: {
-                        allow_sol_transfers: true,
-                        allow_spl_transfers: true,
-                        allow_token2022_transfers: false,
-                        allow_assign: true,
-                    },
-                    price: {
-                        type: 'margin',
-                        margin: 0.1,
-                    },
-                },
-            };
-
-            await testSuccessfulRpcMethod('getConfig', () => client.getConfig(), mockConfig);
-        });
-    });
-
-    describe('getBlockhash', () => {
-        it('should return blockhash', async () => {
-            const mockResponse: GetBlockhashResponse = {
-                blockhash: 'test_blockhash_value',
-            };
-
-            await testSuccessfulRpcMethod('getBlockhash', () => client.getBlockhash(), mockResponse);
-        });
-    });
-
-    describe('getSupportedTokens', () => {
-        it('should return supported tokens list', async () => {
-            const mockResponse: GetSupportedTokensResponse = {
-                tokens: ['SOL', 'USDC', 'USDT'],
-            };
-
-            await testSuccessfulRpcMethod('getSupportedTokens', () => client.getSupportedTokens(), mockResponse);
-        });
-    });
-
-    describe('estimateTransactionFee', () => {
-        it('should estimate transaction fee', async () => {
-            const request: EstimateTransactionFeeRequest = {
-                transaction: 'base64_encoded_transaction',
-                fee_token: 'SOL',
-            };
-            const mockResponse: EstimateTransactionFeeResponse = { fee_in_lamports: 5000 };
-
-            await testSuccessfulRpcMethod(
-                'estimateTransactionFee',
-                () => client.estimateTransactionFee(request),
-                mockResponse,
-                request
-            );
-        });
-    });
-
-    describe('signTransaction', () => {
-        it('should sign transaction', async () => {
-            const request: SignTransactionRequest = {
-                transaction: 'base64_encoded_transaction',
-            };
-            const mockResponse: SignTransactionResponse = {
-                signature: 'test_signature',
-                signed_transaction: 'base64_signed_transaction',
-            };
-
-            await testSuccessfulRpcMethod(
-                'signTransaction',
-                () => client.signTransaction(request),
-                mockResponse,
-                request
-            );
-        });
-    });
-
-    describe('signAndSendTransaction', () => {
-        it('should sign and send transaction', async () => {
-            const request: SignAndSendTransactionRequest = {
-                transaction: 'base64_encoded_transaction',
-            };
-            const mockResponse: SignAndSendTransactionResponse = {
-                signature: 'test_signature',
-                signed_transaction: 'base64_signed_transaction',
-            };
-
-            await testSuccessfulRpcMethod(
-                'signAndSendTransaction',
-                () => client.signAndSendTransaction(request),
-                mockResponse,
-                request
-            );
-        });
-    });
-
-    describe('signTransactionIfPaid', () => {
-        const testSignTransactionIfPaid = async (margin?: number) => {
-            const request: SignTransactionIfPaidRequest = {
-                transaction: 'base64_encoded_transaction',
-                ...(margin !== undefined && { margin }),
-            };
-            const mockResponse: SignTransactionIfPaidResponse = {
-                transaction: 'base64_encoded_transaction',
-                signed_transaction: 'base64_signed_transaction',
-            };
-
-            await testSuccessfulRpcMethod(
-                'signTransactionIfPaid',
-                () => client.signTransactionIfPaid(request),
-                mockResponse,
-                request
-            );
-        };
-
-        it('should sign transaction if paid', () => testSignTransactionIfPaid(10));
-        it('should handle request without margin', () => testSignTransactionIfPaid());
-    });
-
-    describe('transferTransaction', () => {
-        it('should create transfer transaction', async () => {
-            const request: TransferTransactionRequest = {
-                amount: 1000000,
-                token: 'SOL',
-                source: 'source_address',
-                destination: 'destination_address',
-            };
-            const mockResponse: TransferTransactionResponse = {
-                transaction: 'base64_encoded_transaction',
-                message: 'Transfer transaction created',
-                blockhash: 'test_blockhash',
-            };
-
-            await testSuccessfulRpcMethod(
-                'transferTransaction',
-                () => client.transferTransaction(request),
-                mockResponse,
-                request
-            );
-        });
-    });
-
-    describe('Error Handling Edge Cases', () => {
-        it('should handle malformed JSON responses', async () => {
-            mockFetch.mockResolvedValueOnce({
-                json: jest.fn().mockRejectedValueOnce(new Error('Invalid JSON')),
-            });
-            await expect(client.getConfig()).rejects.toThrow('Invalid JSON');
-        });
-
-        it('should handle responses with an error object', async () => {
-            const mockError = { code: -32602, message: 'Invalid params' };
-            mockErrorResponse(mockError);
-            await expect(client.getConfig()).rejects.toThrow(
-                'RPC Error -32602: Invalid params'
-            );
-        });
-
-        it('should handle empty error object', async () => {
-            mockErrorResponse({});
-            await expect(client.getConfig()).rejects.toThrow('RPC Error undefined: undefined');
-        });
-    });
+  });
 });

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -50,3 +50,9 @@ serde_json = { workspace = true }
 tokio = { workspace = true }
 hex = { workspace = true }
 testing-utils = { path = "testing-utils" }
+hmac = { workspace = true }
+sha2 = { workspace = true }
+reqwest = { workspace = true }
+futures = { workspace = true }
+anyhow = { workspace = true }
+once_cell = "1.21.3"

--- a/tests/auth_integration_tests.rs
+++ b/tests/auth_integration_tests.rs
@@ -1,0 +1,230 @@
+use hmac::{Hmac, Mac};
+use kora_lib::constant::{X_API_KEY, X_HMAC_SIGNATURE, X_TIMESTAMP};
+use once_cell::sync::Lazy;
+use serde_json::{json, Value};
+use sha2::Sha256;
+use testing_utils::*;
+
+const TEST_API_KEY: &str = "test-api-key-123";
+const TEST_HMAC_SECRET: &str = "test-hmac-secret-456";
+
+pub static JSON_TEST_BODY: Lazy<Value> = Lazy::new(|| {
+    json!({
+        "jsonrpc": "2.0",
+        "method": "getBlockhash",
+        "params": [],
+        "id": 1
+    })
+});
+
+pub static JSON_TEST_BODY_WITH_PARAMS: Lazy<Value> = Lazy::new(|| {
+    json!({
+        "jsonrpc": "2.0",
+        "method": "estimateTransactionFee",
+        "params": {
+            "transaction": "base64_encoded_transaction_here",
+            "commitment": "confirmed"
+        },
+        "id": 1
+    })
+});
+
+/// Helper to make JSON-RPC request with custom headers to test server
+async fn make_auth_request(headers: Option<Vec<(&str, &str)>>) -> reqwest::Response {
+    let client = reqwest::Client::new();
+
+    let mut request = client
+        .post(get_test_server_url())
+        .header("Content-Type", "application/json")
+        .json(&JSON_TEST_BODY.clone());
+
+    if let Some(custom_headers) = headers {
+        for (key, value) in custom_headers {
+            request = request.header(key, value);
+        }
+    }
+
+    request.send().await.expect("Request should complete")
+}
+
+/// Helper to make JSON-RPC request with custom headers and custom body to test server
+async fn make_auth_request_with_body(
+    body: &Value,
+    headers: Option<Vec<(&str, &str)>>,
+) -> reqwest::Response {
+    let client = reqwest::Client::new();
+
+    let mut request =
+        client.post(get_test_server_url()).header("Content-Type", "application/json").json(body);
+
+    if let Some(custom_headers) = headers {
+        for (key, value) in custom_headers {
+            request = request.header(key, value);
+        }
+    }
+
+    request.send().await.expect("Request should complete")
+}
+
+fn get_timestamp() -> String {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs()
+        .to_string()
+}
+
+/// Helper to create HMAC signature
+fn create_hmac_signature(secret: &str, timestamp: &str, body: &str) -> String {
+    let message = format!("{timestamp}{body}");
+    let mut mac = Hmac::<Sha256>::new_from_slice(secret.as_bytes()).unwrap();
+    mac.update(message.as_bytes());
+    hex::encode(mac.finalize().into_bytes())
+}
+
+fn create_valid_hmac_signature_headers() -> Vec<(String, String)> {
+    let timestamp = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs()
+        .to_string();
+
+    let signature =
+        create_hmac_signature(TEST_HMAC_SECRET, &timestamp, &JSON_TEST_BODY.to_string());
+
+    vec![(X_TIMESTAMP.to_string(), timestamp), (X_HMAC_SIGNATURE.to_string(), signature)]
+}
+
+fn create_valid_hmac_signature_headers_with_body(body: &Value) -> Vec<(String, String)> {
+    let timestamp = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs()
+        .to_string();
+
+    let signature = create_hmac_signature(TEST_HMAC_SECRET, &timestamp, &body.to_string());
+
+    vec![(X_TIMESTAMP.to_string(), timestamp), (X_HMAC_SIGNATURE.to_string(), signature)]
+}
+
+/// Test API key authentication
+#[tokio::test]
+async fn test_api_key_authentication() {
+    let valid_hmac = create_valid_hmac_signature_headers();
+    let valid_headers_hmac = valid_hmac.iter().map(|(k, v)| (k.as_str(), v.as_str()));
+
+    // Test valid API key
+    let response = make_auth_request(Some(
+        std::iter::once((X_API_KEY, TEST_API_KEY))
+            .chain(valid_headers_hmac.clone())
+            .collect::<Vec<(&str, &str)>>(),
+    ))
+    .await;
+
+    assert!(
+        response.status().is_success(),
+        "Valid API key should return 200, got {}",
+        response.status()
+    );
+
+    // Test invalid API key
+    let invalid_response = make_auth_request(Some(
+        std::iter::once((X_API_KEY, "wrong-key"))
+            .chain(valid_headers_hmac.clone())
+            .collect::<Vec<(&str, &str)>>(),
+    ))
+    .await;
+
+    assert_eq!(invalid_response.status(), 401, "Invalid API key should return 401");
+
+    // Test missing API key
+    let missing_response =
+        make_auth_request(Some(valid_headers_hmac.clone().collect::<Vec<(&str, &str)>>())).await;
+
+    assert_eq!(missing_response.status(), 401, "Missing API key should return 401");
+}
+
+#[tokio::test]
+async fn test_hmac_authentication() {
+    let valid_hmac = create_valid_hmac_signature_headers();
+    let valid_headers_hmac = valid_hmac.iter().map(|(k, v)| (k.as_str(), v.as_str()));
+
+    let response = make_auth_request(Some(
+        std::iter::once((X_API_KEY, TEST_API_KEY))
+            .chain(valid_headers_hmac.clone())
+            .collect::<Vec<(&str, &str)>>(),
+    ))
+    .await;
+
+    assert!(
+        response.status().is_success(),
+        "Valid HMAC should return 200, got {}",
+        response.status()
+    );
+
+    // Test invalid HMAC signature
+    let invalid_response = make_auth_request(Some(vec![
+        (X_API_KEY, TEST_API_KEY),
+        (X_HMAC_SIGNATURE, "invalid-signature"),
+        (X_TIMESTAMP, get_timestamp().as_str()),
+    ]))
+    .await;
+
+    assert_eq!(invalid_response.status(), 401, "Invalid HMAC should return 401");
+
+    // Test expired timestamp
+    let expired_timestamp =
+        (std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_secs()
+            - 600) // 10 minutes ago
+            .to_string();
+
+    let expired_signature =
+        create_hmac_signature(TEST_HMAC_SECRET, &expired_timestamp, &JSON_TEST_BODY.to_string());
+
+    let expired_response = make_auth_request(Some(vec![
+        (X_API_KEY, TEST_API_KEY),
+        (X_TIMESTAMP, expired_timestamp.as_str()),
+        (X_HMAC_SIGNATURE, expired_signature.as_str()),
+    ]))
+    .await;
+
+    assert_eq!(expired_response.status(), 401, "Expired timestamp should return 401");
+}
+
+#[tokio::test]
+async fn test_liveness_bypass() {
+    let client = reqwest::Client::new();
+    let liveness_response = client
+        .get(format!("{}/liveness", get_test_server_url()))
+        .send()
+        .await
+        .expect("Liveness request should succeed");
+
+    assert!(
+        liveness_response.status().is_success(),
+        "Liveness should bypass auth, got {}",
+        liveness_response.status()
+    );
+}
+
+#[tokio::test]
+async fn test_auth_with_params() {
+    let valid_hmac = create_valid_hmac_signature_headers_with_body(&JSON_TEST_BODY_WITH_PARAMS);
+    let valid_headers_hmac = valid_hmac.iter().map(|(k, v)| (k.as_str(), v.as_str()));
+
+    let response = make_auth_request_with_body(
+        &JSON_TEST_BODY_WITH_PARAMS,
+        Some(
+            std::iter::once((X_API_KEY, TEST_API_KEY))
+                .chain(valid_headers_hmac.clone())
+                .collect::<Vec<(&str, &str)>>(),
+        ),
+    )
+    .await;
+
+    assert!(
+        response.status().is_success(),
+        "Valid API key with params should return 200, got {}",
+        response.status()
+    );
+}

--- a/tests/fixtures/auth-test.toml
+++ b/tests/fixtures/auth-test.toml
@@ -1,0 +1,23 @@
+[kora]
+rate_limit = 100
+api_key = "test-api-key-123"
+hmac_secret = "test-hmac-secret-456"
+
+[validation]
+max_allowed_lamports = 1000000
+max_signatures = 10
+price_source = "Mock"
+allowed_programs = [
+    "11111111111111111111111111111111",
+    "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+    "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL",
+]
+allowed_tokens = ["9BgeTKqmFsPVnfYscfM6NvsgmZxei7XfdciShQ6D3bxJ"]
+allowed_spl_paid_tokens = ["9BgeTKqmFsPVnfYscfM6NvsgmZxei7XfdciShQ6D3bxJ"]
+disallowed_accounts = []
+
+[validation.fee_payer_policy]
+allow_sol_transfers = true
+allow_spl_transfers = true
+allow_token2022_transfers = true
+allow_assign = true

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1,4 +1,4 @@
 mod api_integration_tests;
+mod auth_integration_tests;
 mod compute_budget_integration_tests;
-
 mod token_integration_tests;


### PR DESCRIPTION
Why?

So node operators can control who has access to their node and also control integrity of the requests.

What?

- Added support for API Key and HMAC authentication methods in the Kora RPC server.
- Updated configuration to include optional `api_key` and `hmac_secret`.
- Enhanced integration tests to cover authentication scenarios.
- Updated documentation to reflect new authentication methods and usage examples.
- Refactored Makefile and CI to streamline integration test execution.