### PR TITLE
feat: (PRO-82) add configuration validation enhancements and CLI options

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,10 +2,10 @@
 repos:
   - repo: local
     hooks:
-      - id: make-fmt
-        name: make fmt
-        description: Format Rust code automatically
-        entry: make fmt
+      - id: make-lint
+        name: make lint
+        description: Lint Rust code automatically
+        entry: make lint
         language: system
         types: [rust]
         pass_filenames: false

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: check fmt lint lint-fix test build run clean all regen-tk fix-all generate-ts-client setup-test-env test-integration test-integration-coverage coverage
+.PHONY: check lint test build run clean all install generate-key setup-test-env test-integration test-integration-coverage test-all test-ts coverage coverage-clean build-bin build-lib build-rpc build-tk run-presigned openapi gen-ts-client
 
 # Common configuration
 TEST_PORT := 8080
@@ -25,17 +25,11 @@ install:
 check:
 	cargo fmt --all -- --check
 
-# Format code
-fmt:
-	cargo fmt --all
-
-# Run clippy
+# Run all fixes and checks
 lint:
-	cargo clippy
-
-# Run clippy with auto-fix
-lint-fix:
-	cargo clippy --fix --allow-dirty
+	cargo clippy --fix --allow-dirty -- -D warnings
+	cargo fmt --all
+	cargo fmt --all -- --check
 	
 # Run tests
 test:
@@ -101,6 +95,15 @@ test-integration-coverage:
 	$(call run_integration_phase,2,auth tests,cargo llvm-cov run,--no-report,$(AUTH_CONFIG),$(call run_auth_tests,cargo llvm-cov test,--no-report))
 	@echo "✅ All integration tests completed"
 
+
+# Run TypeScript SDK tests
+test-ts:
+	@echo "🧪 Running TypeScript SDK tests..."
+	@cd sdks/ts && pnpm test
+	@cd sdks/net-ts && pnpm test
+
+test-all: test test-integration test-ts
+
 # Build all binaries
 build:
 	cargo build --workspace
@@ -136,12 +139,6 @@ clean:
 # Gen openapi docs
 openapi:
 	cargo run -p kora-rpc --bin kora-openapi --features docs
-
-# Run all fixes and checks
-lint-fix-all:
-	cargo clippy --fix --allow-dirty -- -D warnings
-	cargo fmt --all
-	cargo fmt --all -- --check
 
 # Generate TypeScript client
 gen-ts-client:

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -61,9 +61,14 @@ async fn main() -> Result<(), KoraError> {
 
     let rpc_client = get_rpc_client(&cli.args.common.rpc_url);
 
-    if let Err(e) = config.validate(rpc_client.as_ref()).await {
-        print_error(&format!("Config validation failed: {e}"));
-        std::process::exit(1);
+    if cli.args.common.validate_config {
+        let _ = config.validate_with_result(rpc_client.as_ref()).await;
+    } else {
+        // Normal validation for non-validate-config mode
+        if let Err(e) = config.validate(rpc_client.as_ref()).await {
+            print_error(&format!("Config validation failed: {e}"));
+            std::process::exit(1);
+        }
     }
 
     // Initialize the signer

--- a/crates/lib/src/args.rs
+++ b/crates/lib/src/args.rs
@@ -77,6 +77,10 @@ pub struct CommonArgs {
 
     #[arg(long, env = "VAULT_PUBKEY")]
     pub vault_pubkey: Option<String>,
+
+    /// Validate configuration file and show results
+    #[arg(long)]
+    pub validate_config: bool,
 }
 
 // RPC-specific arguments

--- a/crates/rpc/src/main.rs
+++ b/crates/rpc/src/main.rs
@@ -29,9 +29,14 @@ async fn main() {
 
     let rpc_client = get_rpc_client(&args.common.rpc_url);
 
-    if let Err(e) = config.validate(rpc_client.as_ref()).await {
-        log::error!("Config validation failed: {e}");
-        std::process::exit(1);
+    if args.common.validate_config {
+        let _ = config.validate_with_result(rpc_client.as_ref()).await;
+    } else {
+        // Normal validation for non-validate-config mode
+        if let Err(e) = config.validate(rpc_client.as_ref()).await {
+            log::error!("Config validation failed: {e}");
+            std::process::exit(1);
+        }
     }
 
     if config.validation.price_source == PriceSource::Jupiter {


### PR DESCRIPTION
- Introduced `validate_config` flag in CLI for optional configuration validation.
- Added `validate_with_result` method in `Config` for detailed validation results.
- Updated Makefile to streamline linting and formatting commands.
- Refactored validation logic to provide warnings and errors for configuration issues.
- Enhanced tests for validation scenarios, ensuring comprehensive coverage of edge cases.