### PR TITLE
chore(cli): and helper documentation for kora-rpc cli (PRO-137)

### DIFF
--- a/crates/lib/src/args.rs
+++ b/crates/lib/src/args.rs
@@ -5,80 +5,92 @@ use clap::{command, Parser};
 #[derive(Debug, Parser)]
 #[command(name = "kora")]
 pub struct CommonArgs {
-    /// RPC URL
+    /// Solana RPC endpoint URL
     #[arg(long, env = "RPC_URL", default_value = "http://127.0.0.1:8899")]
     pub rpc_url: String,
 
-    /// API key for the Kora API
+    /// API key for authenticating requests to the Kora server (optional) - can be set in `kora.toml`
     #[arg(long, env = "KORA_API_KEY")]
     pub api_key: Option<String>,
 
-    /// HMAC secret for the Kora API
+    /// HMAC secret for request signature authentication (optional, provides stronger security than API key) - can be set in `kora.toml`
     #[arg(long, env = "KORA_HMAC_SECRET")]
     pub hmac_secret: Option<String>,
 
-    /// Base58-encoded private key for signing
+    /// Private key for transaction signing (base58, u8 array, or path to JSON keypair file).
+    /// Required unless `skip_signer`, `turnkey_signer`, `vault_signer`, or `privy_signer` is set
     #[arg(long, env = "KORA_PRIVATE_KEY", required_unless_present_any = ["skip_signer", "turnkey_signer", "vault_signer", "privy_signer"])]
     pub private_key: Option<String>,
 
-    /// Path to kora.toml config file
+    /// Path to Kora configuration file (TOML format)
     #[arg(long, default_value = "kora.toml")]
     pub config: String,
 
-    /// Skip loading the signer
+    /// Skip signer initialization (useful for testing or operations that don't require signing)
     #[arg(long = "no-load-signer")]
     pub skip_signer: bool,
 
-    /// Turnkey signer
+    /// Use Turnkey remote signer for secure key management
     #[arg(long = "with-turnkey-signer")]
     pub turnkey_signer: bool,
 
-    /// Turnkey API credentials
+    /// Turnkey API public key for authentication
     #[arg(long, env = "TURNKEY_API_PUBLIC_KEY")]
     pub turnkey_api_public_key: Option<String>,
 
+    /// Turnkey API private key for authentication
     #[arg(long, env = "TURNKEY_API_PRIVATE_KEY")]
     pub turnkey_api_private_key: Option<String>,
 
+    /// Turnkey organization ID where keys are stored
     #[arg(long, env = "TURNKEY_ORGANIZATION_ID")]
     pub turnkey_organization_id: Option<String>,
 
+    /// Turnkey private key ID to use for signing
     #[arg(long, env = "TURNKEY_PRIVATE_KEY_ID")]
     pub turnkey_private_key_id: Option<String>,
 
+    /// Turnkey public key (base58 encoded) for verification
     #[arg(long, env = "TURNKEY_PUBLIC_KEY")]
     pub turnkey_public_key: Option<String>,
 
-    /// Privy API Credentials
+    /// Use Privy remote signer for secure wallet management
     #[arg(long = "with-privy-signer")]
     pub privy_signer: bool,
 
-    /// Privy API credentials
+    /// Privy application ID for authentication
     #[arg(long, env = "PRIVY_APP_ID")]
     pub privy_app_id: Option<String>,
 
+    /// Privy application secret for authentication
     #[arg(long, env = "PRIVY_APP_SECRET")]
     pub privy_app_secret: Option<String>,
 
+    /// Privy wallet ID to use for signing
     #[arg(long, env = "PRIVY_WALLET_ID")]
     pub privy_wallet_id: Option<String>,
 
+    /// Use HashiCorp Vault signer for enterprise key management
     #[arg(long)]
     pub vault_signer: bool,
 
+    /// HashiCorp Vault server address
     #[arg(long, env = "VAULT_ADDR")]
     pub vault_addr: Option<String>,
 
+    /// HashiCorp Vault authentication token
     #[arg(long, env = "VAULT_TOKEN")]
     pub vault_token: Option<String>,
 
+    /// Key name in Vault to use for signing
     #[arg(long, env = "VAULT_KEY_NAME")]
     pub vault_key_name: Option<String>,
 
+    /// Vault public key (base58 encoded) for verification
     #[arg(long, env = "VAULT_PUBKEY")]
     pub vault_pubkey: Option<String>,
 
-    /// Validate configuration file and show results
+    /// Validate configuration file and show results (exits after validation)
     #[arg(long)]
     pub validate_config: bool,
 }
@@ -90,15 +102,15 @@ pub struct RpcArgs {
     #[command(flatten)]
     pub common: CommonArgs,
 
-    /// Port
+    /// HTTP port to listen on for RPC requests
     #[arg(short = 'p', long, default_value = "8080")]
     pub port: Option<u16>,
 
-    /// Logging Format
+    /// Output format for logs (standard or json)
     #[arg(long, default_value = "standard")]
     pub logging_format: LoggingFormat,
 
-    /// Metrics
+    /// Prometheus metrics endpoint URL for monitoring
     #[arg(long, default_value = None)]
     pub metrics_endpoint: Option<String>,
 }

--- a/crates/lib/src/args.rs
+++ b/crates/lib/src/args.rs
@@ -10,16 +10,16 @@ pub struct CommonArgs {
     pub rpc_url: String,
 
     /// API key for authenticating requests to the Kora server (optional) - can be set in `kora.toml`
-    #[arg(long, env = "KORA_API_KEY")]
+    #[arg(long, env = "KORA_API_KEY", help_heading = "Authentication")]
     pub api_key: Option<String>,
 
     /// HMAC secret for request signature authentication (optional, provides stronger security than API key) - can be set in `kora.toml`
-    #[arg(long, env = "KORA_HMAC_SECRET")]
+    #[arg(long, env = "KORA_HMAC_SECRET", help_heading = "Authentication")]
     pub hmac_secret: Option<String>,
 
     /// Private key for transaction signing (base58, u8 array, or path to JSON keypair file).
     /// Required unless `skip_signer`, `turnkey_signer`, `vault_signer`, or `privy_signer` is set
-    #[arg(long, env = "KORA_PRIVATE_KEY", required_unless_present_any = ["skip_signer", "turnkey_signer", "vault_signer", "privy_signer"])]
+    #[arg(long, env = "KORA_PRIVATE_KEY", required_unless_present_any = ["skip_signer", "turnkey_signer", "vault_signer", "privy_signer"], help_heading = "Signing Options")]
     pub private_key: Option<String>,
 
     /// Path to Kora configuration file (TOML format)
@@ -27,67 +27,67 @@ pub struct CommonArgs {
     pub config: String,
 
     /// Skip signer initialization (useful for testing or operations that don't require signing)
-    #[arg(long = "no-load-signer")]
+    #[arg(long = "no-load-signer", help_heading = "Signing Options")]
     pub skip_signer: bool,
 
     /// Use Turnkey remote signer for secure key management
-    #[arg(long = "with-turnkey-signer")]
+    #[arg(long = "with-turnkey-signer", help_heading = "Turnkey Signer")]
     pub turnkey_signer: bool,
 
     /// Turnkey API public key for authentication
-    #[arg(long, env = "TURNKEY_API_PUBLIC_KEY")]
+    #[arg(long, env = "TURNKEY_API_PUBLIC_KEY", help_heading = "Turnkey Signer")]
     pub turnkey_api_public_key: Option<String>,
 
     /// Turnkey API private key for authentication
-    #[arg(long, env = "TURNKEY_API_PRIVATE_KEY")]
+    #[arg(long, env = "TURNKEY_API_PRIVATE_KEY", help_heading = "Turnkey Signer")]
     pub turnkey_api_private_key: Option<String>,
 
     /// Turnkey organization ID where keys are stored
-    #[arg(long, env = "TURNKEY_ORGANIZATION_ID")]
+    #[arg(long, env = "TURNKEY_ORGANIZATION_ID", help_heading = "Turnkey Signer")]
     pub turnkey_organization_id: Option<String>,
 
     /// Turnkey private key ID to use for signing
-    #[arg(long, env = "TURNKEY_PRIVATE_KEY_ID")]
+    #[arg(long, env = "TURNKEY_PRIVATE_KEY_ID", help_heading = "Turnkey Signer")]
     pub turnkey_private_key_id: Option<String>,
 
     /// Turnkey public key (base58 encoded) for verification
-    #[arg(long, env = "TURNKEY_PUBLIC_KEY")]
+    #[arg(long, env = "TURNKEY_PUBLIC_KEY", help_heading = "Turnkey Signer")]
     pub turnkey_public_key: Option<String>,
 
     /// Use Privy remote signer for secure wallet management
-    #[arg(long = "with-privy-signer")]
+    #[arg(long = "with-privy-signer", help_heading = "Privy Signer")]
     pub privy_signer: bool,
 
     /// Privy application ID for authentication
-    #[arg(long, env = "PRIVY_APP_ID")]
+    #[arg(long, env = "PRIVY_APP_ID", help_heading = "Privy Signer")]
     pub privy_app_id: Option<String>,
 
     /// Privy application secret for authentication
-    #[arg(long, env = "PRIVY_APP_SECRET")]
+    #[arg(long, env = "PRIVY_APP_SECRET", help_heading = "Privy Signer")]
     pub privy_app_secret: Option<String>,
 
     /// Privy wallet ID to use for signing
-    #[arg(long, env = "PRIVY_WALLET_ID")]
+    #[arg(long, env = "PRIVY_WALLET_ID", help_heading = "Privy Signer")]
     pub privy_wallet_id: Option<String>,
 
     /// Use HashiCorp Vault signer for enterprise key management
-    #[arg(long)]
+    #[arg(long, help_heading = "Vault Signer")]
     pub vault_signer: bool,
 
     /// HashiCorp Vault server address
-    #[arg(long, env = "VAULT_ADDR")]
+    #[arg(long, env = "VAULT_ADDR", help_heading = "Vault Signer")]
     pub vault_addr: Option<String>,
 
     /// HashiCorp Vault authentication token
-    #[arg(long, env = "VAULT_TOKEN")]
+    #[arg(long, env = "VAULT_TOKEN", help_heading = "Vault Signer")]
     pub vault_token: Option<String>,
 
     /// Key name in Vault to use for signing
-    #[arg(long, env = "VAULT_KEY_NAME")]
+    #[arg(long, env = "VAULT_KEY_NAME", help_heading = "Vault Signer")]
     pub vault_key_name: Option<String>,
 
     /// Vault public key (base58 encoded) for verification
-    #[arg(long, env = "VAULT_PUBKEY")]
+    #[arg(long, env = "VAULT_PUBKEY", help_heading = "Vault Signer")]
     pub vault_pubkey: Option<String>,
 
     /// Validate configuration file and show results (exits after validation)
@@ -97,7 +97,7 @@ pub struct CommonArgs {
 
 // RPC-specific arguments
 #[derive(Debug, Parser)]
-#[command(name = "kora-rpc", version)]
+#[command(name = "kora-rpc", author, version, about = "RPC server for Kora gasless relayer", long_about = None)]
 pub struct RpcArgs {
     #[command(flatten)]
     pub common: CommonArgs,


### PR DESCRIPTION
Improved and expanded documentation comments for command-line arguments in CommonArgs and RpcArgs structs. The changes provide clearer descriptions, usage notes, and context when using `kora-rpc -h`. 

Changes: 
- Added `validate_config`
- Updated comments/descriptions
- Added categorization for cleaner response

New `kora-rpc -h`:  

```bash
RPC server for Kora gasless relayer

Usage: kora-rpc [OPTIONS]

Options:
      --rpc-url <RPC_URL>
          Solana RPC endpoint URL [env: RPC_URL=] [default: http://127.0.0.1:8899]
      --config <CONFIG>
          Path to Kora configuration file (TOML format) [default: kora.toml]
      --validate-config
          Validate configuration file and show results (exits after validation)
  -p, --port <PORT>
          HTTP port to listen on for RPC requests [default: 8080]
      --logging-format <LOGGING_FORMAT>
          Output format for logs (standard or json) [default: standard] [possible values: standard, json]
      --metrics-endpoint <METRICS_ENDPOINT>
          Prometheus metrics endpoint URL for monitoring
  -h, --help
          Print help
  -V, --version
          Print version

Authentication:
      --api-key <API_KEY>          API key for authenticating requests to the Kora server (optional) - can be set in `kora.toml` [env: KORA_API_KEY=]
      --hmac-secret <HMAC_SECRET>  HMAC secret for request signature authentication (optional, provides stronger security than API key) - can be set in `kora.toml` [env: KORA_HMAC_SECRET=]

Signing Options:
      --private-key <PRIVATE_KEY>  Private key for transaction signing (base58, u8 array, or path to JSON keypair file). Required unless `skip_signer`, `turnkey_signer`, `vault_signer`, or `privy_signer` is set [env: KORA_PRIVATE_KEY=]
      --no-load-signer             Skip signer initialization (useful for testing or operations that don't require signing)

Turnkey Signer:
      --with-turnkey-signer
          Use Turnkey remote signer for secure key management
      --turnkey-api-public-key <TURNKEY_API_PUBLIC_KEY>
          Turnkey API public key for authentication [env: TURNKEY_API_PUBLIC_KEY=]
      --turnkey-api-private-key <TURNKEY_API_PRIVATE_KEY>
          Turnkey API private key for authentication [env: TURNKEY_API_PRIVATE_KEY=]
      --turnkey-organization-id <TURNKEY_ORGANIZATION_ID>
          Turnkey organization ID where keys are stored [env: TURNKEY_ORGANIZATION_ID=]
      --turnkey-private-key-id <TURNKEY_PRIVATE_KEY_ID>
          Turnkey private key ID to use for signing [env: TURNKEY_PRIVATE_KEY_ID=]
      --turnkey-public-key <TURNKEY_PUBLIC_KEY>
          Turnkey public key (base58 encoded) for verification [env: TURNKEY_PUBLIC_KEY=]

Privy Signer:
      --with-privy-signer
          Use Privy remote signer for secure wallet management
      --privy-app-id <PRIVY_APP_ID>
          Privy application ID for authentication [env: PRIVY_APP_ID=]
      --privy-app-secret <PRIVY_APP_SECRET>
          Privy application secret for authentication [env: PRIVY_APP_SECRET=]
      --privy-wallet-id <PRIVY_WALLET_ID>
          Privy wallet ID to use for signing [env: PRIVY_WALLET_ID=]

Vault Signer:
      --vault-signer
          Use HashiCorp Vault signer for enterprise key management
      --vault-addr <VAULT_ADDR>
          HashiCorp Vault server address [env: VAULT_ADDR=]
      --vault-token <VAULT_TOKEN>
          HashiCorp Vault authentication token [env: VAULT_TOKEN=]
      --vault-key-name <VAULT_KEY_NAME>
          Key name in Vault to use for signing [env: VAULT_KEY_NAME=]
      --vault-pubkey <VAULT_PUBKEY>
          Vault public key (base58 encoded) for verification [env: VAULT_PUBKEY=]
```