### PR TITLE
fix(tests): fix `make test-all` (PRO-143)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,10 +12,13 @@ node_modules/
 dist/
 .env*
 
-test-ledger/
-
 # Coverage reports
 coverage/
 *.profraw
 
 .DS_Store
+
+# Make test files
+.validator.pid
+.kora.pid
+test-ledger/

--- a/README.md
+++ b/README.md
@@ -105,16 +105,10 @@ make run
 
 ### Local Testing
 
-To run the tests locally, you need to set up a local validator and test environment.
+And run all tests:
 
 ```bash
-solana-test-validator -r
-```
-
-And run integration tests:
-
-```bash
-make test-integration
+make test-all
 ```
 
 ## Repository Structure

--- a/sdks/ts/test/setup.ts
+++ b/sdks/ts/test/setup.ts
@@ -169,6 +169,15 @@ const signAndSendTransaction = async (
   return signature;
 };
 
+function safeStringify(obj: any) {
+  return JSON.stringify(obj, (key, value) => {
+    if (typeof value === 'bigint') {
+      return value.toString();
+    }
+    return value;
+  }, 2);
+}
+
 async function sendAndConfirmInstructions(
   client: Client,
   payer: TransactionSigner,
@@ -191,6 +200,7 @@ async function sendAndConfirmInstructions(
     );
     return signature;
   } catch (error) {
+    console.error(safeStringify(error));
     throw new Error(
       `Failed to ${description.toLowerCase()}: ${error instanceof Error ? error.message : "Unknown error"}`,
     );


### PR DESCRIPTION
issue: `make test-all` was failing on TS tests. This was b/c:
1. state was carrying over between tests (so TS setup functions were failing) and
2. `setup-test-env` also conflicted with TS test setup

Fix: 

- Added solana test validator  to Makefile: Introduces start and stop functions for a local Solana test validator, integrates validator lifecycle into TypeScript SDK tests, and adds a clean-validator target for cleanup. This streamlines local testing workflows involving Solana -- **applied also to exiting integration tests (no local validator running anymore)**
- Modified kora node start/stop functionality to handle edge cases to ensure node is always terminated