### PR TITLE
refactor(lib): (PRO-62) enhance transaction fee estimation by incorporating fee payer outflow calculations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ lint:
 	
 # Run tests
 test:
-	cargo test --lib
+	cargo test --lib --quiet
 
 # Generate a random key that can be used as an API key or as an HMAC secret
 generate-key:

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -3,6 +3,7 @@ use kora_lib::{
     args::CliArgs,
     config::load_config,
     error::KoraError,
+    get_signer,
     rpc::{create_rpc_client, get_rpc_client},
     signer::init::init_signer_type,
     state::init_signer,
@@ -125,7 +126,16 @@ async fn main() -> Result<(), KoraError> {
             let mut resolved_transaction = VersionedTransactionResolved::new(&transaction);
             resolved_transaction.resolve_addresses(&rpc_client).await?;
 
-            let fee = estimate_transaction_fee(&rpc_client, &resolved_transaction).await?;
+            let fee_payer = get_signer()?;
+            let fee_payer_pubkey = fee_payer.solana_pubkey();
+
+            let fee = estimate_transaction_fee(
+                &rpc_client,
+                &resolved_transaction,
+                Some(&fee_payer_pubkey),
+            )
+            .await?;
+
             println!("Estimated fee: {fee} lamports");
         }
         Some(Commands::SignIfPaid { transaction }) => {

--- a/crates/lib/src/transaction/fees.rs
+++ b/crates/lib/src/transaction/fees.rs
@@ -9,7 +9,10 @@ use crate::{
 use serde::{Deserialize, Serialize};
 use solana_client::nonblocking::rpc_client::RpcClient;
 use solana_message::VersionedMessage;
-use solana_sdk::{pubkey::Pubkey, rent::Rent, transaction::VersionedTransaction};
+use solana_sdk::{
+    instruction::CompiledInstruction, pubkey::Pubkey, rent::Rent, transaction::VersionedTransaction,
+};
+use solana_system_interface::{instruction::SystemInstruction, program::ID as SYSTEM_PROGRAM_ID};
 use spl_associated_token_account::get_associated_token_address;
 use std::str::FromStr;
 use utoipa::ToSchema;
@@ -95,6 +98,7 @@ pub async fn estimate_transaction_fee(
     rpc_client: &RpcClient,
     // Should have resolved addresses for lookup tables
     resolved_transaction: &impl VersionedTransactionExt,
+    fee_payer: Option<&Pubkey>,
 ) -> Result<u64, KoraError> {
     let transaction = resolved_transaction.get_transaction();
 
@@ -114,7 +118,20 @@ pub async fn estimate_transaction_fee(
         kora_signature_fee = LAMPORTS_PER_SIGNATURE;
     }
 
-    Ok(base_fee + account_creation_fee + kora_signature_fee)
+    // Calculate fee payer outflow if fee payer is provided, to better estimate the potential fee
+    let fee_payer_outflow = if let Some(fee_payer_pubkey) = fee_payer {
+        calculate_fee_payer_outflow(
+            rpc_client,
+            fee_payer_pubkey,
+            &transaction.message,
+            &transaction.get_all_account_keys(),
+        )
+        .await?
+    } else {
+        0
+    };
+
+    Ok(base_fee + account_creation_fee + kora_signature_fee + fee_payer_outflow)
 }
 
 async fn get_associated_token_account_creation_fees(
@@ -152,6 +169,130 @@ async fn get_associated_token_account_creation_fees(
     Ok(exempt_min * ata_count)
 }
 
+/// Calculate the total outflow (SOL spending) that could occur for a fee payer account in a transaction.
+/// This includes transfers, account creation, and other operations that could drain the fee payer's balance.
+pub async fn calculate_fee_payer_outflow(
+    rpc_client: &RpcClient,
+    fee_payer_pubkey: &Pubkey,
+    message: &VersionedMessage,
+    account_keys: &[Pubkey],
+) -> Result<u64, KoraError> {
+    let mut total = 0u64;
+
+    // Helper function to check if the fee payer is at a specific account index in an instruction
+    let is_fee_payer =
+        |instruction: &CompiledInstruction, account_index: usize| -> Result<bool, KoraError> {
+            if account_index >= instruction.accounts.len() {
+                return Ok(false); // If account index is invalid, fee payer can't be the source
+            }
+            let account_key_index = instruction.accounts[account_index];
+            if (account_key_index as usize) >= account_keys.len() {
+                return Ok(false); // If account key index is invalid, fee payer can't be the source
+            }
+            let account_pubkey = account_keys[account_key_index as usize];
+            Ok(account_pubkey == *fee_payer_pubkey)
+        };
+
+    let get_current_balance = async |account_pubkey: &Pubkey| -> Result<u64, KoraError> {
+        if let Ok(account_balance) =
+            rpc_client.get_account_with_commitment(account_pubkey, rpc_client.commitment()).await
+        {
+            if let Some(account_balance) = account_balance.value {
+                return Ok(account_balance.lamports);
+            }
+        }
+
+        Ok(0)
+    };
+
+    for instruction in message.instructions() {
+        let program_idx = instruction.program_id_index as usize;
+        if program_idx >= account_keys.len() {
+            continue; // Skip invalid program ID index
+        }
+        let program_id = account_keys[program_idx];
+
+        // Handle System Program transfers and account creation
+        if program_id == SYSTEM_PROGRAM_ID {
+            match bincode::deserialize::<SystemInstruction>(&instruction.data) {
+                // Account creation instructions - funding account pays lamports
+                Ok(SystemInstruction::CreateAccount { lamports, .. })
+                | Ok(SystemInstruction::CreateAccountWithSeed { lamports, .. }) => {
+                    if is_fee_payer(instruction, 0)? {
+                        total = total.saturating_add(lamports);
+                    }
+                }
+                // Transfer instructions
+                Ok(SystemInstruction::Transfer { lamports }) => {
+                    // Check if fee payer is sender (outflow)
+                    if is_fee_payer(instruction, 0)? {
+                        total = total.saturating_add(lamports);
+                    }
+                    // Check if fee payer is receiver (inflow, e.g., from account closure)
+                    else if is_fee_payer(instruction, 1)? {
+                        total = total.saturating_sub(lamports);
+                    }
+                }
+                Ok(SystemInstruction::TransferWithSeed { lamports, .. }) => {
+                    // Check if fee payer is sender (outflow). With seeds sender is at index 1
+                    if is_fee_payer(instruction, 1)? {
+                        total = total.saturating_add(lamports);
+                    }
+                    // Check if fee payer is receiver (inflow)
+                    else if is_fee_payer(instruction, 2)? {
+                        total = total.saturating_sub(lamports);
+                    }
+                }
+                // Nonce account withdrawal - can drain entire nonce account balance
+                Ok(SystemInstruction::WithdrawNonceAccount(lamports)) => {
+                    // Check if fee payer is the nonce account (outflow) - index 0
+                    if is_fee_payer(instruction, 0)? {
+                        total = total.saturating_add(lamports);
+                    }
+                    // Check if fee payer is recipient (inflow) - index 1
+                    else if is_fee_payer(instruction, 1)? {
+                        total = total.saturating_sub(lamports);
+                    }
+                }
+                // Account space allocation - may require additional rent
+                Ok(SystemInstruction::Allocate { space }) => {
+                    if is_fee_payer(instruction, 0)? {
+                        // Get the account being allocated (at index 0)
+                        let account_key_index = instruction.accounts[0];
+                        let account_being_allocated = account_keys[account_key_index as usize];
+
+                        // Calculate potential rent increase for space allocation
+                        let rent = solana_sdk::rent::Rent::default();
+                        let current_balance = get_current_balance(&account_being_allocated).await?;
+                        let required_balance = rent.minimum_balance(space as usize);
+                        if required_balance > current_balance {
+                            total = total.saturating_add(required_balance - current_balance);
+                        }
+                    }
+                }
+                Ok(SystemInstruction::AllocateWithSeed { space, .. }) => {
+                    if is_fee_payer(instruction, 1)? {
+                        // Get the account being allocated (at index 0, but fee payer funds it at index 1)
+                        let account_key_index = instruction.accounts[0];
+                        let account_being_allocated = account_keys[account_key_index as usize];
+
+                        // Calculate potential rent increase for space allocation with seed
+                        let rent = solana_sdk::rent::Rent::default();
+                        let current_balance = get_current_balance(&account_being_allocated).await?;
+                        let required_balance = rent.minimum_balance(space as usize);
+                        if required_balance > current_balance {
+                            total = total.saturating_add(required_balance - current_balance);
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+
+    Ok(total)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -160,7 +301,7 @@ mod tests {
         state::init_signer,
         transaction::{new_unsigned_versioned_transaction, VersionedTransactionResolved},
     };
-    use base64::Engine;
+    use base64::{self, Engine};
     use serde_json::json;
     use solana_client::rpc_request::RpcRequest;
     use solana_message::{v0, Message};
@@ -168,12 +309,53 @@ mod tests {
     use solana_sdk::{
         account::Account,
         hash::Hash,
+        instruction::Instruction,
         pubkey::Pubkey,
         signature::{Keypair, Signer},
     };
-    use solana_system_interface::instruction::transfer;
+    use solana_system_interface::instruction::{
+        allocate, allocate_with_seed, create_account, create_account_with_seed, transfer,
+        transfer_with_seed, withdraw_nonce_account,
+    };
     use spl_token::state::Mint;
     use std::{collections::HashMap, sync::Arc};
+
+    fn setup_or_get_test_signer() -> Pubkey {
+        if let Ok(signer) = get_signer() {
+            return signer.solana_pubkey();
+        }
+
+        let test_keypair = Keypair::new();
+        let signer = SolanaMemorySigner::new(test_keypair.insecure_clone());
+        match init_signer(KoraSigner::Memory(signer)) {
+            Ok(_) => test_keypair.pubkey(),
+            Err(_) => {
+                // Signer already initialized, get it
+                get_signer().expect("Signer should be available").solana_pubkey()
+            }
+        }
+    }
+
+    fn get_mock_rpc_client(account: &Account) -> Arc<RpcClient> {
+        let mut mocks = HashMap::new();
+        let encoded_data = base64::engine::general_purpose::STANDARD.encode(&account.data);
+        mocks.insert(
+            RpcRequest::GetAccountInfo,
+            json!({
+                "context": {
+                    "slot": 1
+                },
+                "value": {
+                    "data": [encoded_data, "base64"],
+                    "executable": account.executable,
+                    "lamports": account.lamports,
+                    "owner": account.owner.to_string(),
+                    "rentEpoch": account.rent_epoch
+                }
+            }),
+        );
+        Arc::new(RpcClient::new_mock_with_mocks("http://localhost:8899".to_string(), mocks))
+    }
 
     fn get_mock_rpc_client_with_mint(mint_decimals: u8) -> Arc<RpcClient> {
         let mut mocks = HashMap::new();
@@ -182,7 +364,7 @@ mod tests {
         let mut mint_data = vec![0u8; Mint::LEN];
         let mint = Mint {
             mint_authority: Some(Pubkey::new_unique()).into(),
-            supply: 1000000u64.into(),
+            supply: 1000000,
             decimals: mint_decimals,
             is_initialized: true,
             freeze_authority: None.into(),
@@ -394,22 +576,6 @@ mod tests {
         }
     }
 
-    fn setup_or_get_test_signer() -> Pubkey {
-        if let Ok(signer) = get_signer() {
-            return signer.solana_pubkey();
-        }
-
-        let test_keypair = Keypair::new();
-        let signer = SolanaMemorySigner::new(test_keypair.insecure_clone());
-        match init_signer(KoraSigner::Memory(signer)) {
-            Ok(_) => test_keypair.pubkey(),
-            Err(_) => {
-                // Signer already initialized, get it
-                get_signer().expect("Signer should be available").solana_pubkey()
-            }
-        }
-    }
-
     #[test]
     fn test_is_fee_payer_in_signers_legacy_fee_payer_is_signer() {
         let fee_payer = setup_or_get_test_signer();
@@ -483,5 +649,381 @@ mod tests {
         let resolved_transaction = VersionedTransactionResolved::new(&transaction);
 
         assert!(!is_fee_payer_in_signers(&resolved_transaction).unwrap());
+    }
+
+    #[tokio::test]
+    async fn test_calculate_fee_payer_outflow_transfer() {
+        let fee_payer = Pubkey::new_unique();
+        let recipient = Pubkey::new_unique();
+        let rpc_client = get_mock_rpc_client(&Account::default());
+
+        // Test 1: Fee payer as sender - should add to outflow
+        let transfer_instruction = transfer(&fee_payer, &recipient, 100_000);
+        let message =
+            VersionedMessage::Legacy(Message::new(&[transfer_instruction], Some(&fee_payer)));
+        let outflow = calculate_fee_payer_outflow(
+            &rpc_client,
+            &fee_payer,
+            &message,
+            message.static_account_keys(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(outflow, 100_000, "Transfer from fee payer should add to outflow");
+
+        // Test 2: Fee payer as recipient - should subtract from outflow
+        let sender = Pubkey::new_unique();
+        let transfer_instruction = transfer(&sender, &fee_payer, 50_000);
+        let message =
+            VersionedMessage::Legacy(Message::new(&[transfer_instruction], Some(&fee_payer)));
+        let outflow = calculate_fee_payer_outflow(
+            &rpc_client,
+            &fee_payer,
+            &message,
+            message.static_account_keys(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(outflow, 0, "Transfer to fee payer should subtract from outflow (saturating)");
+
+        // Test 3: Other account as sender - should not affect outflow
+        let other_sender = Pubkey::new_unique();
+        let transfer_instruction = transfer(&other_sender, &recipient, 500_000);
+        let message =
+            VersionedMessage::Legacy(Message::new(&[transfer_instruction], Some(&fee_payer)));
+        let outflow = calculate_fee_payer_outflow(
+            &rpc_client,
+            &fee_payer,
+            &message,
+            message.static_account_keys(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(outflow, 0, "Transfer from other account should not affect outflow");
+    }
+
+    #[tokio::test]
+    async fn test_calculate_fee_payer_outflow_transfer_with_seed() {
+        let fee_payer = Pubkey::new_unique();
+        let recipient = Pubkey::new_unique();
+        let rpc_client = get_mock_rpc_client(&Account::default());
+
+        // Test 1: Fee payer as sender (index 1 for TransferWithSeed)
+        let transfer_instruction = transfer_with_seed(
+            &fee_payer,
+            &fee_payer,
+            "test_seed".to_string(),
+            &SYSTEM_PROGRAM_ID,
+            &recipient,
+            150_000,
+        );
+        let message =
+            VersionedMessage::Legacy(Message::new(&[transfer_instruction], Some(&fee_payer)));
+        let outflow = calculate_fee_payer_outflow(
+            &rpc_client,
+            &fee_payer,
+            &message,
+            message.static_account_keys(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(outflow, 150_000, "TransferWithSeed from fee payer should add to outflow");
+
+        // Test 2: Fee payer as recipient (index 2 for TransferWithSeed)
+        let other_sender = Pubkey::new_unique();
+        let transfer_instruction = transfer_with_seed(
+            &other_sender,
+            &other_sender,
+            "test_seed".to_string(),
+            &SYSTEM_PROGRAM_ID,
+            &fee_payer,
+            75_000,
+        );
+        let message =
+            VersionedMessage::Legacy(Message::new(&[transfer_instruction], Some(&fee_payer)));
+        let outflow = calculate_fee_payer_outflow(
+            &rpc_client,
+            &fee_payer,
+            &message,
+            message.static_account_keys(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            outflow, 0,
+            "TransferWithSeed to fee payer should subtract from outflow (saturating)"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_calculate_fee_payer_outflow_create_account() {
+        let fee_payer = Pubkey::new_unique();
+        let new_account = Pubkey::new_unique();
+        let rpc_client = get_mock_rpc_client(&Account::default());
+
+        // Test 1: Fee payer funding CreateAccount
+        let create_instruction =
+            create_account(&fee_payer, &new_account, 200_000, 100, &SYSTEM_PROGRAM_ID);
+        let message =
+            VersionedMessage::Legacy(Message::new(&[create_instruction], Some(&fee_payer)));
+        let outflow = calculate_fee_payer_outflow(
+            &rpc_client,
+            &fee_payer,
+            &message,
+            message.static_account_keys(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(outflow, 200_000, "CreateAccount funded by fee payer should add to outflow");
+
+        // Test 2: Other account funding CreateAccount
+        let other_funder = Pubkey::new_unique();
+        let create_instruction =
+            create_account(&other_funder, &new_account, 1_000_000, 100, &SYSTEM_PROGRAM_ID);
+        let message =
+            VersionedMessage::Legacy(Message::new(&[create_instruction], Some(&fee_payer)));
+        let outflow = calculate_fee_payer_outflow(
+            &rpc_client,
+            &fee_payer,
+            &message,
+            message.static_account_keys(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(outflow, 0, "CreateAccount funded by other account should not affect outflow");
+    }
+
+    #[tokio::test]
+    async fn test_calculate_fee_payer_outflow_create_account_with_seed() {
+        let fee_payer = Pubkey::new_unique();
+        let new_account = Pubkey::new_unique();
+        let rpc_client = get_mock_rpc_client(&Account::default());
+
+        // Test: Fee payer funding CreateAccountWithSeed
+        let create_instruction = create_account_with_seed(
+            &fee_payer,
+            &new_account,
+            &fee_payer,
+            "test_seed",
+            300_000,
+            100,
+            &SYSTEM_PROGRAM_ID,
+        );
+        let message =
+            VersionedMessage::Legacy(Message::new(&[create_instruction], Some(&fee_payer)));
+        let outflow = calculate_fee_payer_outflow(
+            &rpc_client,
+            &fee_payer,
+            &message,
+            message.static_account_keys(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            outflow, 300_000,
+            "CreateAccountWithSeed funded by fee payer should add to outflow"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_calculate_fee_payer_outflow_nonce_withdraw() {
+        let fee_payer = Pubkey::new_unique();
+        let recipient = Pubkey::new_unique();
+        let authority = Pubkey::new_unique();
+        let rpc_client = get_mock_rpc_client(&Account::default());
+
+        // Test 1: Fee payer as nonce account (outflow)
+        let withdraw_instruction =
+            withdraw_nonce_account(&fee_payer, &authority, &recipient, 50_000);
+        let message =
+            VersionedMessage::Legacy(Message::new(&[withdraw_instruction], Some(&fee_payer)));
+        let outflow = calculate_fee_payer_outflow(
+            &rpc_client,
+            &fee_payer,
+            &message,
+            message.static_account_keys(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            outflow, 50_000,
+            "WithdrawNonceAccount from fee payer nonce should add to outflow"
+        );
+
+        // Test 2: Fee payer as recipient (inflow)
+        let nonce_account = Pubkey::new_unique();
+        let withdraw_instruction =
+            withdraw_nonce_account(&nonce_account, &authority, &fee_payer, 25_000);
+        let message =
+            VersionedMessage::Legacy(Message::new(&[withdraw_instruction], Some(&fee_payer)));
+        let outflow = calculate_fee_payer_outflow(
+            &rpc_client,
+            &fee_payer,
+            &message,
+            message.static_account_keys(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            outflow, 0,
+            "WithdrawNonceAccount to fee payer should subtract from outflow (saturating)"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_calculate_fee_payer_outflow_allocate() {
+        let fee_payer = Pubkey::new_unique();
+        let rpc_client = get_mock_rpc_client(&Account {
+            lamports: 0, // Start with 0 balance to test rent calculation
+            ..Account::default()
+        });
+
+        // Test 1: Fee payer allocating space
+        let allocate_instruction = allocate(&fee_payer, 1000);
+        let message =
+            VersionedMessage::Legacy(Message::new(&[allocate_instruction], Some(&fee_payer)));
+        let outflow = calculate_fee_payer_outflow(
+            &rpc_client,
+            &fee_payer,
+            &message,
+            message.static_account_keys(),
+        )
+        .await
+        .unwrap();
+
+        // Calculate expected rent
+        let rent = Rent::default();
+        let expected_rent = rent.minimum_balance(1000);
+        assert_eq!(outflow, expected_rent, "Allocate should add rent exemption cost");
+
+        // Test 2: Other account allocating
+        let other_account = Pubkey::new_unique();
+        let allocate_instruction = allocate(&other_account, 1000);
+        let message =
+            VersionedMessage::Legacy(Message::new(&[allocate_instruction], Some(&fee_payer)));
+        let outflow = calculate_fee_payer_outflow(
+            &rpc_client,
+            &fee_payer,
+            &message,
+            message.static_account_keys(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(outflow, 0, "Allocate by other account should not affect outflow");
+    }
+
+    #[tokio::test]
+    async fn test_calculate_fee_payer_outflow_allocate_with_seed() {
+        let fee_payer = Pubkey::new_unique();
+        let rpc_client = get_mock_rpc_client(&Account {
+            lamports: 0, // Start with 0 balance to test rent calculation
+            ..Account::default()
+        });
+
+        // Test: Fee payer allocating with seed (fee payer at index 1)
+        let allocate_instruction =
+            allocate_with_seed(&fee_payer, &fee_payer, "test_seed", 2000, &SYSTEM_PROGRAM_ID);
+        let message =
+            VersionedMessage::Legacy(Message::new(&[allocate_instruction], Some(&fee_payer)));
+        let outflow = calculate_fee_payer_outflow(
+            &rpc_client,
+            &fee_payer,
+            &message,
+            message.static_account_keys(),
+        )
+        .await
+        .unwrap();
+
+        // Calculate expected rent
+        let rent = Rent::default();
+        let expected_rent = rent.minimum_balance(2000);
+        assert_eq!(outflow, expected_rent, "AllocateWithSeed should add rent exemption cost");
+    }
+
+    #[tokio::test]
+    async fn test_calculate_fee_payer_outflow_multiple_instructions() {
+        let fee_payer = Pubkey::new_unique();
+        let recipient = Pubkey::new_unique();
+        let sender = Pubkey::new_unique();
+        let new_account = Pubkey::new_unique();
+        let rpc_client = get_mock_rpc_client(&Account::default());
+
+        // Multiple instructions involving fee payer
+        let instructions = vec![
+            transfer(&fee_payer, &recipient, 100_000), // +100,000
+            transfer(&sender, &fee_payer, 30_000),     // -30,000
+            create_account(&fee_payer, &new_account, 50_000, 100, &SYSTEM_PROGRAM_ID), // +50,000
+        ];
+        let message = VersionedMessage::Legacy(Message::new(&instructions, Some(&fee_payer)));
+        let outflow = calculate_fee_payer_outflow(
+            &rpc_client,
+            &fee_payer,
+            &message,
+            message.static_account_keys(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            outflow, 120_000,
+            "Multiple instructions should sum correctly: 100000 - 30000 + 50000 = 120000"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_calculate_fee_payer_outflow_non_system_program() {
+        let fee_payer = Pubkey::new_unique();
+        let fake_program = Pubkey::new_unique();
+        let rpc_client = get_mock_rpc_client(&Account::default());
+
+        // Test with non-system program - should not affect outflow
+        let instruction = Instruction::new_with_bincode(
+            fake_program,
+            &[0u8],
+            vec![], // no accounts needed for this test
+        );
+        let message = VersionedMessage::Legacy(Message::new(&[instruction], Some(&fee_payer)));
+        let outflow = calculate_fee_payer_outflow(
+            &rpc_client,
+            &fee_payer,
+            &message,
+            message.static_account_keys(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(outflow, 0, "Non-system program should not affect outflow");
+    }
+
+    #[tokio::test]
+    async fn test_calculate_fee_payer_outflow_invalid_account_indices() {
+        let fee_payer = Pubkey::new_unique();
+        let rpc_client = get_mock_rpc_client(&Account::default());
+
+        // Create a message with invalid account indices by directly constructing CompiledInstruction
+        let compiled_instruction = CompiledInstruction {
+            program_id_index: 0,     // System program
+            accounts: vec![99, 100], // Invalid indices that exceed account_keys length
+            data: bincode::serialize(&SystemInstruction::Transfer { lamports: 1000 }).unwrap(),
+        };
+
+        let message = VersionedMessage::Legacy(solana_message::legacy::Message {
+            header: solana_message::MessageHeader {
+                num_required_signatures: 1,
+                num_readonly_signed_accounts: 0,
+                num_readonly_unsigned_accounts: 0,
+            },
+            account_keys: vec![SYSTEM_PROGRAM_ID, fee_payer], // Only 2 accounts
+            recent_blockhash: solana_sdk::hash::Hash::default(),
+            instructions: vec![compiled_instruction],
+        });
+
+        let outflow = calculate_fee_payer_outflow(
+            &rpc_client,
+            &fee_payer,
+            &message,
+            message.static_account_keys(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(outflow, 0, "Invalid account indices should not cause outflow");
     }
 }

--- a/crates/lib/src/transaction/paid_transaction.rs
+++ b/crates/lib/src/transaction/paid_transaction.rs
@@ -19,9 +19,11 @@ pub async fn sign_transaction_if_paid(
     resolved_transaction: &impl VersionedTransactionExt,
 ) -> Result<(VersionedTransaction, String), KoraError> {
     let signer = get_signer()?;
+    let fee_payer = signer.solana_pubkey();
 
     // Get the simulation result for fee calculation
-    let min_transaction_fee = estimate_transaction_fee(rpc_client, resolved_transaction).await?;
+    let min_transaction_fee =
+        estimate_transaction_fee(rpc_client, resolved_transaction, Some(&fee_payer)).await?;
 
     let required_lamports = validation
         .price

--- a/crates/lib/src/transaction/tests.rs
+++ b/crates/lib/src/transaction/tests.rs
@@ -73,7 +73,7 @@ async fn test_estimate_transaction_fee_basic() {
         message: VersionedMessage::Legacy(message),
     };
 
-    let fee = estimate_transaction_fee(&rpc_client, &transaction).await.unwrap();
+    let fee = estimate_transaction_fee(&rpc_client, &transaction, None).await.unwrap();
 
     // Base fee + priority fee
     assert!(fee > 0);
@@ -92,7 +92,7 @@ async fn test_estimate_transaction_fee_invalid_transaction() {
         message: VersionedMessage::Legacy(Message::default()),
     };
 
-    let result = estimate_transaction_fee(&rpc_client, &transaction).await;
+    let result = estimate_transaction_fee(&rpc_client, &transaction, None).await;
     assert!(result.is_ok()); // Fee estimation should still work for invalid transactions
 }
 
@@ -117,7 +117,7 @@ async fn test_estimate_transaction_fee_with_token_creation() {
         message: VersionedMessage::Legacy(message),
     };
 
-    let fee = estimate_transaction_fee(&rpc_client, &transaction).await.unwrap();
+    let fee = estimate_transaction_fee(&rpc_client, &transaction, None).await.unwrap();
 
     // Fee should include base fee + priority fee + rent for token account
     let min_expected_lamports = 2_039_280;

--- a/crates/lib/src/transaction/transaction.rs
+++ b/crates/lib/src/transaction/transaction.rs
@@ -136,7 +136,7 @@ pub async fn sign_transaction(
     resolved_transaction.resolve_addresses(rpc_client).await?;
 
     // Validate transaction and accounts with lookup table resolution for V0 transactions
-    validator.validate_transaction(&resolved_transaction).await?;
+    validator.validate_transaction(rpc_client, &resolved_transaction).await?;
 
     // Get latest blockhash and update transaction
     let mut transaction = resolved_transaction.get_transaction().clone();

--- a/crates/rpc/src/method/transfer_transaction.rs
+++ b/crates/rpc/src/method/transfer_transaction.rs
@@ -120,7 +120,7 @@ pub async fn transfer_transaction(
     let mut transaction = new_unsigned_versioned_transaction(message);
 
     // validate transaction before signing
-    validator.validate_transaction(&transaction).await?;
+    validator.validate_transaction(rpc_client, &transaction).await?;
 
     // Find the fee payer position in the account keys
     let fee_payer_position = find_signer_position(&transaction, &fee_payer)?;

--- a/tests/token_integration_tests.rs
+++ b/tests/token_integration_tests.rs
@@ -96,7 +96,7 @@ async fn test_pyusd_token_e2e_with_kora() {
         &validation_config,
     )
     .unwrap()
-    .validate_transaction(&transfer_tx)
+    .validate_transaction(&rpc_client, &transfer_tx)
     .await;
 
     // Assert the transaction is valid according to Kora rules


### PR DESCRIPTION
Why?

Give more accurate estimate

What?

- Updated `estimate_transaction_fee` to accept an optional fee payer parameter for more accurate fee estimations.
- Introduced `calculate_fee_payer_outflow` to account for potential outflows from the fee payer during transaction processing.
- Modified transaction validation and signing processes to utilize the new fee payer logic.
- Adjusted tests to ensure correct fee calculations and validate transaction scenarios involving fee payers.