### PR TITLE
tests(signers):(PRO-49) add privy/turnkey integration tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -159,8 +159,39 @@ test-ts-integration-auth:
 	@$(call stop_kora_server)
 	@$(call stop_solana_validator)
 
-# Run all TypeScript SDK tests
-test-ts: test-ts-unit test-ts-integration-basic test-ts-integration-auth
+# Run TypeScript tests with Turnkey signer
+test-ts-integration-turnkey:
+	@$(call start_solana_validator)
+	@echo "🚀 Starting Kora node with Turnkey signer..."
+	@$(call stop_kora_server)
+	@cargo run -p kora-cli --bin kora -- --config $(REGULAR_CONFIG) --rpc-url $(TEST_RPC_URL) rpc --with-turnkey-signer --port $(TEST_PORT) $(QUIET_OUTPUT) &
+	@echo $$! > .kora.pid
+	@echo "⏳ Waiting for server to start..."
+	@sleep 5
+	@printf "Running TypeScript SDK tests with Turnkey signer...\n"
+	-@cd sdks/ts && pnpm test:integration:turnkey
+	@$(call stop_kora_server)
+	@$(call stop_solana_validator)
+
+# Run TypeScript tests with Privy signer  
+test-ts-integration-privy:
+	@$(call start_solana_validator)
+	@echo "🚀 Starting Kora node with Privy signer..."
+	@$(call stop_kora_server)
+	@cargo run -p kora-cli --bin kora -- --config $(REGULAR_CONFIG) --rpc-url $(TEST_RPC_URL) rpc --with-privy-signer --port $(TEST_PORT) $(QUIET_OUTPUT) &
+	@echo $$! > .kora.pid
+	@echo "⏳ Waiting for server to start..."
+	@sleep 5
+	@printf "Running TypeScript SDK tests with Privy signer...\n"
+	-@cd sdks/ts && pnpm test:integration:privy
+	@$(call stop_kora_server)
+	@$(call stop_solana_validator)
+
+# Run all signer tests
+test-ts-signers: test-ts-integration-turnkey test-ts-integration-privy
+
+# Run all TypeScript SDK tests (no signers b/c api rate limits)
+test-ts: test-ts-unit test-ts-integration-basic test-ts-integration-auth # test-ts-signers
 
 test-all: test test-integration test-ts
 

--- a/sdks/ts/package.json
+++ b/sdks/ts/package.json
@@ -13,6 +13,8 @@
     "test:coverage": "jest --coverage",
     "test:integration": "pnpm test integration.test.ts",
     "test:integration:auth": "ENABLE_AUTH=true pnpm test integration.test.ts",
+    "test:integration:privy": "KORA_SIGNER_TYPE=privy pnpm test integration.test.ts",
+    "test:integration:turnkey": "KORA_SIGNER_TYPE=turnkey pnpm test integration.test.ts",
     "test:unit": "pnpm test unit.test.ts",
     "test:ci:integration": "node scripts/test-with-validator.js",
     "test:ci:integration:auth": "ENABLE_AUTH=true node scripts/test-with-validator.js",

--- a/sdks/ts/test/integration.test.ts
+++ b/sdks/ts/test/integration.test.ts
@@ -7,6 +7,7 @@ import {
     getBase64EncodedWireTransaction,
     getBase64Encoder,
     getTransactionDecoder,
+    partiallySignTransaction,
     signTransaction,
     type KeyPairSigner,
     type Transaction,
@@ -20,8 +21,8 @@ function transactionFromBase64(base64: string): Transaction {
 }
 
 const AUTH_ENABLED = process.env.ENABLE_AUTH === 'true';
-
-describe(`KoraClient Integration Tests (${AUTH_ENABLED ? 'with auth' : 'without auth'})`, () => {
+const KORA_SIGNER_TYPE = process.env.KORA_SIGNER_TYPE || 'memory';
+describe(`KoraClient Integration Tests (${AUTH_ENABLED ? 'with auth' : 'without auth'} | signer type: ${KORA_SIGNER_TYPE})`, () => {
     let client: KoraClient;
     let testWallet: KeyPairSigner;
     let testWalletAddress: Address;
@@ -152,7 +153,6 @@ describe(`KoraClient Integration Tests (${AUTH_ENABLED ? 'with auth' : 'without 
 
             const { transaction: transactionString } = await client.transferTransaction(transferRequest);
             const transaction = transactionFromBase64(transactionString);
-
             // Sign transaction with test wallet before sending
             const signedTransaction = await signTransaction([testWallet.keyPair], transaction);
             const base64SignedTransaction = getBase64EncodedWireTransaction(signedTransaction);


### PR DESCRIPTION
  Add comprehensive integration testing for Privy and Turnkey signers to prevent regressions.

  Changes

  TypeScript Test Infrastructure:
  - Add `KORA_SIGNER_TYPE` environment variable support in test setup
  - Auto-detect signer addresses based on type (Turnkey uses TURNKEY_PUBLIC_KEY, Privy uses PRIVY_PUBLIC_KEY)
  - Update test descriptions to show signer type being tested

  Makefile Targets:
  - `test-ts-integration-turnkey` - Run integration tests with Turnkey signer
  - `test-ts-integration-privy` - Run integration tests with Privy signer
  - `test-ts-signers` - Run all signer integration tests
  - *Excluded* from `test-all` and CI workflows due to env requirements/rate limits  

  TS SDK Package.json Scripts:
  - `test:integration:turnkey` - Direct pnpm script for Turnkey tests
  - `test:integration:privy` - Direct pnpm script for Privy tests

  Requires appropriate signer environment variables to be set--and be conscious of rate limits.
  
  Test flagged a bug. Fix in #168 
