### PR TITLE
feat: allow any spl paid token flag

### DIFF
--- a/crates/lib/src/admin/token_util.rs
+++ b/crates/lib/src/admin/token_util.rs
@@ -399,4 +399,17 @@ mod tests {
             }
         }
     }
+
+    #[tokio::test]
+    async fn test_initialize_atas_when_all_tokens_are_allowed() {
+        let _m = ConfigMockBuilder::new()
+            .with_allowed_spl_paid_tokens(SplTokenPaymentConfig::All)
+            .build_and_setup();
+
+        let rpc_client = RpcMockBuilder::new().build();
+
+        let result = initialize_atas(&rpc_client, None, None, None, None).await;
+
+        assert!(result.is_ok(), "Expected atas init to succeed");
+    }
 }

--- a/crates/lib/src/admin/token_util.rs
+++ b/crates/lib/src/admin/token_util.rs
@@ -22,7 +22,7 @@ use {crate::cache::CacheUtil, crate::state::get_config};
 
 #[cfg(test)]
 use {
-    crate::config::SplTokenPaymentConfig, crate::tests::config_mock::mock_state::get_config,
+    crate::config::SplTokenConfig, crate::tests::config_mock::mock_state::get_config,
     crate::tests::redis_cache_mock::MockCacheUtil as CacheUtil,
 };
 
@@ -290,7 +290,7 @@ mod tests {
         let _m = ConfigMockBuilder::new()
             .with_validation(
                 ValidationConfigBuilder::new()
-                    .with_allowed_spl_paid_tokens(SplTokenPaymentConfig::Allowlist(vec![]))
+                    .with_allowed_spl_paid_tokens(SplTokenConfig::Allowlist(vec![]))
                     .build(),
             )
             .build_and_setup();
@@ -310,7 +310,7 @@ mod tests {
         let _m = ConfigMockBuilder::new()
             .with_validation(
                 ValidationConfigBuilder::new()
-                    .with_allowed_spl_paid_tokens(SplTokenPaymentConfig::Allowlist(
+                    .with_allowed_spl_paid_tokens(SplTokenConfig::Allowlist(
                         allowed_spl_tokens.iter().map(|p| p.to_string()).collect(),
                     ))
                     .build(),
@@ -403,7 +403,7 @@ mod tests {
     #[tokio::test]
     async fn test_initialize_atas_when_all_tokens_are_allowed() {
         let _m = ConfigMockBuilder::new()
-            .with_allowed_spl_paid_tokens(SplTokenPaymentConfig::All)
+            .with_allowed_spl_paid_tokens(SplTokenConfig::All)
             .build_and_setup();
 
         let _ = setup_or_get_test_signer();

--- a/crates/lib/src/admin/token_util.rs
+++ b/crates/lib/src/admin/token_util.rs
@@ -22,7 +22,7 @@ use {crate::cache::CacheUtil, crate::state::get_config};
 
 #[cfg(test)]
 use {
-    crate::tests::config_mock::mock_state::get_config,
+    crate::config::SplTokenPaymentConfig, crate::tests::config_mock::mock_state::get_config,
     crate::tests::redis_cache_mock::MockCacheUtil as CacheUtil,
 };
 
@@ -289,7 +289,9 @@ mod tests {
     async fn test_find_missing_atas_no_spl_tokens() {
         let _m = ConfigMockBuilder::new()
             .with_validation(
-                ValidationConfigBuilder::new().with_allowed_spl_paid_tokens(vec![]).build(),
+                ValidationConfigBuilder::new()
+                    .with_allowed_spl_paid_tokens(SplTokenPaymentConfig::Allowlist(vec![]))
+                    .build(),
             )
             .build_and_setup();
 
@@ -308,9 +310,9 @@ mod tests {
         let _m = ConfigMockBuilder::new()
             .with_validation(
                 ValidationConfigBuilder::new()
-                    .with_allowed_spl_paid_tokens(
+                    .with_allowed_spl_paid_tokens(SplTokenPaymentConfig::Allowlist(
                         allowed_spl_tokens.iter().map(|p| p.to_string()).collect(),
-                    )
+                    ))
                     .build(),
             )
             .build_and_setup();

--- a/crates/lib/src/admin/token_util.rs
+++ b/crates/lib/src/admin/token_util.rs
@@ -406,6 +406,8 @@ mod tests {
             .with_allowed_spl_paid_tokens(SplTokenPaymentConfig::All)
             .build_and_setup();
 
+        let _ = setup_or_get_test_signer();
+
         let rpc_client = RpcMockBuilder::new().build();
 
         let result = initialize_atas(&rpc_client, None, None, None, None).await;

--- a/crates/lib/src/config.rs
+++ b/crates/lib/src/config.rs
@@ -84,10 +84,10 @@ impl<'a> IntoIterator for &'a SplTokenPaymentConfig {
 }
 
 impl SplTokenPaymentConfig {
-    pub fn has_token(&self, token: &String) -> bool {
+    pub fn has_token(&self, token: &str) -> bool {
         match self {
             SplTokenPaymentConfig::All => true,
-            SplTokenPaymentConfig::Allowlist(tokens) => tokens.contains(token),
+            SplTokenPaymentConfig::Allowlist(tokens) => tokens.iter().any(|s| s == token),
         }
     }
 

--- a/crates/lib/src/config.rs
+++ b/crates/lib/src/config.rs
@@ -426,7 +426,7 @@ mod tests {
         let config = ConfigBuilder::new()
             .with_programs(vec!["program1", "program2"])
             .with_tokens(vec!["token1", "token2"])
-            .with_spl_paid_tokens(vec!["token3"])
+            .with_spl_paid_tokens(SplTokenPaymentConfig::Allowlist(vec!["token3".to_string()]))
             .with_disallowed_accounts(vec!["account1"])
             .build_config()
             .unwrap();
@@ -451,7 +451,7 @@ mod tests {
         let config = ConfigBuilder::new()
             .with_programs(vec!["program1", "program2"])
             .with_tokens(vec!["token1", "token2"])
-            .with_spl_paid_tokens(vec!["token3"])
+            .with_spl_paid_tokens(SplTokenPaymentConfig::Allowlist(vec!["token3".to_string()]))
             .with_disallowed_accounts(vec!["account1"])
             .with_enabled_methods(&[
                 ("liveness", true),
@@ -494,23 +494,10 @@ mod tests {
 
     #[test]
     fn test_parse_spl_payment_config() {
-        let config_content = r#"
-            [validation]
-            max_allowed_lamports = 1000000000
-            max_signatures = 10
-            allowed_programs = ["program1", "program2"]
-            allowed_tokens = ["token1", "token2"]
-            allowed_spl_paid_tokens = "All"
-            disallowed_accounts = ["account1"]
-            price_source = "Jupiter"
-            [kora]
-            rate_limit = 100
-        "#;
-
-        let temp_file = NamedTempFile::new().unwrap();
-        fs::write(&temp_file, config_content).unwrap();
-
-        let config = Config::load_config(temp_file.path()).unwrap();
+        let config = ConfigBuilder::new()
+            .with_spl_paid_tokens(SplTokenPaymentConfig::All)
+            .build_config()
+            .unwrap();
 
         assert_eq!(config.validation.allowed_spl_paid_tokens, SplTokenPaymentConfig::All);
     }

--- a/crates/lib/src/config.rs
+++ b/crates/lib/src/config.rs
@@ -59,49 +59,49 @@ impl Default for FeePayerBalanceMetricsConfig {
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub enum SplTokenPaymentConfig {
+pub enum SplTokenConfig {
     All,
     #[serde(untagged)]
     Allowlist(Vec<String>),
 }
 
-impl Default for SplTokenPaymentConfig {
+impl Default for SplTokenConfig {
     fn default() -> Self {
-        SplTokenPaymentConfig::Allowlist(vec![])
+        SplTokenConfig::Allowlist(vec![])
     }
 }
 
-impl<'a> IntoIterator for &'a SplTokenPaymentConfig {
+impl<'a> IntoIterator for &'a SplTokenConfig {
     type Item = &'a String;
     type IntoIter = std::slice::Iter<'a, String>;
 
     fn into_iter(self) -> Self::IntoIter {
         match self {
-            SplTokenPaymentConfig::All => [].iter(),
-            SplTokenPaymentConfig::Allowlist(tokens) => tokens.iter(),
+            SplTokenConfig::All => [].iter(),
+            SplTokenConfig::Allowlist(tokens) => tokens.iter(),
         }
     }
 }
 
-impl SplTokenPaymentConfig {
+impl SplTokenConfig {
     pub fn has_token(&self, token: &str) -> bool {
         match self {
-            SplTokenPaymentConfig::All => true,
-            SplTokenPaymentConfig::Allowlist(tokens) => tokens.iter().any(|s| s == token),
+            SplTokenConfig::All => true,
+            SplTokenConfig::Allowlist(tokens) => tokens.iter().any(|s| s == token),
         }
     }
 
     pub fn has_tokens(&self) -> bool {
         match self {
-            SplTokenPaymentConfig::All => true,
-            SplTokenPaymentConfig::Allowlist(tokens) => !tokens.is_empty(),
+            SplTokenConfig::All => true,
+            SplTokenConfig::Allowlist(tokens) => !tokens.is_empty(),
         }
     }
 
     pub fn as_slice(&self) -> &[String] {
         match self {
-            SplTokenPaymentConfig::All => &[],
-            SplTokenPaymentConfig::Allowlist(v) => v.as_slice(),
+            SplTokenConfig::All => &[],
+            SplTokenConfig::Allowlist(v) => v.as_slice(),
         }
     }
 }
@@ -112,7 +112,7 @@ pub struct ValidationConfig {
     pub max_signatures: u64,
     pub allowed_programs: Vec<String>,
     pub allowed_tokens: Vec<String>,
-    pub allowed_spl_paid_tokens: SplTokenPaymentConfig,
+    pub allowed_spl_paid_tokens: SplTokenConfig,
     pub disallowed_accounts: Vec<String>,
     pub price_source: PriceSource,
     #[serde(default)] // Default for backward compatibility
@@ -426,7 +426,7 @@ mod tests {
         let config = ConfigBuilder::new()
             .with_programs(vec!["program1", "program2"])
             .with_tokens(vec!["token1", "token2"])
-            .with_spl_paid_tokens(SplTokenPaymentConfig::Allowlist(vec!["token3".to_string()]))
+            .with_spl_paid_tokens(SplTokenConfig::Allowlist(vec!["token3".to_string()]))
             .with_disallowed_accounts(vec!["account1"])
             .build_config()
             .unwrap();
@@ -437,7 +437,7 @@ mod tests {
         assert_eq!(config.validation.allowed_tokens, vec!["token1", "token2"]);
         assert_eq!(
             config.validation.allowed_spl_paid_tokens,
-            SplTokenPaymentConfig::Allowlist(vec!["token3".to_string()])
+            SplTokenConfig::Allowlist(vec!["token3".to_string()])
         );
         assert_eq!(config.validation.disallowed_accounts, vec!["account1"]);
         assert_eq!(config.validation.price_source, PriceSource::Jupiter);
@@ -451,7 +451,7 @@ mod tests {
         let config = ConfigBuilder::new()
             .with_programs(vec!["program1", "program2"])
             .with_tokens(vec!["token1", "token2"])
-            .with_spl_paid_tokens(SplTokenPaymentConfig::Allowlist(vec!["token3".to_string()]))
+            .with_spl_paid_tokens(SplTokenConfig::Allowlist(vec!["token3".to_string()]))
             .with_disallowed_accounts(vec!["account1"])
             .with_enabled_methods(&[
                 ("liveness", true),
@@ -494,12 +494,10 @@ mod tests {
 
     #[test]
     fn test_parse_spl_payment_config() {
-        let config = ConfigBuilder::new()
-            .with_spl_paid_tokens(SplTokenPaymentConfig::All)
-            .build_config()
-            .unwrap();
+        let config =
+            ConfigBuilder::new().with_spl_paid_tokens(SplTokenConfig::All).build_config().unwrap();
 
-        assert_eq!(config.validation.allowed_spl_paid_tokens, SplTokenPaymentConfig::All);
+        assert_eq!(config.validation.allowed_spl_paid_tokens, SplTokenConfig::All);
     }
 
     #[test]

--- a/crates/lib/src/rpc_server/method/get_config.rs
+++ b/crates/lib/src/rpc_server/method/get_config.rs
@@ -80,9 +80,9 @@ mod tests {
             response.validation_config.allowed_tokens[0],
             "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU"
         ); // USDC devnet
-        assert_eq!(response.validation_config.allowed_spl_paid_tokens.len(), 1);
+        assert_eq!(response.validation_config.allowed_spl_paid_tokens.as_slice().len(), 1);
         assert_eq!(
-            response.validation_config.allowed_spl_paid_tokens[0],
+            response.validation_config.allowed_spl_paid_tokens.as_slice()[0],
             "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU"
         ); // USDC devnet
         assert_eq!(response.validation_config.disallowed_accounts.len(), 0);

--- a/crates/lib/src/tests/config_mock.rs
+++ b/crates/lib/src/tests/config_mock.rs
@@ -1,7 +1,7 @@
 use crate::{
     config::{
         AuthConfig, CacheConfig, Config, EnabledMethods, FeePayerBalanceMetricsConfig,
-        FeePayerPolicy, KoraConfig, MetricsConfig, SplTokenPaymentConfig, Token2022Config,
+        FeePayerPolicy, KoraConfig, MetricsConfig, SplTokenConfig, Token2022Config,
         ValidationConfig,
     },
     fee::price::PriceConfig,
@@ -86,7 +86,7 @@ impl ConfigMockBuilder {
                     allowed_tokens: vec![
                         "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU".parse().unwrap(), // USDC devnet
                     ],
-                    allowed_spl_paid_tokens: SplTokenPaymentConfig::Allowlist(vec![
+                    allowed_spl_paid_tokens: SplTokenConfig::Allowlist(vec![
                         "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU".parse().unwrap(), // USDC devnet
                     ]),
                     disallowed_accounts: vec![],
@@ -161,10 +161,7 @@ impl ConfigMockBuilder {
         self
     }
 
-    pub fn with_allowed_spl_paid_tokens(
-        mut self,
-        spl_payment_config: SplTokenPaymentConfig,
-    ) -> Self {
+    pub fn with_allowed_spl_paid_tokens(mut self, spl_payment_config: SplTokenConfig) -> Self {
         self.config.validation.allowed_spl_paid_tokens = spl_payment_config;
         self
     }
@@ -241,7 +238,7 @@ impl ValidationConfigBuilder {
                 max_signatures: 10,
                 allowed_programs: vec![],
                 allowed_tokens: vec![],
-                allowed_spl_paid_tokens: SplTokenPaymentConfig::Allowlist(vec![]),
+                allowed_spl_paid_tokens: SplTokenConfig::Allowlist(vec![]),
                 disallowed_accounts: vec![],
                 price_source: PriceSource::Mock,
                 fee_payer_policy: FeePayerPolicy::default(),
@@ -270,10 +267,7 @@ impl ValidationConfigBuilder {
         self
     }
 
-    pub fn with_allowed_spl_paid_tokens(
-        mut self,
-        spl_payment_config: SplTokenPaymentConfig,
-    ) -> Self {
+    pub fn with_allowed_spl_paid_tokens(mut self, spl_payment_config: SplTokenConfig) -> Self {
         self.config.allowed_spl_paid_tokens = spl_payment_config;
         self
     }

--- a/crates/lib/src/tests/config_mock.rs
+++ b/crates/lib/src/tests/config_mock.rs
@@ -161,6 +161,14 @@ impl ConfigMockBuilder {
         self
     }
 
+    pub fn with_allowed_spl_paid_tokens(
+        mut self,
+        spl_payment_config: SplTokenPaymentConfig,
+    ) -> Self {
+        self.config.validation.allowed_spl_paid_tokens = spl_payment_config;
+        self
+    }
+
     pub fn with_payment_address(mut self, payment_address: Option<String>) -> Self {
         self.config.kora.payment_address = payment_address;
         self
@@ -262,8 +270,11 @@ impl ValidationConfigBuilder {
         self
     }
 
-    pub fn with_allowed_spl_paid_tokens(mut self, config: SplTokenPaymentConfig) -> Self {
-        self.config.allowed_spl_paid_tokens = config;
+    pub fn with_allowed_spl_paid_tokens(
+        mut self,
+        spl_payment_config: SplTokenPaymentConfig,
+    ) -> Self {
+        self.config.allowed_spl_paid_tokens = spl_payment_config;
         self
     }
 

--- a/crates/lib/src/tests/config_mock.rs
+++ b/crates/lib/src/tests/config_mock.rs
@@ -1,7 +1,8 @@
 use crate::{
     config::{
         AuthConfig, CacheConfig, Config, EnabledMethods, FeePayerBalanceMetricsConfig,
-        FeePayerPolicy, KoraConfig, MetricsConfig, Token2022Config, ValidationConfig,
+        FeePayerPolicy, KoraConfig, MetricsConfig, SplTokenPaymentConfig, Token2022Config,
+        ValidationConfig,
     },
     fee::price::PriceConfig,
     oracle::PriceSource,
@@ -85,9 +86,9 @@ impl ConfigMockBuilder {
                     allowed_tokens: vec![
                         "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU".parse().unwrap(), // USDC devnet
                     ],
-                    allowed_spl_paid_tokens: vec![
+                    allowed_spl_paid_tokens: SplTokenPaymentConfig::Allowlist(vec![
                         "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU".parse().unwrap(), // USDC devnet
-                    ],
+                    ]),
                     disallowed_accounts: vec![],
                     price_source: PriceSource::Mock,
                     fee_payer_policy: FeePayerPolicy::default(),
@@ -232,7 +233,7 @@ impl ValidationConfigBuilder {
                 max_signatures: 10,
                 allowed_programs: vec![],
                 allowed_tokens: vec![],
-                allowed_spl_paid_tokens: vec![],
+                allowed_spl_paid_tokens: SplTokenPaymentConfig::Allowlist(vec![]),
                 disallowed_accounts: vec![],
                 price_source: PriceSource::Mock,
                 fee_payer_policy: FeePayerPolicy::default(),
@@ -261,8 +262,8 @@ impl ValidationConfigBuilder {
         self
     }
 
-    pub fn with_allowed_spl_paid_tokens(mut self, tokens: Vec<String>) -> Self {
-        self.config.allowed_spl_paid_tokens = tokens;
+    pub fn with_allowed_spl_paid_tokens(mut self, config: SplTokenPaymentConfig) -> Self {
+        self.config.allowed_spl_paid_tokens = config;
         self
     }
 

--- a/crates/lib/src/tests/toml_mock.rs
+++ b/crates/lib/src/tests/toml_mock.rs
@@ -77,8 +77,8 @@ impl ConfigBuilder {
         self
     }
 
-    pub fn with_spl_paid_tokens(mut self, config: SplTokenPaymentConfig) -> Self {
-        self.validation.allowed_spl_paid_tokens = config;
+    pub fn with_spl_paid_tokens(mut self, spl_payment_config: SplTokenPaymentConfig) -> Self {
+        self.validation.allowed_spl_paid_tokens = spl_payment_config;
         self
     }
 

--- a/crates/lib/src/tests/toml_mock.rs
+++ b/crates/lib/src/tests/toml_mock.rs
@@ -2,7 +2,7 @@ use std::fs;
 use tempfile::NamedTempFile;
 
 use crate::{
-    config::{Config, SplTokenPaymentConfig},
+    config::{Config, SplTokenConfig},
     error::KoraError,
 };
 
@@ -27,7 +27,7 @@ struct ValidationSection {
     max_signatures: u64,
     allowed_programs: Vec<String>,
     allowed_tokens: Vec<String>,
-    allowed_spl_paid_tokens: SplTokenPaymentConfig,
+    allowed_spl_paid_tokens: SplTokenConfig,
     disallowed_accounts: Vec<String>,
     price_source: String,
     price_config: Option<String>,
@@ -47,7 +47,7 @@ impl Default for ValidationSection {
             max_signatures: 10,
             allowed_programs: vec!["program1".to_string()],
             allowed_tokens: vec!["token1".to_string()],
-            allowed_spl_paid_tokens: SplTokenPaymentConfig::Allowlist(vec!["token2".to_string()]),
+            allowed_spl_paid_tokens: SplTokenConfig::Allowlist(vec!["token2".to_string()]),
             disallowed_accounts: vec![],
             price_source: "Jupiter".to_string(),
             price_config: None,
@@ -77,7 +77,7 @@ impl ConfigBuilder {
         self
     }
 
-    pub fn with_spl_paid_tokens(mut self, spl_payment_config: SplTokenPaymentConfig) -> Self {
+    pub fn with_spl_paid_tokens(mut self, spl_payment_config: SplTokenConfig) -> Self {
         self.validation.allowed_spl_paid_tokens = spl_payment_config;
         self
     }
@@ -174,11 +174,11 @@ impl ConfigBuilder {
             .join(", ");
 
         let spl_tokens_config = match self.validation.allowed_spl_paid_tokens {
-            SplTokenPaymentConfig::Allowlist(ref tokens) => format!(
+            SplTokenConfig::Allowlist(ref tokens) => format!(
                 "[{}]",
                 tokens.iter().map(|t| format!("\"{t}\"")).collect::<Vec<_>>().join(", ")
             ),
-            SplTokenPaymentConfig::All => format!("\"{}\"", "All"),
+            SplTokenConfig::All => format!("\"{}\"", "All"),
         };
 
         let disallowed_list = if self.validation.disallowed_accounts.is_empty() {

--- a/crates/lib/src/token/token.rs
+++ b/crates/lib/src/token/token.rs
@@ -326,7 +326,7 @@ impl TokenUtil {
                     (token_state.mint(), actual_amount)
                 };
 
-                if !config.validation.is_spl_token_paid_valid(&mint_address.to_string()) {
+                if !config.validation.supports_token(&mint_address.to_string()) {
                     return Ok(false);
                 }
 

--- a/crates/lib/src/token/token.rs
+++ b/crates/lib/src/token/token.rs
@@ -326,7 +326,9 @@ impl TokenUtil {
                     (token_state.mint(), actual_amount)
                 };
 
-                if !config.validation.allowed_spl_paid_tokens.contains(&mint_address.to_string()) {
+                if !config.validation.allow_any_spl_paid_token
+                && !config.validation.allowed_spl_paid_tokens.contains(&mint_address.to_string())
+            {
                     return Ok(false);
                 }
 

--- a/crates/lib/src/token/token.rs
+++ b/crates/lib/src/token/token.rs
@@ -326,9 +326,7 @@ impl TokenUtil {
                     (token_state.mint(), actual_amount)
                 };
 
-                if !config.validation.allow_any_spl_paid_token
-                && !config.validation.allowed_spl_paid_tokens.contains(&mint_address.to_string())
-            {
+                if !config.validation.is_spl_token_paid_valid(&mint_address.to_string()) {
                     return Ok(false);
                 }
 

--- a/crates/lib/src/transaction/versioned_transaction.rs
+++ b/crates/lib/src/transaction/versioned_transaction.rs
@@ -377,6 +377,7 @@ impl LookupTableUtil {
 #[cfg(test)]
 mod tests {
     use crate::{
+        config::SplTokenPaymentConfig,
         tests::{
             common::RpcMockBuilder, config_mock::mock_state::setup_config_mock,
             toml_mock::ConfigBuilder,
@@ -403,7 +404,7 @@ mod tests {
         ConfigBuilder::new()
             .with_programs(vec![])
             .with_tokens(vec![])
-            .with_spl_paid_tokens(vec![])
+            .with_spl_paid_tokens(SplTokenPaymentConfig::Allowlist(vec![]))
             .with_free_price()
             .with_cache_config(None, false, 60, 30) // Disable cache for tests
             .build_config()

--- a/crates/lib/src/transaction/versioned_transaction.rs
+++ b/crates/lib/src/transaction/versioned_transaction.rs
@@ -377,7 +377,7 @@ impl LookupTableUtil {
 #[cfg(test)]
 mod tests {
     use crate::{
-        config::SplTokenPaymentConfig,
+        config::SplTokenConfig,
         tests::{
             common::RpcMockBuilder, config_mock::mock_state::setup_config_mock,
             toml_mock::ConfigBuilder,
@@ -404,7 +404,7 @@ mod tests {
         ConfigBuilder::new()
             .with_programs(vec![])
             .with_tokens(vec![])
-            .with_spl_paid_tokens(SplTokenPaymentConfig::Allowlist(vec![]))
+            .with_spl_paid_tokens(SplTokenConfig::Allowlist(vec![]))
             .with_free_price()
             .with_cache_config(None, false, 60, 30) // Disable cache for tests
             .build_config()

--- a/crates/lib/src/validator/config_validator.rs
+++ b/crates/lib/src/validator/config_validator.rs
@@ -683,7 +683,7 @@ mod tests {
         let _ = update_config(config);
 
         let mock_account = create_mock_program_account();
-        let rpc_client = RpcClient::new("http://localhost:8899".to_string());
+        let rpc_client = RpcMockBuilder::new().build();
 
         let result = ConfigValidator::validate_with_result(&rpc_client, true).await;
         assert!(result.is_ok());

--- a/crates/lib/src/validator/config_validator.rs
+++ b/crates/lib/src/validator/config_validator.rs
@@ -113,7 +113,9 @@ impl ConfigValidator {
         }
 
         // Validate allowed spl paid tokens
-        if let Err(e) = TokenUtil::check_valid_tokens(&config.validation.allowed_spl_paid_tokens) {
+        if let Err(e) =
+            TokenUtil::check_valid_tokens(config.validation.allowed_spl_paid_tokens.as_slice())
+        {
             errors.push(format!("Invalid spl paid token address: {e}"));
         }
 
@@ -142,7 +144,7 @@ impl ConfigValidator {
             }
 
             // If fees enabled, allowed_spl_paid_tokens can't be empty
-            if config.validation.allowed_spl_paid_tokens.is_empty() {
+            if !config.validation.allowed_spl_paid_tokens.has_tokens() {
                 errors.push(
                     "When fees are enabled, allowed_spl_paid_tokens cannot be empty".to_string(),
                 );
@@ -168,7 +170,7 @@ impl ConfigValidator {
                 if Pubkey::from_str(token).is_err() {
                     errors.push(format!("Invalid token address for fixed price: {token}"));
                 }
-                if !config.validation.allowed_spl_paid_tokens.contains(token) {
+                if !config.validation.is_spl_token_paid_valid(token) {
                     errors.push(format!(
                         "Token address for fixed price is not in allowed spl paid tokens: {token}"
                     ));
@@ -317,7 +319,9 @@ mod tests {
                 max_signatures: 10,
                 allowed_programs: vec!["program1".to_string()],
                 allowed_tokens: vec!["token1".to_string()],
-                allowed_spl_paid_tokens: vec!["token3".to_string()],
+                allowed_spl_paid_tokens: SplTokenPaymentConfig::Allowlist(vec![
+                    "token3".to_string()
+                ]),
                 disallowed_accounts: vec!["account1".to_string()],
                 price_source: PriceSource::Jupiter,
                 fee_payer_policy: FeePayerPolicy::default(),
@@ -353,9 +357,9 @@ mod tests {
                     SPL_TOKEN_PROGRAM_ID.to_string(),
                 ],
                 allowed_tokens: vec!["4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU".to_string()],
-                allowed_spl_paid_tokens: vec![
-                    "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU".to_string()
-                ],
+                allowed_spl_paid_tokens: SplTokenPaymentConfig::Allowlist(vec![
+                    "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU".to_string(),
+                ]),
                 disallowed_accounts: vec![],
                 price_source: PriceSource::Jupiter,
                 fee_payer_policy: FeePayerPolicy::default(),
@@ -385,7 +389,7 @@ mod tests {
                 max_signatures: 0,        // Should warn
                 allowed_programs: vec![], // Should warn
                 allowed_tokens: vec!["4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU".to_string()],
-                allowed_spl_paid_tokens: vec![],
+                allowed_spl_paid_tokens: SplTokenPaymentConfig::Allowlist(vec![]),
                 disallowed_accounts: vec![],
                 price_source: PriceSource::Mock, // Should warn
                 fee_payer_policy: FeePayerPolicy::default(),
@@ -439,7 +443,7 @@ mod tests {
                 max_signatures: 10,
                 allowed_programs: vec!["SomeOtherProgram".to_string()], // Missing system program
                 allowed_tokens: vec!["4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU".to_string()],
-                allowed_spl_paid_tokens: vec![],
+                allowed_spl_paid_tokens: SplTokenPaymentConfig::Allowlist(vec![]),
                 disallowed_accounts: vec![],
                 price_source: PriceSource::Jupiter,
                 fee_payer_policy: FeePayerPolicy::default(),
@@ -471,7 +475,9 @@ mod tests {
                 max_signatures: 10,
                 allowed_programs: vec![SYSTEM_PROGRAM_ID.to_string()],
                 allowed_tokens: vec![], // Error - no tokens
-                allowed_spl_paid_tokens: vec!["invalid_token_address".to_string()], // Error - invalid token
+                allowed_spl_paid_tokens: SplTokenPaymentConfig::Allowlist(vec![
+                    "invalid_token_address".to_string(),
+                ]), // Error - invalid token
                 disallowed_accounts: vec!["invalid_account_address".to_string()], // Error - invalid account
                 price_source: PriceSource::Jupiter,
                 fee_payer_policy: FeePayerPolicy::default(),
@@ -506,9 +512,9 @@ mod tests {
                 max_signatures: 10,
                 allowed_programs: vec![SYSTEM_PROGRAM_ID.to_string()],
                 allowed_tokens: vec!["4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU".to_string()],
-                allowed_spl_paid_tokens: vec![
-                    "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU".to_string()
-                ],
+                allowed_spl_paid_tokens: SplTokenPaymentConfig::Allowlist(vec![
+                    "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU".to_string(),
+                ]),
                 disallowed_accounts: vec![],
                 price_source: PriceSource::Jupiter,
                 fee_payer_policy: FeePayerPolicy::default(),
@@ -543,9 +549,9 @@ mod tests {
                 max_signatures: 10,
                 allowed_programs: vec![SYSTEM_PROGRAM_ID.to_string()],
                 allowed_tokens: vec!["4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU".to_string()],
-                allowed_spl_paid_tokens: vec![
-                    "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU".to_string()
-                ],
+                allowed_spl_paid_tokens: SplTokenPaymentConfig::Allowlist(vec![
+                    "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU".to_string(),
+                ]),
                 disallowed_accounts: vec![],
                 price_source: PriceSource::Jupiter,
                 fee_payer_policy: FeePayerPolicy::default(),
@@ -588,9 +594,9 @@ mod tests {
                     SPL_TOKEN_PROGRAM_ID.to_string(),
                 ],
                 allowed_tokens: vec!["4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU".to_string()],
-                allowed_spl_paid_tokens: vec![
-                    "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU".to_string()
-                ],
+                allowed_spl_paid_tokens: SplTokenPaymentConfig::Allowlist(vec![
+                    "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU".to_string(),
+                ]),
                 disallowed_accounts: vec![],
                 price_source: PriceSource::Jupiter,
                 fee_payer_policy: FeePayerPolicy::default(),
@@ -627,7 +633,7 @@ mod tests {
                 max_signatures: 10,
                 allowed_programs: vec![SYSTEM_PROGRAM_ID.to_string()], // Missing token programs
                 allowed_tokens: vec!["4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU".to_string()],
-                allowed_spl_paid_tokens: vec![], // Empty when fees enabled - should error
+                allowed_spl_paid_tokens: SplTokenPaymentConfig::Allowlist(vec![]), // Empty when fees enabled - should error
                 disallowed_accounts: vec![],
                 price_source: PriceSource::Jupiter,
                 fee_payer_policy: FeePayerPolicy::default(),
@@ -653,6 +659,38 @@ mod tests {
 
     #[tokio::test]
     #[serial]
+    async fn test_validate_with_result_fee_and_any_spl_token_allowed() {
+        let config = Config {
+            validation: ValidationConfig {
+                max_allowed_lamports: 1_000_000,
+                max_signatures: 10,
+                allowed_programs: vec![
+                    SYSTEM_PROGRAM_ID.to_string(),
+                    SPL_TOKEN_PROGRAM_ID.to_string(),
+                ],
+                allowed_tokens: vec!["4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU".to_string()],
+                allowed_spl_paid_tokens: SplTokenPaymentConfig::All, // All tokens are allowed
+                disallowed_accounts: vec![],
+                price_source: PriceSource::Jupiter,
+                fee_payer_policy: FeePayerPolicy::default(),
+                price: PriceConfig { model: PriceModel::Margin { margin: 0.1 } },
+                token_2022: Token2022Config::default(),
+            },
+            metrics: MetricsConfig::default(),
+            kora: KoraConfig::default(),
+        };
+
+        let _ = update_config(config);
+
+        let mock_account = create_mock_program_account();
+        let rpc_client = get_mock_rpc_client(&mock_account);
+
+        let result = ConfigValidator::validate_with_result(&rpc_client, true).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    #[serial]
     async fn test_validate_with_result_paid_tokens_not_in_allowed_tokens() {
         let config = Config {
             validation: ValidationConfig {
@@ -663,9 +701,9 @@ mod tests {
                     SPL_TOKEN_PROGRAM_ID.to_string(),
                 ],
                 allowed_tokens: vec!["4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU".to_string()],
-                allowed_spl_paid_tokens: vec![
+                allowed_spl_paid_tokens: SplTokenPaymentConfig::Allowlist(vec![
                     "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v".to_string(), // Not in allowed_tokens
-                ],
+                ]),
                 disallowed_accounts: vec![],
                 price_source: PriceSource::Jupiter,
                 fee_payer_policy: FeePayerPolicy::default(),
@@ -694,9 +732,9 @@ mod tests {
                 max_signatures: 10,
                 allowed_programs: vec![SYSTEM_PROGRAM_ID.to_string()],
                 allowed_tokens: vec!["4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU".to_string()], // Required to pass basic validation
-                allowed_spl_paid_tokens: vec![
-                    "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU".to_string()
-                ],
+                allowed_spl_paid_tokens: SplTokenPaymentConfig::Allowlist(vec![
+                    "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU".to_string(),
+                ]),
                 disallowed_accounts: vec![],
                 price_source: PriceSource::Jupiter,
                 fee_payer_policy: FeePayerPolicy::default(),
@@ -716,7 +754,7 @@ mod tests {
                 max_signatures: 10,
                 allowed_programs: vec![], // No programs
                 allowed_tokens: vec!["4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU".to_string()],
-                allowed_spl_paid_tokens: vec![], // Empty to avoid duplicate validation
+                allowed_spl_paid_tokens: SplTokenPaymentConfig::Allowlist(vec![]), // Empty to avoid duplicate validation
                 disallowed_accounts: vec![],
                 price_source: PriceSource::Jupiter,
                 fee_payer_policy: FeePayerPolicy::default(),
@@ -778,7 +816,7 @@ mod tests {
                 max_signatures: 10,
                 allowed_programs: vec![SYSTEM_PROGRAM_ID.to_string()],
                 allowed_tokens: vec!["4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU".to_string()],
-                allowed_spl_paid_tokens: vec![],
+                allowed_spl_paid_tokens: SplTokenPaymentConfig::Allowlist(vec![]),
                 disallowed_accounts: vec![],
                 price_source: PriceSource::Jupiter,
                 fee_payer_policy: FeePayerPolicy::default(),
@@ -810,7 +848,7 @@ mod tests {
                 max_signatures: 10,
                 allowed_programs: vec![SYSTEM_PROGRAM_ID.to_string()],
                 allowed_tokens: vec!["4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU".to_string()],
-                allowed_spl_paid_tokens: vec![],
+                allowed_spl_paid_tokens: SplTokenPaymentConfig::Allowlist(vec![]),
                 disallowed_accounts: vec![],
                 price_source: PriceSource::Jupiter,
                 fee_payer_policy: FeePayerPolicy::default(),
@@ -841,7 +879,7 @@ mod tests {
                 max_signatures: 10,
                 allowed_programs: vec![SYSTEM_PROGRAM_ID.to_string()],
                 allowed_tokens: vec!["4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU".to_string()],
-                allowed_spl_paid_tokens: vec![],
+                allowed_spl_paid_tokens: SplTokenPaymentConfig::Allowlist(vec![]),
                 disallowed_accounts: vec![],
                 price_source: PriceSource::Jupiter,
                 fee_payer_policy: FeePayerPolicy::default(),
@@ -871,7 +909,7 @@ mod tests {
                 max_signatures: 10,
                 allowed_programs: vec![SYSTEM_PROGRAM_ID.to_string()],
                 allowed_tokens: vec!["4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU".to_string()],
-                allowed_spl_paid_tokens: vec![],
+                allowed_spl_paid_tokens: SplTokenPaymentConfig::Allowlist(vec![]),
                 disallowed_accounts: vec![],
                 price_source: PriceSource::Jupiter,
                 fee_payer_policy: FeePayerPolicy::default(),
@@ -905,7 +943,7 @@ mod tests {
                 max_signatures: 10,
                 allowed_programs: vec![SYSTEM_PROGRAM_ID.to_string()],
                 allowed_tokens: vec!["4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU".to_string()],
-                allowed_spl_paid_tokens: vec![],
+                allowed_spl_paid_tokens: SplTokenPaymentConfig::Allowlist(vec![]),
                 disallowed_accounts: vec![],
                 price_source: PriceSource::Jupiter,
                 fee_payer_policy: FeePayerPolicy::default(),
@@ -939,7 +977,7 @@ mod tests {
                 max_signatures: 10,
                 allowed_programs: vec![SYSTEM_PROGRAM_ID.to_string()],
                 allowed_tokens: vec!["4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU".to_string()],
-                allowed_spl_paid_tokens: vec![],
+                allowed_spl_paid_tokens: SplTokenPaymentConfig::Allowlist(vec![]),
                 disallowed_accounts: vec![],
                 price_source: PriceSource::Jupiter,
                 fee_payer_policy: FeePayerPolicy::default(),

--- a/crates/lib/src/validator/config_validator.rs
+++ b/crates/lib/src/validator/config_validator.rs
@@ -170,7 +170,7 @@ impl ConfigValidator {
                 if Pubkey::from_str(token).is_err() {
                     errors.push(format!("Invalid token address for fixed price: {token}"));
                 }
-                if !config.validation.is_spl_token_paid_valid(token) {
+                if !config.validation.supports_token(token) {
                     errors.push(format!(
                         "Token address for fixed price is not in allowed spl paid tokens: {token}"
                     ));

--- a/crates/lib/src/validator/config_validator.rs
+++ b/crates/lib/src/validator/config_validator.rs
@@ -296,7 +296,7 @@ mod tests {
     use crate::{
         config::{
             AuthConfig, CacheConfig, Config, EnabledMethods, FeePayerPolicy, KoraConfig,
-            MetricsConfig, ValidationConfig,
+            MetricsConfig, SplTokenPaymentConfig, ValidationConfig,
         },
         fee::price::PriceConfig,
         state::update_config,
@@ -683,7 +683,7 @@ mod tests {
         let _ = update_config(config);
 
         let mock_account = create_mock_program_account();
-        let rpc_client = get_mock_rpc_client(&mock_account);
+        let rpc_client = RpcClient::new("http://localhost:8899".to_string());
 
         let result = ConfigValidator::validate_with_result(&rpc_client, true).await;
         assert!(result.is_ok());

--- a/crates/lib/src/validator/config_validator.rs
+++ b/crates/lib/src/validator/config_validator.rs
@@ -303,7 +303,7 @@ mod tests {
         tests::common::{
             create_mock_non_executable_account, create_mock_program_account,
             create_mock_rpc_client_account_not_found, create_mock_rpc_client_with_account,
-            create_mock_rpc_client_with_mint,
+            create_mock_rpc_client_with_mint, RpcMockBuilder,
         },
     };
     use serial_test::serial;
@@ -716,7 +716,7 @@ mod tests {
 
         let _ = update_config(config);
 
-        let rpc_client = RpcClient::new("http://localhost:8899".to_string());
+        let rpc_client = RpcMockBuilder::new().build();
         let result = ConfigValidator::validate_with_result(&rpc_client, true).await;
         assert!(result.is_err());
         let errors = result.unwrap_err();

--- a/crates/lib/src/validator/config_validator.rs
+++ b/crates/lib/src/validator/config_validator.rs
@@ -296,7 +296,7 @@ mod tests {
     use crate::{
         config::{
             AuthConfig, CacheConfig, Config, EnabledMethods, FeePayerPolicy, KoraConfig,
-            MetricsConfig, SplTokenPaymentConfig, ValidationConfig,
+            MetricsConfig, SplTokenConfig, ValidationConfig,
         },
         fee::price::PriceConfig,
         state::update_config,
@@ -319,9 +319,7 @@ mod tests {
                 max_signatures: 10,
                 allowed_programs: vec!["program1".to_string()],
                 allowed_tokens: vec!["token1".to_string()],
-                allowed_spl_paid_tokens: SplTokenPaymentConfig::Allowlist(vec![
-                    "token3".to_string()
-                ]),
+                allowed_spl_paid_tokens: SplTokenConfig::Allowlist(vec!["token3".to_string()]),
                 disallowed_accounts: vec!["account1".to_string()],
                 price_source: PriceSource::Jupiter,
                 fee_payer_policy: FeePayerPolicy::default(),
@@ -357,7 +355,7 @@ mod tests {
                     SPL_TOKEN_PROGRAM_ID.to_string(),
                 ],
                 allowed_tokens: vec!["4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU".to_string()],
-                allowed_spl_paid_tokens: SplTokenPaymentConfig::Allowlist(vec![
+                allowed_spl_paid_tokens: SplTokenConfig::Allowlist(vec![
                     "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU".to_string(),
                 ]),
                 disallowed_accounts: vec![],
@@ -389,7 +387,7 @@ mod tests {
                 max_signatures: 0,        // Should warn
                 allowed_programs: vec![], // Should warn
                 allowed_tokens: vec!["4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU".to_string()],
-                allowed_spl_paid_tokens: SplTokenPaymentConfig::Allowlist(vec![]),
+                allowed_spl_paid_tokens: SplTokenConfig::Allowlist(vec![]),
                 disallowed_accounts: vec![],
                 price_source: PriceSource::Mock, // Should warn
                 fee_payer_policy: FeePayerPolicy::default(),
@@ -443,7 +441,7 @@ mod tests {
                 max_signatures: 10,
                 allowed_programs: vec!["SomeOtherProgram".to_string()], // Missing system program
                 allowed_tokens: vec!["4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU".to_string()],
-                allowed_spl_paid_tokens: SplTokenPaymentConfig::Allowlist(vec![]),
+                allowed_spl_paid_tokens: SplTokenConfig::Allowlist(vec![]),
                 disallowed_accounts: vec![],
                 price_source: PriceSource::Jupiter,
                 fee_payer_policy: FeePayerPolicy::default(),
@@ -475,8 +473,8 @@ mod tests {
                 max_signatures: 10,
                 allowed_programs: vec![SYSTEM_PROGRAM_ID.to_string()],
                 allowed_tokens: vec![], // Error - no tokens
-                allowed_spl_paid_tokens: SplTokenPaymentConfig::Allowlist(vec![
-                    "invalid_token_address".to_string(),
+                allowed_spl_paid_tokens: SplTokenConfig::Allowlist(vec![
+                    "invalid_token_address".to_string()
                 ]), // Error - invalid token
                 disallowed_accounts: vec!["invalid_account_address".to_string()], // Error - invalid account
                 price_source: PriceSource::Jupiter,
@@ -512,7 +510,7 @@ mod tests {
                 max_signatures: 10,
                 allowed_programs: vec![SYSTEM_PROGRAM_ID.to_string()],
                 allowed_tokens: vec!["4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU".to_string()],
-                allowed_spl_paid_tokens: SplTokenPaymentConfig::Allowlist(vec![
+                allowed_spl_paid_tokens: SplTokenConfig::Allowlist(vec![
                     "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU".to_string(),
                 ]),
                 disallowed_accounts: vec![],
@@ -549,7 +547,7 @@ mod tests {
                 max_signatures: 10,
                 allowed_programs: vec![SYSTEM_PROGRAM_ID.to_string()],
                 allowed_tokens: vec!["4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU".to_string()],
-                allowed_spl_paid_tokens: SplTokenPaymentConfig::Allowlist(vec![
+                allowed_spl_paid_tokens: SplTokenConfig::Allowlist(vec![
                     "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU".to_string(),
                 ]),
                 disallowed_accounts: vec![],
@@ -594,7 +592,7 @@ mod tests {
                     SPL_TOKEN_PROGRAM_ID.to_string(),
                 ],
                 allowed_tokens: vec!["4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU".to_string()],
-                allowed_spl_paid_tokens: SplTokenPaymentConfig::Allowlist(vec![
+                allowed_spl_paid_tokens: SplTokenConfig::Allowlist(vec![
                     "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU".to_string(),
                 ]),
                 disallowed_accounts: vec![],
@@ -633,7 +631,7 @@ mod tests {
                 max_signatures: 10,
                 allowed_programs: vec![SYSTEM_PROGRAM_ID.to_string()], // Missing token programs
                 allowed_tokens: vec!["4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU".to_string()],
-                allowed_spl_paid_tokens: SplTokenPaymentConfig::Allowlist(vec![]), // Empty when fees enabled - should error
+                allowed_spl_paid_tokens: SplTokenConfig::Allowlist(vec![]), // Empty when fees enabled - should error
                 disallowed_accounts: vec![],
                 price_source: PriceSource::Jupiter,
                 fee_payer_policy: FeePayerPolicy::default(),
@@ -669,7 +667,7 @@ mod tests {
                     SPL_TOKEN_PROGRAM_ID.to_string(),
                 ],
                 allowed_tokens: vec!["4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU".to_string()],
-                allowed_spl_paid_tokens: SplTokenPaymentConfig::All, // All tokens are allowed
+                allowed_spl_paid_tokens: SplTokenConfig::All, // All tokens are allowed
                 disallowed_accounts: vec![],
                 price_source: PriceSource::Jupiter,
                 fee_payer_policy: FeePayerPolicy::default(),
@@ -701,7 +699,7 @@ mod tests {
                     SPL_TOKEN_PROGRAM_ID.to_string(),
                 ],
                 allowed_tokens: vec!["4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU".to_string()],
-                allowed_spl_paid_tokens: SplTokenPaymentConfig::Allowlist(vec![
+                allowed_spl_paid_tokens: SplTokenConfig::Allowlist(vec![
                     "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v".to_string(), // Not in allowed_tokens
                 ]),
                 disallowed_accounts: vec![],
@@ -732,7 +730,7 @@ mod tests {
                 max_signatures: 10,
                 allowed_programs: vec![SYSTEM_PROGRAM_ID.to_string()],
                 allowed_tokens: vec!["4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU".to_string()], // Required to pass basic validation
-                allowed_spl_paid_tokens: SplTokenPaymentConfig::Allowlist(vec![
+                allowed_spl_paid_tokens: SplTokenConfig::Allowlist(vec![
                     "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU".to_string(),
                 ]),
                 disallowed_accounts: vec![],
@@ -754,7 +752,7 @@ mod tests {
                 max_signatures: 10,
                 allowed_programs: vec![], // No programs
                 allowed_tokens: vec!["4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU".to_string()],
-                allowed_spl_paid_tokens: SplTokenPaymentConfig::Allowlist(vec![]), // Empty to avoid duplicate validation
+                allowed_spl_paid_tokens: SplTokenConfig::Allowlist(vec![]), // Empty to avoid duplicate validation
                 disallowed_accounts: vec![],
                 price_source: PriceSource::Jupiter,
                 fee_payer_policy: FeePayerPolicy::default(),
@@ -816,7 +814,7 @@ mod tests {
                 max_signatures: 10,
                 allowed_programs: vec![SYSTEM_PROGRAM_ID.to_string()],
                 allowed_tokens: vec!["4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU".to_string()],
-                allowed_spl_paid_tokens: SplTokenPaymentConfig::Allowlist(vec![]),
+                allowed_spl_paid_tokens: SplTokenConfig::Allowlist(vec![]),
                 disallowed_accounts: vec![],
                 price_source: PriceSource::Jupiter,
                 fee_payer_policy: FeePayerPolicy::default(),
@@ -848,7 +846,7 @@ mod tests {
                 max_signatures: 10,
                 allowed_programs: vec![SYSTEM_PROGRAM_ID.to_string()],
                 allowed_tokens: vec!["4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU".to_string()],
-                allowed_spl_paid_tokens: SplTokenPaymentConfig::Allowlist(vec![]),
+                allowed_spl_paid_tokens: SplTokenConfig::Allowlist(vec![]),
                 disallowed_accounts: vec![],
                 price_source: PriceSource::Jupiter,
                 fee_payer_policy: FeePayerPolicy::default(),
@@ -879,7 +877,7 @@ mod tests {
                 max_signatures: 10,
                 allowed_programs: vec![SYSTEM_PROGRAM_ID.to_string()],
                 allowed_tokens: vec!["4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU".to_string()],
-                allowed_spl_paid_tokens: SplTokenPaymentConfig::Allowlist(vec![]),
+                allowed_spl_paid_tokens: SplTokenConfig::Allowlist(vec![]),
                 disallowed_accounts: vec![],
                 price_source: PriceSource::Jupiter,
                 fee_payer_policy: FeePayerPolicy::default(),
@@ -909,7 +907,7 @@ mod tests {
                 max_signatures: 10,
                 allowed_programs: vec![SYSTEM_PROGRAM_ID.to_string()],
                 allowed_tokens: vec!["4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU".to_string()],
-                allowed_spl_paid_tokens: SplTokenPaymentConfig::Allowlist(vec![]),
+                allowed_spl_paid_tokens: SplTokenConfig::Allowlist(vec![]),
                 disallowed_accounts: vec![],
                 price_source: PriceSource::Jupiter,
                 fee_payer_policy: FeePayerPolicy::default(),
@@ -943,7 +941,7 @@ mod tests {
                 max_signatures: 10,
                 allowed_programs: vec![SYSTEM_PROGRAM_ID.to_string()],
                 allowed_tokens: vec!["4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU".to_string()],
-                allowed_spl_paid_tokens: SplTokenPaymentConfig::Allowlist(vec![]),
+                allowed_spl_paid_tokens: SplTokenConfig::Allowlist(vec![]),
                 disallowed_accounts: vec![],
                 price_source: PriceSource::Jupiter,
                 fee_payer_policy: FeePayerPolicy::default(),
@@ -977,7 +975,7 @@ mod tests {
                 max_signatures: 10,
                 allowed_programs: vec![SYSTEM_PROGRAM_ID.to_string()],
                 allowed_tokens: vec!["4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU".to_string()],
-                allowed_spl_paid_tokens: SplTokenPaymentConfig::Allowlist(vec![]),
+                allowed_spl_paid_tokens: SplTokenConfig::Allowlist(vec![]),
                 disallowed_accounts: vec![],
                 price_source: PriceSource::Jupiter,
                 fee_payer_policy: FeePayerPolicy::default(),

--- a/docs/getting-started/demo/server/kora.toml
+++ b/docs/getting-started/demo/server/kora.toml
@@ -31,6 +31,7 @@ allowed_tokens = [
 allowed_spl_paid_tokens = [
     "usdCAEFbouFGxdkbHCRtMTcN7DJHd3aCmP9vqjLgmAp", # Update this based on the USDC_LOCAL_KEY public key comment in your .env
 ]
+allow_any_spl_paid_token = false  # Allow any token to be used for payment, takes precedence over `allowed_spl_paid_tokens`
 
 disallowed_accounts = [
     "hndXZGK45hCxfBYvxejAXzCfCujoqkNf7rk4sTB8pek", # Test disallowed account for lookup table

--- a/docs/getting-started/demo/server/kora.toml
+++ b/docs/getting-started/demo/server/kora.toml
@@ -31,7 +31,6 @@ allowed_tokens = [
 allowed_spl_paid_tokens = [
     "usdCAEFbouFGxdkbHCRtMTcN7DJHd3aCmP9vqjLgmAp", # Update this based on the USDC_LOCAL_KEY public key comment in your .env
 ]
-allow_any_spl_paid_token = false  # Allow any token to be used for payment, takes precedence over `allowed_spl_paid_tokens`
 
 disallowed_accounts = [
     "hndXZGK45hCxfBYvxejAXzCfCujoqkNf7rk4sTB8pek", # Test disallowed account for lookup table

--- a/kora.toml
+++ b/kora.toml
@@ -37,6 +37,7 @@ allowed_tokens = [
     "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v", # USDC
 ]
 allowed_spl_paid_tokens = []
+allow_any_spl_paid_token = false  # Allow any token to be used for payment, takes precedence over `allowed_spl_paid_tokens`
 disallowed_accounts = []
 
 # Fee payer policy controls what actions the fee payer can perform

--- a/kora.toml
+++ b/kora.toml
@@ -37,7 +37,7 @@ allowed_tokens = [
     "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v", # USDC
 ]
 allowed_spl_paid_tokens = []
-allow_any_spl_paid_token = false  # Allow any token to be used for payment, takes precedence over `allowed_spl_paid_tokens`
+#allowed_spl_paid_tokens = "All"  # Allow any token to be used for payment,
 disallowed_accounts = []
 
 # Fee payer policy controls what actions the fee payer can perform


### PR DESCRIPTION
Add `allow_any_spl_paid_token` flag that will bypass check (and takes precedence) for whether token is in `allowed_spl_paid_tokens` when checking whether transaction is paid.

For our use case we need to allow to use any SPL token for payment - the price of the token will be checked by the oracle. An alternative would be to allow `allowed_spl_paid_tokens` be empty, but I think that having this flag set explicitly makes more sense for backwards compatibility and security reasons. 

