### PR TITLE
feat: Implement payment instruction fee estimation and validation

### DIFF
--- a/crates/lib/src/config.rs
+++ b/crates/lib/src/config.rs
@@ -10,7 +10,7 @@ use crate::{
         DEFAULT_METRICS_SCRAPE_INTERVAL,
     },
     error::KoraError,
-    fee::price::PriceConfig,
+    fee::price::{PriceConfig, PriceModel},
     get_signer,
     oracle::PriceSource,
 };
@@ -55,6 +55,12 @@ pub struct ValidationConfig {
     pub fee_payer_policy: FeePayerPolicy,
     #[serde(default)]
     pub price: PriceConfig,
+}
+
+impl ValidationConfig {
+    pub fn is_payment_required(&self) -> bool {
+        !matches!(&self.price.model, PriceModel::Free)
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]

--- a/crates/lib/src/constant.rs
+++ b/crates/lib/src/constant.rs
@@ -1,6 +1,7 @@
 pub const SOL_MINT: &str = "So11111111111111111111111111111111111111112";
 pub const NATIVE_SOL: &str = "11111111111111111111111111111111";
 pub const LAMPORTS_PER_SIGNATURE: u64 = 5000;
+pub const ESTIMATED_LAMPORTS_FOR_PAYMENT_INSTRUCTION: u64 = 50;
 pub const MIN_BALANCE_FOR_RENT_EXEMPTION: u64 = 2_039_280;
 pub const DEFAULT_INTEREST_MULTIPLIER: u128 = 100 * 24 * 60 * 60 / 10000 / (365 * 24 * 60 * 60);
 
@@ -18,3 +19,75 @@ pub const JUPITER_API_PRO_URL: &str = "https://api.jup.ag";
 pub const DEFAULT_METRICS_ENDPOINT: &str = "/metrics";
 pub const DEFAULT_METRICS_PORT: u16 = 8080;
 pub const DEFAULT_METRICS_SCRAPE_INTERVAL: u64 = 60;
+
+// Account Indexes within instructions
+// Instruction indexes for the instructions that we support to parse from the transaction
+pub mod instruction_indexes {
+    pub mod system_create_account {
+        pub const REQUIRED_NUMBER_OF_ACCOUNTS: usize = 1;
+        pub const PAYER_INDEX: usize = 0;
+    }
+
+    pub mod system_transfer {
+        pub const REQUIRED_NUMBER_OF_ACCOUNTS: usize = 2;
+        pub const SENDER_INDEX: usize = 0;
+        pub const RECEIVER_INDEX: usize = 1;
+    }
+
+    pub mod system_transfer_with_seed {
+        pub const REQUIRED_NUMBER_OF_ACCOUNTS: usize = 3;
+        pub const SENDER_INDEX: usize = 1;
+        pub const RECEIVER_INDEX: usize = 2;
+    }
+
+    pub mod system_withdraw_nonce_account {
+        pub const REQUIRED_NUMBER_OF_ACCOUNTS: usize = 5;
+        pub const NONCE_AUTHORITY_INDEX: usize = 4;
+        pub const RECIPIENT_INDEX: usize = 1;
+    }
+
+    pub mod system_assign {
+        pub const REQUIRED_NUMBER_OF_ACCOUNTS: usize = 1;
+        pub const AUTHORITY_INDEX: usize = 0;
+    }
+
+    pub mod system_assign_with_seed {
+        pub const REQUIRED_NUMBER_OF_ACCOUNTS: usize = 2;
+        pub const AUTHORITY_INDEX: usize = 1;
+    }
+
+    pub mod spl_token_transfer {
+        pub const REQUIRED_NUMBER_OF_ACCOUNTS: usize = 3;
+        pub const OWNER_INDEX: usize = 2;
+        pub const SOURCE_ADDRESS_INDEX: usize = 0;
+        pub const DESTINATION_ADDRESS_INDEX: usize = 1;
+    }
+
+    pub mod spl_token_transfer_checked {
+        pub const REQUIRED_NUMBER_OF_ACCOUNTS: usize = 4;
+        pub const OWNER_INDEX: usize = 3;
+        pub const MINT_INDEX: usize = 1;
+        pub const SOURCE_ADDRESS_INDEX: usize = 0;
+        pub const DESTINATION_ADDRESS_INDEX: usize = 2;
+    }
+
+    pub mod spl_token_burn {
+        pub const REQUIRED_NUMBER_OF_ACCOUNTS: usize = 3;
+        pub const OWNER_INDEX: usize = 2;
+    }
+
+    pub mod spl_token_close_account {
+        pub const REQUIRED_NUMBER_OF_ACCOUNTS: usize = 3;
+        pub const OWNER_INDEX: usize = 2;
+    }
+
+    pub mod spl_token_approve {
+        pub const REQUIRED_NUMBER_OF_ACCOUNTS: usize = 3;
+        pub const OWNER_INDEX: usize = 2;
+    }
+
+    pub mod spl_token_approve_checked {
+        pub const REQUIRED_NUMBER_OF_ACCOUNTS: usize = 4;
+        pub const OWNER_INDEX: usize = 3;
+    }
+}

--- a/crates/lib/src/rpc_server/method/estimate_transaction_fee.rs
+++ b/crates/lib/src/rpc_server/method/estimate_transaction_fee.rs
@@ -45,6 +45,7 @@ pub async fn estimate_transaction_fee(
         rpc_client,
         &mut resolved_transaction,
         Some(&fee_payer),
+        validation_config.is_payment_required(),
     )
     .await?;
 

--- a/crates/lib/src/rpc_server/method/sign_transaction.rs
+++ b/crates/lib/src/rpc_server/method/sign_transaction.rs
@@ -29,7 +29,7 @@ pub async fn sign_transaction(
 
     let (signed_transaction, _) = resolved_transaction.sign_transaction(rpc_client).await?;
 
-    let encoded = signed_transaction.encode_b64_transaction()?;
+    let encoded = TransactionUtil::encode_versioned_transaction(&signed_transaction);
 
     Ok(SignTransactionResponse {
         signature: transaction.signatures[0].to_string(),

--- a/crates/lib/src/rpc_server/method/sign_transaction_if_paid.rs
+++ b/crates/lib/src/rpc_server/method/sign_transaction_if_paid.rs
@@ -33,7 +33,7 @@ pub async fn sign_transaction_if_paid(
         .map_err(|e| KoraError::TokenOperationError(e.to_string()))?;
 
     Ok(SignTransactionIfPaidResponse {
-        transaction: transaction.encode_b64_transaction()?,
+        transaction: TransactionUtil::encode_versioned_transaction(&transaction),
         signed_transaction,
     })
 }

--- a/crates/lib/src/rpc_server/method/transfer_transaction.rs
+++ b/crates/lib/src/rpc_server/method/transfer_transaction.rs
@@ -117,20 +117,20 @@ pub async fn transfer_transaction(
     ));
     let transaction = TransactionUtil::new_unsigned_versioned_transaction(message);
 
-    let mut simple_resolved_transaction =
-        VersionedTransactionResolved::from_transaction_only(&transaction);
+    let mut resolved_transaction =
+        VersionedTransactionResolved::from_kora_built_transaction(&transaction);
 
     // validate transaction before signing
-    validator.validate_transaction(&mut simple_resolved_transaction).await?;
+    validator.validate_transaction(&mut resolved_transaction).await?;
 
     // Find the fee payer position in the account keys
-    let fee_payer_position = simple_resolved_transaction.find_signer_position(&fee_payer)?;
+    let fee_payer_position = resolved_transaction.find_signer_position(&fee_payer)?;
 
-    let signature = signer.sign_solana(&simple_resolved_transaction).await?;
+    let signature = signer.sign_solana(&resolved_transaction).await?;
 
-    simple_resolved_transaction.transaction.signatures[fee_payer_position] = signature;
+    resolved_transaction.transaction.signatures[fee_payer_position] = signature;
 
-    let encoded = simple_resolved_transaction.encode_b64_transaction()?;
+    let encoded = resolved_transaction.encode_b64_transaction()?;
     let message_encoded = transaction.message.encode_b64_message()?;
 
     Ok(TransferTransactionResponse {

--- a/crates/lib/src/tests/common/mod.rs
+++ b/crates/lib/src/tests/common/mod.rs
@@ -1,10 +1,14 @@
 use crate::{
+    config::{FeePayerPolicy, KoraConfig, MetricsConfig, ValidationConfig},
+    fee::price::PriceConfig,
     get_signer,
+    oracle::PriceSource,
     signer::{KoraSigner, SolanaMemorySigner},
-    state::init_signer,
+    state::{get_config, init_signer, update_config},
+    Config,
 };
 use base64::{self, Engine};
-use serde_json::json;
+use serde_json::{json, Value};
 use solana_client::{nonblocking::rpc_client::RpcClient, rpc_request::RpcRequest};
 use solana_program::program_pack::Pack;
 use solana_sdk::{
@@ -41,8 +45,50 @@ pub fn setup_or_get_test_signer() -> Pubkey {
 }
 
 /*
+Config Mocks
+*/
+pub fn setup_or_get_test_config() -> Config {
+    if let Ok(config) = get_config() {
+        return config.clone();
+    }
+
+    let config = Config {
+        validation: ValidationConfig {
+            max_allowed_lamports: 1000000000000000000,
+            max_signatures: 1000000000000000000,
+            allowed_programs: vec![],
+            allowed_tokens: vec![],
+            allowed_spl_paid_tokens: vec![],
+            disallowed_accounts: vec![],
+            price_source: PriceSource::Mock,
+            fee_payer_policy: FeePayerPolicy::default(),
+            price: PriceConfig::default(),
+        },
+        kora: KoraConfig::default(),
+        metrics: MetricsConfig::default(),
+    };
+
+    match update_config(config.clone()) {
+        Ok(_) => config.clone(),
+        Err(e) => {
+            panic!("Failed to initialize config: {e}");
+        }
+    }
+}
+
+/*
 RPC Mocks
 */
+pub fn get_fee_estimate_response_mock(fee: u64) -> (RpcRequest, Value) {
+    (
+        RpcRequest::GetFeeForMessage,
+        json!({
+            "context": { "slot": 1 },
+            "value": fee
+        }),
+    )
+}
+
 pub fn get_mock_rpc_client(account: &Account) -> Arc<RpcClient> {
     let mut mocks = HashMap::new();
     let encoded_data = base64::engine::general_purpose::STANDARD.encode(&account.data);
@@ -61,6 +107,31 @@ pub fn get_mock_rpc_client(account: &Account) -> Arc<RpcClient> {
             }
         }),
     );
+    Arc::new(RpcClient::new_mock_with_mocks(DEFAULT_LOCAL_RPC_URL.to_string(), mocks))
+}
+
+pub fn get_mock_rpc_client_with_extra_mocks(
+    account: &Account,
+    extra_mocks: HashMap<RpcRequest, Value>,
+) -> Arc<RpcClient> {
+    let mut mocks = HashMap::new();
+    let encoded_data = base64::engine::general_purpose::STANDARD.encode(&account.data);
+    mocks.insert(
+        RpcRequest::GetAccountInfo,
+        json!({
+            "context": {
+                "slot": 1
+            },
+            "value": {
+                "data": [encoded_data, "base64"],
+                "executable": account.executable,
+                "lamports": account.lamports,
+                "owner": account.owner.to_string(),
+                "rentEpoch": account.rent_epoch
+            }
+        }),
+    );
+    mocks.extend(extra_mocks);
     Arc::new(RpcClient::new_mock_with_mocks(DEFAULT_LOCAL_RPC_URL.to_string(), mocks))
 }
 
@@ -103,6 +174,24 @@ pub fn create_mock_rpc_client_account_not_found() -> Arc<RpcClient> {
 /*
 Account Mocks
 */
+pub fn create_mock_token_account(owner: &Pubkey, mint: &Pubkey) -> Account {
+    let token_account = spl_token::state::Account {
+        mint: *mint,
+        owner: *owner,
+        amount: 100,
+        delegate: COption::None,
+        state: spl_token::state::AccountState::Initialized,
+        is_native: COption::Some(0),
+        delegated_amount: 0,
+        close_authority: COption::None,
+    };
+
+    let mut data = vec![0u8; spl_token::state::Account::LEN];
+    token_account.pack_into_slice(&mut data);
+
+    Account { lamports: 1000000, data, owner: spl_token::id(), executable: false, rent_epoch: 0 }
+}
+
 pub fn create_mock_program_account() -> Account {
     Account {
         lamports: 1000000,

--- a/crates/lib/src/token/token.rs
+++ b/crates/lib/src/token/token.rs
@@ -140,7 +140,7 @@ impl TokenUtil {
         let config = get_config()?;
 
         for instruction in transaction_resolved
-            .get_or_parse_spl_instructions()
+            .get_or_parse_spl_instructions()?
             .get(&ParsedSPLInstructionType::SplTokenTransfer)
             .unwrap_or(&vec![])
         {

--- a/crates/lib/src/transaction/transaction.rs
+++ b/crates/lib/src/transaction/transaction.rs
@@ -44,7 +44,12 @@ impl TransactionUtil {
         message: VersionedMessage,
     ) -> VersionedTransactionResolved {
         let transaction = TransactionUtil::new_unsigned_versioned_transaction(message);
-        VersionedTransactionResolved::from_transaction_only(&transaction)
+        VersionedTransactionResolved::from_kora_built_transaction(&transaction)
+    }
+
+    pub fn encode_versioned_transaction(transaction: &VersionedTransaction) -> String {
+        let serialized = bincode::serialize(transaction).unwrap();
+        STANDARD.encode(serialized)
     }
 }
 

--- a/crates/lib/src/validator/transaction_validator.rs
+++ b/crates/lib/src/validator/transaction_validator.rs
@@ -170,7 +170,7 @@ impl TransactionValidator {
         &self,
         transaction_resolved: &mut VersionedTransactionResolved,
     ) -> Result<(), KoraError> {
-        let system_instructions = transaction_resolved.get_or_parse_system_instructions();
+        let system_instructions = transaction_resolved.get_or_parse_system_instructions()?;
 
         let check_if_allowed = |address: &Pubkey, policy_allowed: bool| {
             if *address == self.fee_payer_pubkey && !policy_allowed {
@@ -199,7 +199,7 @@ impl TransactionValidator {
         }
 
         // Validate SPL instructions
-        let spl_instructions = transaction_resolved.get_or_parse_spl_instructions();
+        let spl_instructions = transaction_resolved.get_or_parse_spl_instructions()?;
 
         for instruction in
             spl_instructions.get(&ParsedSPLInstructionType::SplTokenTransfer).unwrap_or(&vec![])

--- a/tests/integration/rpc_integration_tests.rs
+++ b/tests/integration/rpc_integration_tests.rs
@@ -1,4 +1,5 @@
 use crate::common::*;
+use base64::{engine::general_purpose::STANDARD, Engine};
 use jsonrpsee::{core::client::ClientT, rpc_params};
 use kora_lib::{
     token::{TokenInterface, TokenProgram},
@@ -494,133 +495,6 @@ async fn test_estimate_transaction_fee_without_fee_token() {
 }
 
 #[tokio::test]
-async fn test_estimate_fee_with_all_outflow_costs() {
-    let client = ClientTestHelper::get_test_client().await;
-    let rpc_client = RPCTestHelper::get_rpc_client().await;
-
-    let response: serde_json::Value =
-        client.request("getConfig", rpc_params![]).await.expect("Failed to get config");
-    let fee_payer = Pubkey::from_str(response["fee_payer"].as_str().unwrap()).unwrap();
-
-    let sender = SenderTestHelper::get_test_sender_keypair();
-    let recipient = RecipientTestHelper::get_recipient_pubkey();
-    let new_account = Keypair::new();
-    let nonce_account = Keypair::new();
-    let authority = SenderTestHelper::get_test_sender_keypair(); // Use sender as authority for simplicity
-
-    // Create instructions that exercise all outflow calculation paths:
-
-    // 1. SOL Transfer (fee payer as sender) - adds to outflow
-    let sol_transfer =
-        solana_system_interface::instruction::transfer(&fee_payer, &recipient, 100_000);
-
-    // 2. Account creation (fee payer funding) - adds to outflow
-    let account_creation = solana_system_interface::instruction::create_account(
-        &fee_payer,
-        &new_account.pubkey(),
-        50_000,
-        100,
-        &solana_system_interface::program::ID,
-    );
-
-    // 3. Nonce account creation and withdrawal setup (fee payer receives funds) - subtracts from outflow
-    let nonce_creation = solana_system_interface::instruction::create_account(
-        &sender.pubkey(), // Different funder to not affect fee payer outflow
-        &nonce_account.pubkey(),
-        1_000_000, // Nonce accounts need minimum balance
-        80,        // Nonce account size
-        &solana_system_interface::program::ID,
-    );
-
-    let nonce_withdraw = solana_system_interface::instruction::withdraw_nonce_account(
-        &nonce_account.pubkey(),
-        &authority.pubkey(),
-        &fee_payer, // Fee payer receives funds
-        200_000,
-    );
-
-    // 4. Space allocation (fee payer allocating) - adds rent cost to outflow
-    let space_allocation = solana_system_interface::instruction::allocate(
-        &fee_payer, 500, // Allocate 500 bytes
-    );
-
-    let blockhash = rpc_client
-        .get_latest_blockhash_with_commitment(CommitmentConfig::finalized())
-        .await
-        .unwrap();
-
-    let message = VersionedMessage::Legacy(Message::new_with_blockhash(
-        &[sol_transfer, account_creation, nonce_creation, nonce_withdraw, space_allocation],
-        Some(&fee_payer), // Fee payer pays transaction fees
-        &blockhash.0,
-    ));
-
-    let transaction = TransactionUtil::new_unsigned_versioned_transaction_resolved(message);
-    let encoded_transaction = transaction.encode_b64_transaction().unwrap();
-
-    let response: serde_json::Value = client
-        .request(
-            "estimateTransactionFee",
-            rpc_params![
-                encoded_transaction,
-                &USDCMintTestHelper::get_test_usdc_mint_pubkey().to_string()
-            ],
-        )
-        .await
-        .expect("Failed to estimate transaction fee");
-
-    assert!(response["fee_in_lamports"].as_u64().is_some(), "Expected fee_in_lamports in response");
-    let fee_lamports = response["fee_in_lamports"].as_u64().unwrap();
-
-    let rent = solana_sdk::rent::Rent::default();
-
-    // Get current fee payer account to calculate actual rent difference
-    let fee_payer_account = rpc_client.get_account(&fee_payer).await.unwrap_or_else(|_| {
-        solana_sdk::account::Account {
-            lamports: 0,
-            data: vec![], // Default empty account
-            owner: solana_sdk::system_program::ID,
-            executable: false,
-            rent_epoch: 0,
-        }
-    });
-
-    let current_lamport_balance = fee_payer_account.lamports;
-    let required_balance_for_500_bytes = rent.minimum_balance(500);
-
-    let space_allocation_rent =
-        required_balance_for_500_bytes.saturating_sub(current_lamport_balance);
-
-    // Expected outflow breakdown:
-    let sol_transfer_outflow = 100_000u64;
-    let account_creation_outflow = 50_000u64;
-    let nonce_withdrawal_inflow = 200_000u64;
-
-    // Net outflow calculation
-    let gross_outflow = sol_transfer_outflow + account_creation_outflow + space_allocation_rent;
-    let net_outflow = gross_outflow.saturating_sub(nonce_withdrawal_inflow);
-
-    // Expected fee components
-    let expected_base_fee = 20_000u64; // Complex transaction with 5 instructions
-    let expected_account_creation_fee = 0u64; // No ATA creation
-    let expected_kora_signature_fee = 0u64; // Fee payer is in signers
-    let expected_total_fee = expected_base_fee
-        + expected_account_creation_fee
-        + expected_kora_signature_fee
-        + net_outflow;
-
-    // Calculate percentage difference
-    let diff = expected_total_fee.abs_diff(fee_lamports);
-    let percentage_diff = (diff as f64 / expected_total_fee as f64) * 100.0;
-
-    // Assert within 0.1% of expected calculation
-    assert!(
-        percentage_diff < 0.1,
-        "Fee calculation should be within 0.1% of expected. Expected: {expected_total_fee}, Actual: {fee_lamports}, Diff: {percentage_diff:.2}%"
-    );
-}
-
-#[tokio::test]
 async fn test_estimate_transaction_fee_with_fee_token() {
     let client = ClientTestHelper::get_test_client().await;
     let test_tx = TransactionTestHelper::create_test_transaction()
@@ -645,11 +519,11 @@ async fn test_estimate_transaction_fee_with_fee_token() {
 
     // Verify the conversion makes sense
     // Mocked price DEFAULT_MOCKED_PRICE is 0.001, so 0.001 SOL per usdc
-    // Fee in lamport is 10000
+    // Fee in lamport is 10050
     // 10000 lamports -> 0.00001 SOL -> 0.00001 / 0.001 (sol per usdc) = 0.01 usdc
     // 0.01 usdc * 10^6 = 10000 usdc in base units
-    assert_eq!(fee_in_lamports, 10000, "Fee in lamports should be 10000");
-    assert_eq!(fee_in_token, 10000.0, "Fee in token should be 10000");
+    assert_eq!(fee_in_lamports, 10050, "Fee in lamports should be 10050");
+    assert_eq!(fee_in_token, 10050.0, "Fee in token should be 10050");
 }
 
 #[tokio::test]
@@ -667,4 +541,25 @@ async fn test_estimate_transaction_fee_with_invalid_mint() {
         .await;
 
     assert!(result.is_err(), "Expected error for invalid mint address");
+}
+
+#[tokio::test]
+async fn test_estimate_transaction_fee_without_payment_instruction() {
+    let client = ClientTestHelper::get_test_client().await;
+    let test_tx = TransactionTestHelper::create_test_transaction()
+        .await
+        .expect("Failed to create test transaction");
+
+    let response: serde_json::Value = client
+        .request("estimateTransactionFee", rpc_params![test_tx])
+        .await
+        .expect("Failed to estimate transaction fee with token");
+
+    assert!(response["fee_in_lamports"].as_u64().is_some(), "Expected fee_in_lamports in response");
+
+    let fee_in_lamports = response["fee_in_lamports"].as_u64().unwrap();
+
+    println!("fee_in_lamports: {:?}", fee_in_lamports);
+    // Fee in lamport is 10000 + payment instruction fee
+    assert_eq!(fee_in_lamports, 10050, "Fee in lamports should be 10000, got {}", fee_in_lamports);
 }

--- a/tests/src/common/helpers.rs
+++ b/tests/src/common/helpers.rs
@@ -4,7 +4,7 @@ use jsonrpsee::{core::client::ClientT, http_client::HttpClientBuilder, rpc_param
 use kora_lib::{
     signer::KeypairUtil,
     token::{TokenInterface, TokenProgram},
-    transaction::{TransactionUtil, VersionedTransactionOps, VersionedTransactionResolved},
+    transaction::TransactionUtil,
 };
 use solana_address_lookup_table_interface::state::AddressLookupTable;
 use solana_client::nonblocking::rpc_client::RpcClient;
@@ -235,10 +235,8 @@ impl TransactionTestHelper {
         ));
         let transaction = TransactionUtil::new_unsigned_versioned_transaction(message);
 
-        let resolved_transaction =
-            VersionedTransactionResolved::from_transaction_only(&transaction);
-
-        Ok(resolved_transaction.encode_b64_transaction()?)
+        let serialized = bincode::serialize(&transaction).unwrap();
+        Ok(STANDARD.encode(serialized))
     }
 
     pub async fn create_test_spl_transaction() -> Result<String> {
@@ -284,10 +282,8 @@ impl TransactionTestHelper {
         ));
         let transaction = TransactionUtil::new_unsigned_versioned_transaction(message);
 
-        let resolved_transaction =
-            VersionedTransactionResolved::from_transaction_only(&transaction);
-
-        Ok(resolved_transaction.encode_b64_transaction()?)
+        let serialized = bincode::serialize(&transaction).unwrap();
+        Ok(STANDARD.encode(serialized))
     }
 
     pub async fn create_v0_transaction_with_lookup(


### PR DESCRIPTION
- Added `is_payment_required` method to `ValidationConfig` to determine if a payment instruction is necessary.
- Enhanced `estimate_transaction_fee` to include estimated fees for payment instructions.
- Introduced `has_payment_instruction` to check for payment instructions in transactions.
- Updated transaction signing methods to utilize the new fee estimation logic.
- Refactored instruction parsing to validate account indexes for various SPL and system instructions.
- Added tests to ensure correct fee estimation behavior with and without payment instructions.