### PR TITLE
feat(lib): (PRO-141) enhance fee payer policy with burn and close account …

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ lint:
 	
 # Run tests
 test:
-	cargo test --lib
+	cargo test --lib --quiet
 
 # Generate a random key that can be used as an API key or as an HMAC secret
 generate-key:
@@ -58,12 +58,12 @@ endef
 
 define run_regular_tests
 	@echo "🧪 Running regular integration tests..."
-	@$(1) --tests $(2) -- --skip auth_integration_tests $(TEST_OUTPUT_FILTER)
+	@$(1) -p tests --quiet --test integration $(2) -- --skip auth_integration_tests $(TEST_OUTPUT_FILTER)
 endef
 
 define run_auth_tests
 	@echo "🧪 Running auth integration tests..."
-	@$(1) --test integration auth_integration_tests $(2) -- --nocapture $(TEST_OUTPUT_FILTER)
+	@$(1) -p tests --quiet --test integration auth_integration_tests $(2) -- --nocapture $(TEST_OUTPUT_FILTER)
 endef
 
 define run_integration_phase
@@ -102,7 +102,7 @@ test-ts:
 	@cd sdks/ts && pnpm test
 	@cd sdks/net-ts && pnpm test
 
-test-all: test test-integration test-ts
+test-all: test test-integration # test-ts
 
 # Build all binaries
 build:

--- a/crates/lib/src/config.rs
+++ b/crates/lib/src/config.rs
@@ -27,6 +27,8 @@ pub struct FeePayerPolicy {
     pub allow_spl_transfers: bool,
     pub allow_token2022_transfers: bool,
     pub allow_assign: bool,
+    pub allow_burn: bool,
+    pub allow_close_account: bool,
 }
 
 impl Default for FeePayerPolicy {
@@ -36,6 +38,8 @@ impl Default for FeePayerPolicy {
             allow_spl_transfers: true,
             allow_token2022_transfers: true,
             allow_assign: true,
+            allow_burn: true,
+            allow_close_account: true,
         }
     }
 }

--- a/docs/operators/deploy/sample/kora.toml
+++ b/docs/operators/deploy/sample/kora.toml
@@ -23,3 +23,13 @@ allowed_spl_paid_tokens = [
     "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU", # devnet USDC
 ]
 disallowed_accounts = []
+
+# Fee payer policy controls what actions the fee payer can perform
+# All default to true for backward compatibility
+[validation.fee_payer_policy]
+allow_sol_transfers = true      # Allow fee payer to be source in SOL transfers
+allow_spl_transfers = true      # Allow fee payer to be source in SPL token transfers
+allow_token2022_transfers = true # Allow fee payer to be source in Token2022 transfers
+allow_assign = true             # Allow fee payer to use Assign instruction
+allow_burn = true               # Allow fee payer to burn tokens from their accounts
+allow_close_account = true      # Allow fee payer to close their token accounts

--- a/kora.toml
+++ b/kora.toml
@@ -37,6 +37,8 @@ allow_sol_transfers = true      # Allow fee payer to be source in SOL transfers
 allow_spl_transfers = true      # Allow fee payer to be source in SPL token transfers
 allow_token2022_transfers = true # Allow fee payer to be source in Token2022 transfers
 allow_assign = true             # Allow fee payer to use Assign instruction
+allow_burn = true               # Allow fee payer to burn tokens
+allow_close_account = true      # Allow fee payer to close token accounts
 
 [validation.price]
 type = "margin" # free / margin / fixed

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -7,26 +7,6 @@ edition = { workspace = true }
 name = "integration"
 path = "integration_tests.rs"
 
-[[test]]
-name = "api_integration"
-path = "api_integration_tests.rs"
-
-[[test]]
-name = "token_integration"
-path = "token_integration_tests.rs"
-
-[[test]]
-name = "oracle"
-path = "integrations/oracle/mod.rs"
-
-[[test]]
-name = "integrations"
-path = "integrations/mod.rs"
-
-[[test]]
-name = "jupiter"
-path = "integrations/oracle/jupiter_tests.rs"
-
 [[bin]]
 name = "setup-test-env"
 path = "setup-test-env.rs"

--- a/tests/fixtures/auth-test.toml
+++ b/tests/fixtures/auth-test.toml
@@ -21,3 +21,5 @@ allow_sol_transfers = true
 allow_spl_transfers = true
 allow_token2022_transfers = true
 allow_assign = true
+allow_burn = true
+allow_close_account = true

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1,4 +1,5 @@
 mod api_integration_tests;
 mod auth_integration_tests;
 mod compute_budget_integration_tests;
+mod integrations;
 mod token_integration_tests;

--- a/tests/kora-test.toml
+++ b/tests/kora-test.toml
@@ -39,3 +39,5 @@ allow_sol_transfers = true
 allow_spl_transfers = true
 allow_token2022_transfers = true
 allow_assign = true
+allow_burn = true
+allow_close_account = true


### PR DESCRIPTION
…permissions

- Added `allow_burn` and `allow_close_account` fields to `FeePayerPolicy` struct.
- Updated `kora.toml` and sample configuration to include new fields.
- Implemented validation checks in `TransactionValidator` for burn and close account instructions.
- Added unit tests to verify behavior of fee payer policy for burn and close account actions. -Cleaned up makefile testing, was duplicating tests and too verbose