### PR TITLE
chore: Add SDK Publishing CI Workflows

### DIFF
--- a/.github/workflows/ts-sdk-publish.yml
+++ b/.github/workflows/ts-sdk-publish.yml
@@ -1,32 +1,86 @@
-name: NPM Publish
+name: Publish SDKs
+
 on:
-  workflow_dispatch:
   push:
     branches:
-      - master
+      - main
+    paths:
+      - 'sdks/**'
+
+# Prevent concurrent releases
+concurrency:
+  group: release
+  cancel-in-progress: false
+
 jobs:
-  publish:
+  typescript-integration:
+    uses: ./.github/workflows/typescript-integration.yml
+    secrets: inherit
+
+  publish-sdks:
+    name: Publish SDKs
     runs-on: ubuntu-latest
+    needs: [typescript-integration]
+    # Only run if there are changes in changeset files or package files
+    if: contains(github.event.head_commit.message, 'changeset')
+    
+    defaults:
+      run:
+        working-directory: sdks
+
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v2
+      - name: Checkout repository
+        uses: actions/checkout@v4
         with:
-          version: 9.10.0
-      - uses: actions/setup-node@v4
+          fetch-depth: 0 # Fetch full history for changeset
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
         with:
           node-version: 'lts/*'
-          cache: 'pnpm'
           registry-url: 'https://registry.npmjs.org'
-      - name: Install root dependencies
-        run: pnpm install
-      - name: Install TypeScript client dependencies
-        working-directory: sdks/ts
-        run: pnpm install
-      - name: Build client
-        working-directory: sdks/ts
-        run: pnpm build
-      - name: Publish client
-        working-directory: sdks/ts
-        run: pnpm publish --no-git-checks --access public
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.12.3
+          run_install: false
+
+      - name: Get pnpm store directory
+        shell: bash
+        run: |
+          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+
+      - name: Setup pnpm cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build TypeScript SDK
+        run: pnpm --filter "@kora/sdk" build
+
+      - name: Create release PR or publish packages
+        id: changesets
+        uses: changesets/action@v1
+        with:
+          version: pnpm changeset:version
+          publish: pnpm changeset:publish
+          commit: 'chore: release ts sdk packages'
+          title: 'chore: release ts sdk packages'
+          createGithubReleases: false
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish release summary
+        if: steps.changesets.outputs.published == 'true'
+        run: |
+          echo "🎉 Successfully published packages:"
+          echo "${{ steps.changesets.outputs.publishedPackages }}" | jq -r '.[] | "  - \(.name)@\(.version)"'

--- a/.github/workflows/validate-changeset.yml
+++ b/.github/workflows/validate-changeset.yml
@@ -1,0 +1,62 @@
+name: Validate PR
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'sdks/**'
+
+jobs:
+  validate-changeset:
+    name: Validate Changeset
+    runs-on: ubuntu-latest
+    if: "!contains(github.event.pull_request.labels.*.name, 'no-changeset')"
+    
+    defaults:
+      run:
+        working-directory: sdks
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 'lts/*'
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.12.3
+
+      - name: Get pnpm store directory
+        shell: bash
+        run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+
+      - name: Setup pnpm cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Check for changeset
+        run: |
+          if [ -z "$(ls .changeset/*.md 2>/dev/null | grep -v README)" ]; then
+            echo "❌ No changeset found!"
+            echo "Please run 'pnpm changeset' to create a changeset for your changes."
+            echo "If this PR doesn't need a changeset, add the 'no-changeset' label."
+            exit 1
+          else
+            echo "✅ Changeset found!"
+          fi
+
+      - name: Validate changeset format
+        run: pnpm changeset status


### PR DESCRIPTION
Adds two GitHub Actions workflows for SDK release management. Need to: 
- Add `NPM_TOKEN` to GH env @pkxro 
- Will need testing and debugging once merged to ensure workflows behave correctly with our setup.

**`ts-sdk-publish.yml`**
- Runs on pushes to `main` that touch `sdks/`
- Creates/updates "Version Packages" PR when changesets are present
- Publishes to npm when Version Packages PR is merged
- Uses `typescript-integration.yml` for quality checks

**`validate-changeset.yml`**  
- Ensures PRs include changesets (unless labeled `no-changeset`)

**Release Flow:**
1. Developer adds changeset → merge PR → "Version Packages" PR created/updated
2. Multiple changesets accumulate in the Version Packages PR over time
3. Merge Version Packages PR → packages published to npm / Changelogs updated / package.json version updated

