### PR TITLE
fix: (PRO-155) resolve mint account index for TransferChecked instructions

### DIFF
--- a/crates/lib/src/token/token.rs
+++ b/crates/lib/src/token/token.rs
@@ -152,7 +152,10 @@ impl TokenUtil {
             // token program will fail. Same with the balance of the source account, if too low the instruction will fail.
             // This might be useful if the token account is being created within the same transaction, since the source account is not yet created.
             let (mint_address, actual_amount) = if let Some(mint_index) = mint_index {
-                let mint_key = account_keys[mint_index];
+                if mint_index >= ix.accounts.len() {
+                    return Ok(false);
+                }
+                let mint_key = account_keys[ix.accounts[mint_index] as usize];
                 let mint_account = rpc_client.get_account(&mint_key).await?;
                 let mint_state = token_program.unpack_mint(&mint_key, &mint_account.data)?;
 


### PR DESCRIPTION
 Fixed incorrect mint account resolution in token payment validation that was causing "An account's data contents was invalid" error when running TypeScript integration test. Issue was not present on Rust integration test. This was happening b/c Rust test uses `transfer` and TS test uses `transfer_checked` (different account indices).

The issue occurred when processing TransferChecked instructions in transactions with multiple instructions (e.g., ATA creation + transfer). The mint index returned by decode_transfer_instruction is relative to the instruction's accounts, but was being used directly as an index  into the transaction's global account list.

This caused the system to attempt unpacking the wrong account (e.g. the destination ATA) as mint data, resulting in validation failures.

Changes:
- Use ix.accounts[mint_index] to properly resolve mint account index
- Add bounds checking for instruction account access

Resolves the TS integration test error that was preventing proper was was using TransferChecked for token payments.