### PR TITLE
fix(signers):(PRO-204) Privy Signer Initialization and Fee Payer Position

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -96,7 +96,7 @@ async fn main() -> Result<(), KoraError> {
 
             // Initialize the signer
             if !rpc_args.skip_signer {
-                let signer = init_signer_type(&rpc_args).unwrap();
+                let signer = init_signer_type(&rpc_args).await.unwrap();
                 init_signer(signer).unwrap_or_else(|e| {
                     print_error(&format!("Failed to initialize signer: {e}"));
                     std::process::exit(1);

--- a/crates/lib/src/signer/init.rs
+++ b/crates/lib/src/signer/init.rs
@@ -108,7 +108,6 @@ async fn init_privy_signer(config: &PrivyArgs) -> Result<KoraSigner, KoraError> 
     let mut privy_signer = PrivySigner::new(app_id, app_secret, wallet_id);
 
     // Initialize the signer to fetch the public key from Privy
-    // This is a blocking call in an async context, but init_signer_type is sync
     privy_signer
         .init()
         .await

--- a/crates/lib/src/signer/init.rs
+++ b/crates/lib/src/signer/init.rs
@@ -10,13 +10,13 @@ use crate::{
     },
 };
 
-pub fn init_signer_type(args: &RpcArgs) -> Result<KoraSigner, KoraError> {
+pub async fn init_signer_type(args: &RpcArgs) -> Result<KoraSigner, KoraError> {
     if args.turnkey_args.turnkey_signer {
         init_turnkey_signer(&args.turnkey_args)
     } else if args.vault_args.vault_signer {
         init_vault_signer(&args.vault_args)
     } else if args.privy_args.privy_signer {
-        init_privy_signer(&args.privy_args)
+        init_privy_signer(&args.privy_args).await
     } else {
         init_memory_signer(args.private_key.as_ref())
     }
@@ -86,7 +86,7 @@ fn init_turnkey_signer(config: &TurnkeyArgs) -> Result<KoraSigner, KoraError> {
     Ok(KoraSigner::Turnkey(signer))
 }
 
-fn init_privy_signer(config: &PrivyArgs) -> Result<KoraSigner, KoraError> {
+async fn init_privy_signer(config: &PrivyArgs) -> Result<KoraSigner, KoraError> {
     let app_id = config
         .privy_app_id
         .clone()
@@ -109,10 +109,10 @@ fn init_privy_signer(config: &PrivyArgs) -> Result<KoraSigner, KoraError> {
 
     // Initialize the signer to fetch the public key from Privy
     // This is a blocking call in an async context, but init_signer_type is sync
-    tokio::task::block_in_place(|| {
-        tokio::runtime::Handle::current().block_on(async { privy_signer.init().await })
-    })
-    .map_err(|e| KoraError::SigningError(format!("Failed to initialize Privy signer: {e}")))?;
+    privy_signer
+        .init()
+        .await
+        .map_err(|e| KoraError::SigningError(format!("Failed to initialize Privy signer: {e}")))?;
 
     Ok(KoraSigner::Privy(privy_signer))
 }

--- a/crates/lib/src/transaction/versioned_transaction.rs
+++ b/crates/lib/src/transaction/versioned_transaction.rs
@@ -185,7 +185,10 @@ impl VersionedTransactionUtilExt for VersionedTransaction {
 
         // Sign transaction
         let signature = signer.sign_solana(&transaction).await?;
-        transaction.signatures[0] = signature;
+
+        // Find the fee payer position - don't assume it's at position 0
+        let fee_payer_position = transaction.find_signer_position(&signer.solana_pubkey())?;
+        transaction.signatures[fee_payer_position] = signature;
 
         // Serialize signed transaction
         let serialized = bincode::serialize(&transaction)?;


### PR DESCRIPTION
  Fixes bug where Privy signer was not properly initialized, causing transaction signature failures.

  ### Root Cause

  Privy signer was created but never initialized, leaving public_key as `Pubkey::default()` instead of the actual wallet address.

  ### Changes

  **Privy Signer Initialization:**
  - Add async initialization call in `init_privy_signer()` to fetch public key from Privy API
  - Use `tokio::task::block_in_place` to handle async call in sync context

  **Transaction Signing Improvement:**
  - Replace hardcoded `transaction.signatures[0]` with dynamic fee payer position lookup
  - Prevents signature position mismatches when fee payer is not at index 0 (this was not the issue, but seems worth keeping in since it was a potential source of error when debugging)
  
  Supporting tests in #167 