### PR TITLE
chore: (PRO-166) Switch OpenAPI validation to Redocly CLI

### DIFF
--- a/crates/lib/src/rpc_server/openapi/docs.rs
+++ b/crates/lib/src/rpc_server/openapi/docs.rs
@@ -116,8 +116,10 @@ pub fn update_docs() {
 
     std::fs::write(&path, json).unwrap();
 
-    let validate_result = std::process::Command::new("swagger-cli")
-        .arg("validate")
+    let validate_result = std::process::Command::new("npx")
+        .arg("@redocly/cli@latest")
+        .arg("lint")
+        .arg("--extends=minimal")
         .arg(path.to_str().unwrap())
         .output()
         .unwrap();


### PR DESCRIPTION
Replaces the use of 'swagger-cli validate' (deprecated) with 'npx @redocly/cli@latest lint --extends=minimal' for OpenAPI document validation in update_docs().