### PR TITLE
feat: (PRO-50) enhance token price calculations and fee estimation

### DIFF
--- a/.github/workflows/typescript-integration.yml
+++ b/.github/workflows/typescript-integration.yml
@@ -1,28 +1,29 @@
 name: TypeScript Integration Tests
 
 on:
+  workflow_dispatch:
   workflow_call:
   push:
     branches: [main]
     paths:
       # TS SDK changes
-      - 'sdks/ts/**'
+      - "sdks/ts/**"
       # Backend changes that affect TS integration
-      - 'crates/**'
-      - 'Cargo.*'
-      - 'Makefile'
-      - '.github/workflows/typescript-integration.yml'
+      - "crates/**"
+      - "Cargo.*"
+      - "Makefile"
+      - ".github/workflows/typescript-integration.yml"
 
   pull_request:
     branches: [main]
     paths:
-      # TS SDK changes  
-      - 'sdks/ts/**'
+      # TS SDK changes
+      - "sdks/ts/**"
       # Backend changes that affect TS integration
-      - 'crates/**'
-      - 'Cargo.*'
-      - 'Makefile'
-      - '.github/workflows/typescript-integration.yml'
+      - "crates/**"
+      - "Cargo.*"
+      - "Makefile"
+      - ".github/workflows/typescript-integration.yml"
 
 env:
   CARGO_TERM_COLOR: always
@@ -55,7 +56,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 'lts/*'
+          node-version: "lts/*"
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4

--- a/crates/lib/src/oracle/oracle.rs
+++ b/crates/lib/src/oracle/oracle.rs
@@ -5,6 +5,8 @@ use serde::{Deserialize, Serialize};
 use std::{sync::Arc, time::Duration};
 use tokio::time::sleep;
 
+pub const DEFAULT_MOCKED_PRICE: f64 = 0.001;
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TokenPrice {
     pub price: f64,
@@ -45,7 +47,7 @@ pub fn get_price_oracle(source: PriceSource) -> Arc<dyn PriceOracle + Send + Syn
                     let price = match mint_address {
                         USDC_DEVNET_MINT => 0.0001,                           // USDC
                         "So11111111111111111111111111111111111111112" => 1.0, // SOL
-                        _ => 0.001, // Default price for unknown tokens
+                        _ => DEFAULT_MOCKED_PRICE, // Default price for unknown tokens
                     };
                     Ok(TokenPrice { price, confidence: 1.0, source: PriceSource::Mock })
                 });

--- a/crates/lib/src/token/mod.rs
+++ b/crates/lib/src/token/mod.rs
@@ -1,7 +1,10 @@
-use crate::error::KoraError;
-use solana_sdk::pubkey::Pubkey;
-use std::str::FromStr;
-
+use crate::{
+    error::KoraError,
+    oracle::{get_price_oracle, PriceSource, RetryingPriceOracle, TokenPrice},
+};
+use solana_client::nonblocking::rpc_client::RpcClient;
+use solana_sdk::{native_token::LAMPORTS_PER_SOL, pubkey::Pubkey};
+use std::{str::FromStr, time::Duration};
 mod interface;
 mod token;
 mod token22;
@@ -36,4 +39,237 @@ pub fn check_valid_tokens(tokens: &[String]) -> Result<Vec<Pubkey>, KoraError> {
                 .map_err(|_| KoraError::ValidationError(format!("Invalid token address: {token}")))
         })
         .collect()
+}
+
+pub async fn get_token_price_and_decimals(
+    mint: &Pubkey,
+    price_source: PriceSource,
+    rpc_client: &RpcClient,
+) -> Result<(TokenPrice, u8), KoraError> {
+    let mint_account = rpc_client.get_account(mint).await?;
+
+    let is_token2022 = mint_account.owner == spl_token_2022::id();
+    let token_program =
+        TokenProgram::new(if is_token2022 { TokenType::Token2022 } else { TokenType::Spl });
+
+    let decimals = token_program.get_mint_decimals(&mint_account.data)?;
+
+    let oracle =
+        RetryingPriceOracle::new(3, Duration::from_secs(1), get_price_oracle(price_source));
+
+    // Get token price in SOL directly
+    let token_price = oracle
+        .get_token_price(&mint.to_string())
+        .await
+        .map_err(|e| KoraError::RpcError(format!("Failed to fetch token price: {e}")))?;
+
+    Ok((token_price, decimals))
+}
+
+pub async fn calculate_token_value_in_lamports(
+    amount: u64,
+    mint: &Pubkey,
+    price_source: PriceSource,
+    rpc_client: &RpcClient,
+) -> Result<u64, KoraError> {
+    let (token_price, decimals) =
+        get_token_price_and_decimals(mint, price_source, rpc_client).await?;
+
+    // Convert token amount to its real value based on decimals and multiply by SOL price
+    let token_amount = amount as f64 / 10f64.powi(decimals as i32);
+    let sol_amount = token_amount * token_price.price;
+
+    // Convert SOL to lamports and round down
+    let lamports = (sol_amount * LAMPORTS_PER_SOL as f64).floor() as u64;
+
+    Ok(lamports)
+}
+
+pub async fn calculate_lamports_value_in_token(
+    lamports: u64,
+    mint: &Pubkey,
+    price_source: &PriceSource,
+    rpc_client: &RpcClient,
+) -> Result<f64, KoraError> {
+    let (token_price, decimals) =
+        get_token_price_and_decimals(mint, price_source.clone(), rpc_client).await?;
+
+    // Convert lamports to SOL, then to token amount
+    let fee_in_sol = lamports as f64 / LAMPORTS_PER_SOL as f64;
+    let fee_in_token_base_units = fee_in_sol / token_price.price;
+    let fee_in_token = fee_in_token_base_units * 10f64.powi(decimals as i32);
+
+    Ok(fee_in_token)
+}
+
+#[cfg(test)]
+mod tests_token {
+    use super::*;
+    use base64::Engine;
+    use serde_json::json;
+    use solana_client::rpc_request::RpcRequest;
+    use solana_program::program_pack::Pack;
+    use solana_sdk::{account::Account, program_option::COption};
+    use spl_token::state::Mint;
+    use spl_token_2022::state::Mint as Mint2022;
+    use std::{collections::HashMap, sync::Arc};
+
+    fn get_mock_rpc_client(account: &Account) -> Arc<RpcClient> {
+        let mut mocks = HashMap::new();
+        let encoded_data = base64::engine::general_purpose::STANDARD.encode(&account.data);
+        mocks.insert(
+            RpcRequest::GetAccountInfo,
+            json!({
+                "context": {
+                    "slot": 1
+                },
+                "value": {
+                    "data": [encoded_data, "base64"],
+                    "executable": account.executable,
+                    "lamports": account.lamports,
+                    "owner": account.owner.to_string(),
+                    "rentEpoch": account.rent_epoch
+                }
+            }),
+        );
+        Arc::new(RpcClient::new_mock_with_mocks("http://localhost:8899".to_string(), mocks))
+    }
+
+    fn create_mock_spl_mint_account(decimals: u8) -> Account {
+        let mint_data = Mint {
+            mint_authority: COption::Some(Pubkey::new_unique()),
+            supply: 1_000_000_000_000,
+            decimals,
+            is_initialized: true,
+            freeze_authority: COption::None,
+        };
+
+        let mut data = vec![0u8; Mint::LEN];
+        mint_data.pack_into_slice(&mut data);
+
+        Account { lamports: 0, data, owner: spl_token::id(), executable: false, rent_epoch: 0 }
+    }
+
+    fn create_mock_token2022_mint_account(decimals: u8) -> Account {
+        let mint_data = Mint2022 {
+            mint_authority: COption::Some(Pubkey::new_unique()),
+            supply: 1_000_000_000_000,
+            decimals,
+            is_initialized: true,
+            freeze_authority: COption::None,
+        };
+
+        let mut data = vec![0u8; Mint2022::LEN];
+        mint_data.pack_into_slice(&mut data);
+
+        Account { lamports: 0, data, owner: spl_token_2022::id(), executable: false, rent_epoch: 0 }
+    }
+
+    #[tokio::test]
+    async fn test_check_valid_tokens() {
+        let valid_tokens = vec![
+            "So11111111111111111111111111111111111111112".to_string(),
+            "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU".to_string(),
+        ];
+        let result = check_valid_tokens(&valid_tokens).unwrap();
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0].to_string(), "So11111111111111111111111111111111111111112");
+        assert_eq!(result[1].to_string(), "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU");
+    }
+
+    #[tokio::test]
+    async fn test_check_valid_tokens_invalid() {
+        let invalid_tokens = vec!["invalid_token_address".to_string()];
+        let result = check_valid_tokens(&invalid_tokens);
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_get_token_price_and_decimals_spl() {
+        let mint = Pubkey::from_str("So11111111111111111111111111111111111111112").unwrap();
+        let account = create_mock_spl_mint_account(9);
+        let rpc_client = get_mock_rpc_client(&account);
+
+        let (token_price, decimals) =
+            get_token_price_and_decimals(&mint, PriceSource::Mock, &rpc_client).await.unwrap();
+
+        assert_eq!(decimals, 9);
+        assert_eq!(token_price.price, 1.0);
+    }
+
+    #[tokio::test]
+    async fn test_get_token_price_and_decimals_token2022() {
+        let mint = Pubkey::from_str("4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU").unwrap();
+
+        let account = create_mock_token2022_mint_account(6);
+        let rpc_client = get_mock_rpc_client(&account);
+
+        let (token_price, decimals) =
+            get_token_price_and_decimals(&mint, PriceSource::Mock, &rpc_client).await.unwrap();
+
+        assert_eq!(decimals, 6);
+        assert_eq!(token_price.price, 0.0001);
+    }
+
+    #[tokio::test]
+    async fn test_calculate_token_value_in_lamports() {
+        let mint = Pubkey::from_str("So11111111111111111111111111111111111111112").unwrap();
+        let account = create_mock_spl_mint_account(9);
+        let rpc_client = get_mock_rpc_client(&account);
+
+        let amount = 1_000_000_000; // 1 SOL in lamports
+        let result =
+            calculate_token_value_in_lamports(amount, &mint, PriceSource::Mock, &rpc_client)
+                .await
+                .unwrap();
+
+        assert_eq!(result, 1_000_000_000); // Should equal input since SOL price is 1.0
+    }
+
+    #[tokio::test]
+    async fn test_calculate_token_value_in_lamports_usdc() {
+        let mint = Pubkey::from_str("4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU").unwrap();
+        let account = create_mock_spl_mint_account(6);
+        let rpc_client = get_mock_rpc_client(&account);
+
+        let amount = 1_000_000; // 1 USDC (6 decimals)
+        let result =
+            calculate_token_value_in_lamports(amount, &mint, PriceSource::Mock, &rpc_client)
+                .await
+                .unwrap();
+
+        // 1 USDC * 0.0001 SOL/USDC = 0.0001 SOL = 100,000 lamports
+        assert_eq!(result, 100_000);
+    }
+
+    #[tokio::test]
+    async fn test_calculate_lamports_value_in_token() {
+        let mint = Pubkey::from_str("So11111111111111111111111111111111111111112").unwrap();
+        let account = create_mock_spl_mint_account(9);
+        let rpc_client = get_mock_rpc_client(&account);
+
+        let lamports = 1_000_000_000; // 1 SOL
+        let result =
+            calculate_lamports_value_in_token(lamports, &mint, &PriceSource::Mock, &rpc_client)
+                .await
+                .unwrap();
+
+        assert_eq!(result, 1_000_000_000.0); // Should equal input since SOL price is 1.0
+    }
+
+    #[tokio::test]
+    async fn test_calculate_lamports_value_in_token_usdc() {
+        let mint = Pubkey::from_str("4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU").unwrap();
+        let account = create_mock_spl_mint_account(6);
+        let rpc_client = get_mock_rpc_client(&account);
+
+        let lamports = 100_000; // 0.0001 SOL
+        let result =
+            calculate_lamports_value_in_token(lamports, &mint, &PriceSource::Mock, &rpc_client)
+                .await
+                .unwrap();
+
+        // 0.0001 SOL / 0.0001 SOL/USDC = 1 USDC = 1,000,000 base units
+        assert_eq!(result, 1_000_000.0);
+    }
 }

--- a/crates/lib/src/transaction/validator.rs
+++ b/crates/lib/src/transaction/validator.rs
@@ -2,8 +2,11 @@ use crate::{
     config::{FeePayerPolicy, ValidationConfig},
     error::KoraError,
     oracle::PriceSource,
-    token::{Token2022Account, TokenInterface, TokenProgram, TokenType},
-    transaction::{fees::calculate_token_value_in_lamports, VersionedTransactionExt},
+    token::{
+        calculate_token_value_in_lamports, Token2022Account, TokenInterface, TokenProgram,
+        TokenType,
+    },
+    transaction::VersionedTransactionExt,
 };
 use solana_client::nonblocking::rpc_client::RpcClient;
 use solana_message::VersionedMessage;

--- a/crates/rpc/src/method/estimate_transaction_fee.rs
+++ b/crates/rpc/src/method/estimate_transaction_fee.rs
@@ -2,12 +2,16 @@ use std::sync::Arc;
 use utoipa::ToSchema;
 
 use kora_lib::{
+    config::ValidationConfig,
     error::KoraError,
+    token::calculate_lamports_value_in_token,
     transaction::{
         decode_b64_transaction, estimate_transaction_fee as lib_estimate_transaction_fee,
         VersionedTransactionResolved,
     },
 };
+use solana_sdk::pubkey::Pubkey;
+use std::str::FromStr;
 
 use serde::{Deserialize, Serialize};
 use solana_client::nonblocking::rpc_client::RpcClient;
@@ -15,16 +19,19 @@ use solana_client::nonblocking::rpc_client::RpcClient;
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct EstimateTransactionFeeRequest {
     pub transaction: String, // Base64 encoded serialized transaction
-    pub fee_token: String,
+    #[serde(default)]
+    pub fee_token: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct EstimateTransactionFeeResponse {
     pub fee_in_lamports: u64,
+    pub fee_in_token: Option<f64>,
 }
 
 pub async fn estimate_transaction_fee(
     rpc_client: &Arc<RpcClient>,
+    validation: &ValidationConfig,
     request: EstimateTransactionFeeRequest,
 ) -> Result<EstimateTransactionFeeResponse, KoraError> {
     let transaction = decode_b64_transaction(&request.transaction)?;
@@ -33,7 +40,26 @@ pub async fn estimate_transaction_fee(
     let mut resolved_transaction = VersionedTransactionResolved::new(&transaction);
     resolved_transaction.resolve_addresses(rpc_client).await?;
 
-    let fee = lib_estimate_transaction_fee(rpc_client, &resolved_transaction).await?;
+    let fee_in_lamports = lib_estimate_transaction_fee(rpc_client, &resolved_transaction).await?;
 
-    Ok(EstimateTransactionFeeResponse { fee_in_lamports: fee })
+    let mut fee_in_token = None;
+
+    // If fee_token is provided, calculate the fee in that token
+    if let Some(fee_token) = &request.fee_token {
+        let token_mint = Pubkey::from_str(fee_token).map_err(|_| {
+            KoraError::InvalidTransaction("Invalid fee token mint address".to_string())
+        })?;
+
+        let fee_value_in_token = calculate_lamports_value_in_token(
+            fee_in_lamports,
+            &token_mint,
+            &validation.price_source,
+            rpc_client,
+        )
+        .await?;
+
+        fee_in_token = Some(fee_value_in_token);
+    }
+
+    Ok(EstimateTransactionFeeResponse { fee_in_lamports, fee_in_token })
 }

--- a/crates/rpc/src/rpc.rs
+++ b/crates/rpc/src/rpc.rs
@@ -65,7 +65,7 @@ impl KoraRpc {
         request: EstimateTransactionFeeRequest,
     ) -> Result<EstimateTransactionFeeResponse, KoraError> {
         info!("Estimate transaction fee request: {request:?}");
-        let result = estimate_transaction_fee(&self.rpc_client, request).await;
+        let result = estimate_transaction_fee(&self.rpc_client, &self.validation, request).await;
         info!("Estimate transaction fee response: {result:?}");
         result
     }


### PR DESCRIPTION
Why?

So the caller knows how many tokens to include instead of having to calculate it themselves.

What?

- Introduced `get_token_price_and_decimals` and `calculate_token_value_in_lamports` functions for improved token price handling.
- Updated `estimate_transaction_fee` to optionally return fee in specified token.
- Refactored related tests to ensure accuracy in price and fee calculations.