### PR TITLE
feat(lib): add allow_approve to FeePayerPolicy and validation (PRO-141)

### DIFF
--- a/crates/lib/src/config.rs
+++ b/crates/lib/src/config.rs
@@ -29,6 +29,7 @@ pub struct FeePayerPolicy {
     pub allow_assign: bool,
     pub allow_burn: bool,
     pub allow_close_account: bool,
+    pub allow_approve: bool,
 }
 
 impl Default for FeePayerPolicy {
@@ -40,6 +41,7 @@ impl Default for FeePayerPolicy {
             allow_assign: true,
             allow_burn: true,
             allow_close_account: true,
+            allow_approve: true,
         }
     }
 }

--- a/docs/operators/deploy/sample/kora.toml
+++ b/docs/operators/deploy/sample/kora.toml
@@ -33,3 +33,4 @@ allow_token2022_transfers = true # Allow fee payer to be source in Token2022 tra
 allow_assign = true             # Allow fee payer to use Assign instruction
 allow_burn = true               # Allow fee payer to burn tokens from their accounts
 allow_close_account = true      # Allow fee payer to close their token accounts
+allow_approve = true            # Allow fee payer to approve tokens from their accounts

--- a/kora.toml
+++ b/kora.toml
@@ -39,6 +39,7 @@ allow_token2022_transfers = true # Allow fee payer to be source in Token2022 tra
 allow_assign = true             # Allow fee payer to use Assign instruction
 allow_burn = true               # Allow fee payer to burn tokens
 allow_close_account = true      # Allow fee payer to close token accounts
+allow_approve = true            # Allow fee payer to approve tokens
 
 [validation.price]
 type = "margin" # free / margin / fixed

--- a/tests/fixtures/auth-test.toml
+++ b/tests/fixtures/auth-test.toml
@@ -23,3 +23,4 @@ allow_token2022_transfers = true
 allow_assign = true
 allow_burn = true
 allow_close_account = true
+allow_approve = true

--- a/tests/kora-test.toml
+++ b/tests/kora-test.toml
@@ -41,3 +41,4 @@ allow_token2022_transfers = true
 allow_assign = true
 allow_burn = true
 allow_close_account = true
+allow_approve = true


### PR DESCRIPTION
Added `allow_approve` for:
- TokenInstruction::Approve
- TokenInstruction::ApproveChecked
- TokenInstruction::Approve (Token 2022)
- TokenInstruction::ApproveChecked (Token 2022)

PR into #140 