### PR TITLE
feat(cli): add initialize-atas command for payment token ATAs & custo…

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -3,6 +3,7 @@ mod args;
 use args::GlobalArgs;
 use clap::{Parser, Subcommand};
 use kora_lib::{
+    admin::token_util::initialize_paymaster_atas,
     error::KoraError,
     log::LoggingFormat,
     rpc::get_rpc_client,
@@ -25,10 +26,10 @@ enum Commands {
         #[command(subcommand)]
         config_command: ConfigCommands,
     },
-    /// Start the RPC server
+    /// RPC server operations
     Rpc {
-        #[command(flatten)]
-        rpc_args: Box<RpcArgs>,
+        #[command(subcommand)]
+        rpc_command: RpcCommands,
     },
     /// Generate OpenAPI documentation
     #[cfg(feature = "docs")]
@@ -45,6 +46,20 @@ enum ConfigCommands {
     Validate,
     /// Validate configuration file with RPC validation (slower but more thorough)
     ValidateWithRpc,
+}
+
+#[derive(Subcommand)]
+enum RpcCommands {
+    /// Start the RPC server
+    Start {
+        #[command(flatten)]
+        rpc_args: Box<RpcArgs>,
+    },
+    /// Initialize ATAs for all allowed payment tokens
+    InitializeAtas {
+        #[command(flatten)]
+        rpc_args: Box<RpcArgs>,
+    },
 }
 
 #[derive(Parser)]
@@ -85,42 +100,62 @@ async fn main() -> Result<(), KoraError> {
             }
             std::process::exit(0);
         }
-        Some(Commands::Rpc { rpc_args }) => {
-            // Validate config before starting server
-            if let Err(e) = ConfigValidator::validate(&config, rpc_client.as_ref()).await {
-                print_error(&format!("Config validation failed: {e}"));
-                std::process::exit(1);
-            }
-
-            setup_logging(&rpc_args.logging_format);
-
-            // Initialize the signer
-            if !rpc_args.skip_signer {
-                let signer = init_signer_type(&rpc_args).await.unwrap();
-                init_signer(signer).unwrap_or_else(|e| {
-                    print_error(&format!("Failed to initialize signer: {e}"));
-                    std::process::exit(1);
-                });
-            }
-
-            let rpc_client = get_rpc_client(&cli.global_args.rpc_url);
-
-            let rpc_server =
-                KoraRpc::new(rpc_client, config.validation.clone(), config.kora.clone());
-            let ServerHandles { rpc_handle, metrics_handle } =
-                run_rpc_server(rpc_server, rpc_args.port, &config.metrics).await.unwrap_or_else(
-                    |e| {
-                        log::error!("Server start failed: {e}");
+        Some(Commands::Rpc { rpc_command }) => {
+            match rpc_command {
+                RpcCommands::Start { rpc_args } => {
+                    // Validate config before starting server
+                    if let Err(e) = ConfigValidator::validate(&config, rpc_client.as_ref()).await {
+                        print_error(&format!("Config validation failed: {e}"));
                         std::process::exit(1);
-                    },
-                );
+                    }
 
-            tokio::signal::ctrl_c().await.unwrap();
-            rpc_handle.stop().unwrap();
-            if let Some(handle) = metrics_handle {
-                handle.stop().unwrap();
+                    setup_logging(&rpc_args.logging_format);
+
+                    // Initialize the signer
+                    if !rpc_args.skip_signer {
+                        let signer = init_signer_type(&rpc_args).await.unwrap();
+                        init_signer(signer).unwrap_or_else(|e| {
+                            print_error(&format!("Failed to initialize signer: {e}"));
+                            std::process::exit(1);
+                        });
+                    }
+
+                    let rpc_client = get_rpc_client(&cli.global_args.rpc_url);
+
+                    let kora_rpc = KoraRpc::new(rpc_client, config.validation, config.kora);
+
+                    let ServerHandles { rpc_handle, metrics_handle } =
+                        run_rpc_server(kora_rpc, rpc_args.port, &config.metrics).await?;
+
+                    tokio::signal::ctrl_c().await.unwrap();
+                    println!("Shutting down server...");
+                    rpc_handle.stop().unwrap();
+                    if let Some(handle) = metrics_handle {
+                        handle.stop().unwrap();
+                    }
+                }
+                RpcCommands::InitializeAtas { rpc_args } => {
+                    if !rpc_args.skip_signer {
+                        let signer = init_signer_type(&rpc_args).await.unwrap();
+                        init_signer(signer).unwrap_or_else(|e| {
+                            print_error(&format!("Failed to initialize signer: {e}"));
+                            std::process::exit(1);
+                        });
+                    } else {
+                        print_error("Cannot initialize ATAs without a signer.");
+                        std::process::exit(1);
+                    }
+
+                    // Initialize ATAs
+                    if let Err(e) = initialize_paymaster_atas(&rpc_client, &config).await {
+                        print_error(&format!("Failed to initialize ATAs: {e}"));
+                        std::process::exit(1);
+                    }
+                    println!("Successfully initialized all payment ATAs");
+                }
             }
         }
+
         #[cfg(feature = "docs")]
         Some(Commands::Openapi { output }) => {
             docs::update_docs();
@@ -141,11 +176,12 @@ async fn main() -> Result<(), KoraError> {
         None => {
             println!("No command specified. Use --help for usage information.");
             println!("Available commands:");
-            println!("  config validate         - Validate configuration");
+            println!("  config validate          - Validate configuration");
             println!("  config validate-with-rpc - Validate configuration with RPC calls");
-            println!("  rpc                     - Start RPC server");
+            println!("  rpc start                - Start RPC server");
+            println!("  rpc initialize-atas      - Initialize ATAs for payment tokens");
             #[cfg(feature = "docs")]
-            println!("  openapi                 - Generate OpenAPI documentation");
+            println!("  openapi                  - Generate OpenAPI documentation");
         }
     }
 

--- a/crates/lib/src/admin/mod.rs
+++ b/crates/lib/src/admin/mod.rs
@@ -1,0 +1,1 @@
+pub mod token_util;

--- a/crates/lib/src/admin/token_util.rs
+++ b/crates/lib/src/admin/token_util.rs
@@ -1,0 +1,123 @@
+use crate::{
+    config::Config, error::KoraError, signer::Signer, state::get_signer, token::token::TokenType,
+    transaction::TransactionUtil,
+};
+use solana_client::nonblocking::rpc_client::RpcClient;
+use solana_message::{Message, VersionedMessage};
+use solana_sdk::{pubkey::Pubkey, signature::Signature};
+
+use spl_associated_token_account::{
+    get_associated_token_address, instruction::create_associated_token_account,
+};
+use std::{str::FromStr, sync::Arc};
+
+/// Initialize ATAs for all allowed payment tokens for the paymaster
+/// This function does not use cache and directly checks on-chain
+pub async fn initialize_paymaster_atas(
+    rpc_client: &Arc<RpcClient>,
+    config: &Config,
+) -> Result<(), KoraError> {
+    let signer = get_signer()?;
+
+    // Determine the payment address
+    let payment_address = config.kora.get_payment_address()?;
+
+    println!("Initializing ATAs for payment address: {payment_address}");
+
+    // Parse all allowed SPL paid token mints
+    let mut token_mints = Vec::new();
+    for token_str in &config.validation.allowed_spl_paid_tokens {
+        match Pubkey::from_str(token_str) {
+            Ok(mint) => token_mints.push(mint),
+            Err(_) => {
+                println!("⚠️  Skipping invalid token mint: {token_str}");
+                continue;
+            }
+        }
+    }
+
+    if token_mints.is_empty() {
+        println!("✓ No SPL payment tokens configured");
+        return Ok(());
+    }
+
+    let mut atas_to_create = Vec::new();
+    let mut instructions = Vec::new();
+
+    // Check each token mint for existing ATA
+    for mint in &token_mints {
+        let ata = get_associated_token_address(&payment_address, mint);
+
+        match rpc_client.get_account(&ata).await {
+            Ok(_) => {
+                println!("✓ ATA already exists for token {mint}: {ata}");
+            }
+            Err(_) => {
+                // Fetch mint account to determine if it's SPL or Token2022
+                let mint_account = rpc_client.get_account(mint).await.map_err(|e| {
+                    KoraError::RpcError(format!("Failed to fetch mint account for {mint}: {e}"))
+                })?;
+
+                let token_program = TokenType::get_token_program_from_owner(&mint_account.owner)?;
+
+                println!("Creating ATA for token {mint}: {ata}");
+
+                atas_to_create.push((mint, ata));
+
+                let create_ata_ix = create_associated_token_account(
+                    &signer.solana_pubkey(),
+                    &payment_address,
+                    mint,
+                    &token_program.program_id(),
+                );
+                instructions.push(create_ata_ix);
+            }
+        }
+    }
+
+    if instructions.is_empty() {
+        println!("✓ All required ATAs already exist");
+        return Ok(());
+    }
+
+    println!("Creating {} ATAs in a single transaction...", instructions.len());
+
+    let blockhash = rpc_client
+        .get_latest_blockhash()
+        .await
+        .map_err(|e| KoraError::RpcError(format!("Failed to get blockhash: {e}")))?;
+
+    let message = VersionedMessage::Legacy(Message::new_with_blockhash(
+        &instructions,
+        Some(&signer.solana_pubkey()),
+        &blockhash,
+    ));
+
+    let mut tx = TransactionUtil::new_unsigned_versioned_transaction(message);
+    let signature = signer.sign(&tx).await?;
+
+    let sig_bytes: [u8; 64] = signature
+        .bytes
+        .try_into()
+        .map_err(|_| KoraError::SigningError("Invalid signature length".to_string()))?;
+
+    let sig = Signature::from(sig_bytes);
+    tx.signatures = vec![sig];
+
+    match rpc_client.send_and_confirm_transaction(&tx).await {
+        Ok(signature) => {
+            println!("✓ Successfully created ATAs. Transaction signature: {signature}");
+
+            for (mint, ata) in atas_to_create {
+                println!("  - Token {mint}: ATA {ata}");
+            }
+        }
+        Err(e) => {
+            return Err(KoraError::RpcError(format!(
+                "Failed to send ATA creation transaction: {e}"
+            )));
+        }
+    }
+
+    Ok(())
+}

--- a/crates/lib/src/mod.rs
+++ b/crates/lib/src/mod.rs
@@ -1,3 +1,4 @@
+pub mod admin;
 pub mod config;
 pub mod constant;
 pub mod error;

--- a/crates/lib/src/rpc_server/method/sign_transaction_if_paid.rs
+++ b/crates/lib/src/rpc_server/method/sign_transaction_if_paid.rs
@@ -1,5 +1,5 @@
 use crate::{
-    config::ValidationConfig,
+    config::{KoraConfig, ValidationConfig},
     transaction::{
         TransactionUtil, VersionedTransactionExt, VersionedTransactionResolved,
         VersionedTransactionUtilExt,
@@ -25,6 +25,7 @@ pub struct SignTransactionIfPaidResponse {
 pub async fn sign_transaction_if_paid(
     rpc_client: &Arc<RpcClient>,
     validation: &ValidationConfig,
+    kora_config: &KoraConfig,
     request: SignTransactionIfPaidRequest,
 ) -> Result<SignTransactionIfPaidResponse, KoraError> {
     let transaction_requested = TransactionUtil::decode_b64_transaction(&request.transaction)?;
@@ -33,7 +34,7 @@ pub async fn sign_transaction_if_paid(
     resolved_transaction.resolve_addresses(rpc_client).await?;
 
     let (transaction, signed_transaction) = resolved_transaction
-        .sign_transaction_if_paid(rpc_client, validation)
+        .sign_transaction_if_paid(rpc_client, validation, kora_config)
         .await
         .map_err(|e| KoraError::TokenOperationError(e.to_string()))?;
 

--- a/crates/lib/src/token/interface.rs
+++ b/crates/lib/src/token/interface.rs
@@ -9,6 +9,12 @@ use std::any::Any;
 
 use crate::validator::transaction_validator::TransactionValidator;
 
+pub struct DecodedTransfer {
+    pub amount: u64,
+    pub mint_index: Option<usize>,
+    pub destination_index: usize,
+}
+
 pub trait TokenState: Any + Send + Sync {
     fn mint(&self) -> Pubkey;
     fn owner(&self) -> Pubkey;
@@ -86,7 +92,7 @@ pub trait TokenInterface: Send + Sync {
     fn decode_transfer_instruction(
         &self,
         data: &[u8],
-    ) -> Result<(u64, Option<usize>), Box<dyn std::error::Error + Send + Sync>>;
+    ) -> Result<DecodedTransfer, Box<dyn std::error::Error + Send + Sync>>;
 
     fn process_spl_instruction(
         &self,

--- a/crates/lib/src/token/spl_token.rs
+++ b/crates/lib/src/token/spl_token.rs
@@ -1,4 +1,4 @@
-use crate::token::interface::TokenMint;
+use crate::token::interface::{DecodedTransfer, TokenMint};
 
 use super::interface::{
     ParsedSplInstruction, SplInstructionCommand, SplInstructionType, TokenInterface, TokenState,
@@ -211,12 +211,14 @@ impl TokenInterface for TokenProgram {
     fn decode_transfer_instruction(
         &self,
         data: &[u8],
-    ) -> Result<(u64, Option<usize>), Box<dyn std::error::Error + Send + Sync>> {
+    ) -> Result<DecodedTransfer, Box<dyn std::error::Error + Send + Sync>> {
         let instruction = spl_token::instruction::TokenInstruction::unpack(data)?;
         match instruction {
-            spl_token::instruction::TokenInstruction::Transfer { amount } => Ok((amount, None)),
+            spl_token::instruction::TokenInstruction::Transfer { amount } => {
+                Ok(DecodedTransfer { amount, mint_index: None, destination_index: 1 })
+            }
             spl_token::instruction::TokenInstruction::TransferChecked { amount, .. } => {
-                Ok((amount, Some(1)))
+                Ok(DecodedTransfer { amount, mint_index: Some(1), destination_index: 2 })
             }
             _ => Err("Not a transfer instruction".into()),
         }

--- a/crates/lib/src/token/spl_token_2022.rs
+++ b/crates/lib/src/token/spl_token_2022.rs
@@ -1,4 +1,4 @@
-use crate::token::interface::TokenMint;
+use crate::token::interface::{DecodedTransfer, TokenMint};
 
 use super::interface::{TokenInterface, TokenState};
 use async_trait::async_trait;
@@ -534,12 +534,16 @@ impl TokenInterface for Token2022Program {
     fn decode_transfer_instruction(
         &self,
         data: &[u8],
-    ) -> Result<(u64, Option<usize>), Box<dyn std::error::Error + Send + Sync>> {
+    ) -> Result<DecodedTransfer, Box<dyn std::error::Error + Send + Sync>> {
         let instruction = instruction::TokenInstruction::unpack(data)?;
         match instruction {
             #[allow(deprecated)]
-            instruction::TokenInstruction::Transfer { amount } => Ok((amount, None)),
-            instruction::TokenInstruction::TransferChecked { amount, .. } => Ok((amount, Some(1))),
+            instruction::TokenInstruction::Transfer { amount } => {
+                Ok(DecodedTransfer { amount, mint_index: None, destination_index: 1 })
+            }
+            instruction::TokenInstruction::TransferChecked { amount, .. } => {
+                Ok(DecodedTransfer { amount, mint_index: Some(1), destination_index: 2 })
+            }
             _ => Err("Not a transfer instruction".into()),
         }
     }

--- a/crates/lib/src/token/token.rs
+++ b/crates/lib/src/token/token.rs
@@ -2,7 +2,10 @@ use crate::{
     config::ValidationConfig,
     error::KoraError,
     oracle::{get_price_oracle, PriceSource, RetryingPriceOracle, TokenPrice},
-    token::{interface::TokenMint, Token2022Program, TokenInterface, TokenProgram},
+    token::{
+        interface::{DecodedTransfer, TokenMint},
+        Token2022Program, TokenInterface, TokenProgram,
+    },
 };
 use solana_client::nonblocking::rpc_client::RpcClient;
 use solana_sdk::{
@@ -127,6 +130,7 @@ impl TokenUtil {
         Ok(fee_in_token)
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub async fn process_token_transfer(
         ix: &CompiledInstruction,
         token_program: &dyn TokenInterface,
@@ -135,17 +139,43 @@ impl TokenUtil {
         validation: &ValidationConfig,
         total_lamport_value: &mut u64,
         required_lamports: u64,
+        expected_destination: &Pubkey,
     ) -> Result<bool, KoraError> {
-        if let Ok((amount, mint_index)) = token_program.decode_transfer_instruction(&ix.data) {
+        if let Ok(DecodedTransfer { amount, destination_index, mint_index }) =
+            token_program.decode_transfer_instruction(&ix.data)
+        {
             if ix.accounts.is_empty() {
                 return Ok(false);
             }
 
-            let source_idx = ix.accounts[0] as usize;
-            if source_idx >= account_keys.len() {
+            if destination_index >= ix.accounts.len() {
                 return Ok(false);
             }
+
+            let source_idx = ix.accounts[0] as usize;
+            let dest_idx = ix.accounts[destination_index] as usize;
+
+            if source_idx >= account_keys.len() || dest_idx >= account_keys.len() {
+                return Ok(false);
+            }
+
             let source_key = account_keys[source_idx];
+            let dest_key = account_keys[dest_idx];
+
+            // Validate the destination account is that of the payment address (or signer if none provided)
+            let destination_account = rpc_client
+                .get_account(&dest_key)
+                .await
+                .map_err(|e| KoraError::RpcError(e.to_string()))?;
+
+            let token_state =
+                token_program.unpack_token_account(&destination_account.data).map_err(|e| {
+                    KoraError::InvalidTransaction(format!("Invalid token account: {e}"))
+                })?;
+
+            if token_state.owner() != *expected_destination {
+                return Ok(false);
+            }
 
             // If we have a transfer checked and therefore the mint account, we don't need to check the source's account owner as TokenProgram,
             // since we already know the instruction is with the system program,so if the source account is invalid, the instruction with the

--- a/crates/lib/src/validator/config_validator.rs
+++ b/crates/lib/src/validator/config_validator.rs
@@ -26,6 +26,15 @@ impl ConfigValidator {
         }
 
         TokenUtil::check_valid_tokens(&config.validation.allowed_tokens)?;
+
+        if let Some(payment_address) = &config.kora.payment_address {
+            if let Err(e) = Pubkey::from_str(payment_address) {
+                return Err(KoraError::InternalServerError(format!(
+                    "Invalid payment address: {e}"
+                )));
+            }
+        }
+
         Ok(())
     }
 
@@ -40,6 +49,13 @@ impl ConfigValidator {
         // Validate rate limit (warn if 0)
         if config.kora.rate_limit == 0 {
             warnings.push("Rate limit is set to 0 - this will block all requests".to_string());
+        }
+
+        // Validate payment address
+        if let Some(payment_address) = &config.kora.payment_address {
+            if let Err(e) = Pubkey::from_str(payment_address) {
+                errors.push(format!("Invalid payment address: {e}"));
+            }
         }
 
         // Validate enabled methods (warn if all false)
@@ -309,11 +325,7 @@ mod tests {
                 fee_payer_policy: FeePayerPolicy::default(),
                 price: PriceConfig::default(),
             },
-            kora: KoraConfig {
-                rate_limit: 100,
-                enabled_methods: EnabledMethods::default(),
-                auth: AuthConfig::default(),
-            },
+            kora: KoraConfig::default(),
             metrics: MetricsConfig::default(),
         };
 
@@ -344,11 +356,7 @@ mod tests {
                 fee_payer_policy: FeePayerPolicy::default(),
                 price: PriceConfig::default(),
             },
-            kora: KoraConfig {
-                rate_limit: 100,
-                enabled_methods: EnabledMethods::default(),
-                auth: AuthConfig::default(),
-            },
+            kora: KoraConfig::default(),
             metrics: MetricsConfig::default(),
         };
 
@@ -387,6 +395,7 @@ mod tests {
                     sign_transaction_if_paid: false, // All false - should warn
                 },
                 auth: AuthConfig::default(),
+                payment_address: None,
             },
             metrics: MetricsConfig::default(),
         };
@@ -419,11 +428,7 @@ mod tests {
                 fee_payer_policy: FeePayerPolicy::default(),
                 price: PriceConfig { model: PriceModel::Free },
             },
-            kora: KoraConfig {
-                rate_limit: 100,
-                enabled_methods: EnabledMethods::default(),
-                auth: AuthConfig::default(),
-            },
+            kora: KoraConfig::default(),
             metrics: MetricsConfig::default(),
         };
 
@@ -452,12 +457,8 @@ mod tests {
                     model: PriceModel::Margin { margin: -0.1 }, // Error - negative margin
                 },
             },
-            kora: KoraConfig {
-                rate_limit: 100,
-                enabled_methods: EnabledMethods::default(),
-                auth: AuthConfig::default(),
-            },
             metrics: MetricsConfig::default(),
+            kora: KoraConfig::default(),
         };
 
         let rpc_client = RpcClient::new("http://localhost:8899".to_string());
@@ -492,12 +493,8 @@ mod tests {
                     },
                 },
             },
-            kora: KoraConfig {
-                rate_limit: 100,
-                enabled_methods: EnabledMethods::default(),
-                auth: AuthConfig::default(),
-            },
             metrics: MetricsConfig::default(),
+            kora: KoraConfig::default(),
         };
 
         let rpc_client = RpcClient::new("http://localhost:8899".to_string());
@@ -529,12 +526,8 @@ mod tests {
                     },
                 },
             },
-            kora: KoraConfig {
-                rate_limit: 100,
-                enabled_methods: EnabledMethods::default(),
-                auth: AuthConfig::default(),
-            },
             metrics: MetricsConfig::default(),
+            kora: KoraConfig::default(),
         };
 
         let rpc_client = RpcClient::new("http://localhost:8899".to_string());
@@ -574,12 +567,8 @@ mod tests {
                     },
                 },
             },
-            kora: KoraConfig {
-                rate_limit: 100,
-                enabled_methods: EnabledMethods::default(),
-                auth: AuthConfig::default(),
-            },
             metrics: MetricsConfig::default(),
+            kora: KoraConfig::default(),
         };
 
         let rpc_client = RpcClient::new("http://localhost:8899".to_string());
@@ -606,12 +595,8 @@ mod tests {
                 fee_payer_policy: FeePayerPolicy::default(),
                 price: PriceConfig { model: PriceModel::Margin { margin: 0.1 } },
             },
-            kora: KoraConfig {
-                rate_limit: 100,
-                enabled_methods: EnabledMethods::default(),
-                auth: AuthConfig::default(),
-            },
             metrics: MetricsConfig::default(),
+            kora: KoraConfig::default(),
         };
 
         let rpc_client = RpcClient::new("http://localhost:8899".to_string());
@@ -644,12 +629,8 @@ mod tests {
                 fee_payer_policy: FeePayerPolicy::default(),
                 price: PriceConfig { model: PriceModel::Free },
             },
-            kora: KoraConfig {
-                rate_limit: 100,
-                enabled_methods: EnabledMethods::default(),
-                auth: AuthConfig::default(),
-            },
             metrics: MetricsConfig::default(),
+            kora: KoraConfig::default(),
         };
 
         let rpc_client = RpcClient::new("http://localhost:8899".to_string());
@@ -676,12 +657,8 @@ mod tests {
                 fee_payer_policy: FeePayerPolicy::default(),
                 price: PriceConfig { model: PriceModel::Free },
             },
-            kora: KoraConfig {
-                rate_limit: 100,
-                enabled_methods: EnabledMethods::default(),
-                auth: AuthConfig::default(),
-            },
             metrics: MetricsConfig::default(),
+            kora: KoraConfig::default(),
         }
     }
 
@@ -699,12 +676,8 @@ mod tests {
                 fee_payer_policy: FeePayerPolicy::default(),
                 price: PriceConfig { model: PriceModel::Free },
             },
-            kora: KoraConfig {
-                rate_limit: 100,
-                enabled_methods: EnabledMethods::default(),
-                auth: AuthConfig::default(),
-            },
             metrics: MetricsConfig::default(),
+            kora: KoraConfig::default(),
         }
     }
 
@@ -757,12 +730,8 @@ mod tests {
                 fee_payer_policy: FeePayerPolicy::default(),
                 price: PriceConfig { model: PriceModel::Free },
             },
-            kora: KoraConfig {
-                rate_limit: 100,
-                enabled_methods: EnabledMethods::default(),
-                auth: AuthConfig::default(),
-            },
             metrics: MetricsConfig::default(),
+            kora: KoraConfig::default(),
         };
 
         let mock_account = create_mock_non_executable_account(); // Non-executable
@@ -789,12 +758,8 @@ mod tests {
                 fee_payer_policy: FeePayerPolicy::default(),
                 price: PriceConfig { model: PriceModel::Free },
             },
-            kora: KoraConfig {
-                rate_limit: 100,
-                enabled_methods: EnabledMethods::default(),
-                auth: AuthConfig::default(),
-            },
             metrics: MetricsConfig::default(),
+            kora: KoraConfig::default(),
         };
 
         let rpc_client = create_mock_rpc_client_account_not_found();
@@ -820,12 +785,8 @@ mod tests {
                 fee_payer_policy: FeePayerPolicy::default(),
                 price: PriceConfig { model: PriceModel::Free },
             },
-            kora: KoraConfig {
-                rate_limit: 100,
-                enabled_methods: EnabledMethods::default(),
-                auth: AuthConfig::default(),
-            },
             metrics: MetricsConfig::default(),
+            kora: KoraConfig::default(),
         };
 
         // Use account not found RPC client - should not matter when skipping RPC validation

--- a/crates/lib/src/validator/transaction_validator.rs
+++ b/crates/lib/src/validator/transaction_validator.rs
@@ -357,7 +357,7 @@ impl TransactionValidator {
         required_lamports: u64,
         validation: &ValidationConfig,
         rpc_client: &RpcClient,
-        _signer_pubkey: Pubkey,
+        expected_payment_destination: &Pubkey,
     ) -> Result<(), KoraError> {
         let mut total_lamport_value = 0;
 
@@ -381,6 +381,7 @@ impl TransactionValidator {
                     validation,
                     &mut total_lamport_value,
                     required_lamports,
+                    expected_payment_destination,
                 )
                 .await?
                 {

--- a/tests/payment-address/initialize_atas_tests.rs
+++ b/tests/payment-address/initialize_atas_tests.rs
@@ -1,0 +1,54 @@
+use crate::common::*;
+use solana_sdk::pubkey::Pubkey;
+use spl_associated_token_account::get_associated_token_address;
+use std::{process::Command, str::FromStr};
+
+/// Test the new CLI structure and initialize-atas command
+#[tokio::test]
+async fn test_cli_initialize_atas_command() {
+    let rpc_client = RPCTestHelper::get_rpc_client().await;
+    let paymaster_pubkey = Pubkey::from_str(TEST_PAYMENT_ADDRESS).unwrap();
+    let test_usdc_mint = USDCMintTestHelper::get_test_usdc_mint_pubkey();
+
+    let expected_ata = get_associated_token_address(&paymaster_pubkey, &test_usdc_mint);
+
+    let sender_key_path = FEE_PAYER_DEFAULT;
+
+    let output = Command::new("cargo")
+        .current_dir("../..") // Set working directory to kora root
+        .args([
+            "run",
+            "-p",
+            "kora-cli",
+            "--bin",
+            "kora",
+            "--",
+            "--config",
+            "tests/common/fixtures/paymaster-address-test.toml",
+            "--rpc-url",
+            rpc_client.url().as_str(),
+            "rpc",
+            "initialize-atas",
+            "--private-key",
+            sender_key_path,
+        ])
+        .output()
+        .expect("Failed to execute command");
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        panic!(
+            "initialize-atas command failed with exit code: {}\nSTDOUT: {}\nSTDERR: {}",
+            output.status.code().unwrap_or(-1),
+            stdout,
+            stderr
+        );
+    }
+
+    // Verify the ATA was created successfully
+    assert!(
+        rpc_client.get_account(&expected_ata).await.is_ok(),
+        "ATA should exist after successful initialization"
+    );
+}


### PR DESCRIPTION
…m payment address for Paymaster

- Introduced a new subcommand `initialize-atas` under the RPC command to initialize associated token accounts (ATAs) for allowed payment tokens.
- Updated CLI structure to support the new command.
- Enhanced KoraConfig to include an optional payment address.
- Implemented logic to validate and create ATAs directly from the command line.
- Added tests to verify the functionality of the new command.