### PR TITLE
chore: Update fee-payer key path in run target

### DIFF
--- a/makefiles/rs.mk
+++ b/makefiles/rs.mk
@@ -38,7 +38,7 @@ run-presigned:
 
 # Run with default configuration
 run:
-	cargo run -p kora-cli --bin kora -- --config kora.toml --rpc-url http://127.0.0.1:8899 rpc start --private-key ./tests/testing-utils/local-keys/fee-payer-local.json
+	cargo run -p kora-cli --bin kora -- --config kora.toml --rpc-url http://127.0.0.1:8899 rpc start --private-key ./tests/src/common/local-keys/fee-payer-local.json
 
 # Clean build artifacts
 clean:


### PR DESCRIPTION
Changed the path to the fee-payer-local.json file in the run target to reflect its new location under tests/src/common/local-keys. This ensures the correct key file is used when running the default configuration.