### PR TITLE
feat: (PRO-162) Implement Redis caching for account data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -470,6 +470,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "backon"
+version = "1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "592277618714fbcecda9a02ba7a8781f319d26532a88553bbacc77ba5d2b3a8d"
+dependencies = [
+ "fastrand",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1291,11 +1300,10 @@ checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
 
 [[package]]
 name = "deadpool"
-version = "0.10.0"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb84100978c1c7b37f09ed3ce3e5f843af02c2a2c431bae5b19230dad2c1b490"
+checksum = "5ed5957ff93768adf7a65ab167a17835c3d2c3c50d084fe305174c112f468e2f"
 dependencies = [
- "async-trait",
  "deadpool-runtime",
  "num_cpus",
  "tokio",
@@ -1303,9 +1311,9 @@ dependencies = [
 
 [[package]]
 name = "deadpool-redis"
-version = "0.14.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36f2381b0e993d06a1f6d49f486b33bc4004085bf980340fc05726bacc681fff"
+checksum = "c0965b977f1244bc3783bb27cd79cfcff335a8341da18f79232d00504b18eb1a"
 dependencies = [
  "deadpool",
  "redis",
@@ -4178,24 +4186,25 @@ dependencies = [
 
 [[package]]
 name = "redis"
-version = "0.24.0"
+version = "0.32.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c580d9cbbe1d1b479e8d67cf9daf6a62c957e6846048408b80b43ac3f6af84cd"
+checksum = "7cd3650deebc68526b304898b192fa4102a4ef0b9ada24da096559cb60e0eef8"
 dependencies = [
  "arc-swap",
- "async-trait",
+ "backon",
  "bytes",
+ "cfg-if",
  "combine",
- "futures",
+ "futures-channel",
  "futures-util",
  "itoa",
+ "num-bigint 0.4.6",
  "percent-encoding",
  "pin-project-lite",
  "ryu",
  "sha1_smol",
- "socket2 0.4.10",
+ "socket2 0.6.0",
  "tokio",
- "tokio-retry",
  "tokio-util",
  "url",
 ]
@@ -5019,16 +5028,6 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
-
-[[package]]
-name = "socket2"
-version = "0.4.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f7916fc008ca5542385b89a3d3ce689953c143e9304a9bf8beec1de48994c0d"
-dependencies = [
- "libc",
- "winapi",
-]
 
 [[package]]
 name = "socket2"
@@ -8166,17 +8165,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
 dependencies = [
  "native-tls",
- "tokio",
-]
-
-[[package]]
-name = "tokio-retry"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f57eb36ecbe0fc510036adff84824dd3c24bb781e21bfa67b69d556aa85214f"
-dependencies = [
- "pin-project",
- "rand 0.8.5",
  "tokio",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,8 +75,8 @@ spl-associated-token-account = { version = "6.0.0", features = [
 chrono = "0.4.39"
 hex = "0.4.3"
 p256 = "0.13.3"
-redis = { version = "0.24.0", features = ["tokio-comp", "connection-manager"] }
-deadpool-redis = "0.14.0"
+redis = { version = "0.32.5", features = ["tokio-comp", "connection-manager"] }
+deadpool-redis = "0.22.0"
 vaultrs = "0.7.3"
 utoipa = { version = "4.2.0", features = ["yaml", "chrono"] }
 hmac = "0.12.1"

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -11,7 +11,7 @@ use kora_lib::{
     signer::init::init_signer_type,
     state::{init_config, init_signer},
     validator::config_validator::ConfigValidator,
-    Config,
+    CacheUtil, Config,
 };
 
 #[cfg(feature = "docs")]
@@ -141,6 +141,12 @@ async fn main() -> Result<(), KoraError> {
                         });
                     }
 
+                    // Initialize cache
+                    if let Err(e) = CacheUtil::init().await {
+                        print_error(&format!("Failed to initialize cache: {e}"));
+                        std::process::exit(1);
+                    }
+
                     let rpc_client = get_rpc_client(&cli.global_args.rpc_url);
 
                     let kora_rpc = KoraRpc::new(rpc_client);
@@ -169,6 +175,12 @@ async fn main() -> Result<(), KoraError> {
                         });
                     } else {
                         print_error("Cannot initialize ATAs without a signer.");
+                        std::process::exit(1);
+                    }
+
+                    // Initialize cache
+                    if let Err(e) = CacheUtil::init().await {
+                        print_error(&format!("Failed to initialize cache: {e}"));
                         std::process::exit(1);
                     }
 

--- a/crates/lib/src/admin/token_util.rs
+++ b/crates/lib/src/admin/token_util.rs
@@ -192,15 +192,14 @@ pub async fn find_missing_atas(
     for mint in &token_mints {
         let ata = get_associated_token_address(payment_address, mint);
 
-        match CacheUtil::get_account_from_cache(rpc_client, &ata, false).await {
+        match CacheUtil::get_account(rpc_client, &ata, false).await {
             Ok(_) => {
                 println!("✓ ATA already exists for token {mint}: {ata}");
             }
             Err(_) => {
                 // Fetch mint account to determine if it's SPL or Token2022
-                let mint_account = CacheUtil::get_account_from_cache(rpc_client, mint, false)
-                    .await
-                    .map_err(|e| {
+                let mint_account =
+                    CacheUtil::get_account(rpc_client, mint, false).await.map_err(|e| {
                         KoraError::RpcError(format!("Failed to fetch mint account for {mint}: {e}"))
                     })?;
 

--- a/crates/lib/src/admin/token_util.rs
+++ b/crates/lib/src/admin/token_util.rs
@@ -4,6 +4,7 @@ use crate::{
     state::{get_config, get_signer},
     token::token::TokenType,
     transaction::TransactionUtil,
+    CacheUtil,
 };
 use solana_client::nonblocking::rpc_client::RpcClient;
 use solana_message::{Message, VersionedMessage};
@@ -191,15 +192,17 @@ pub async fn find_missing_atas(
     for mint in &token_mints {
         let ata = get_associated_token_address(payment_address, mint);
 
-        match rpc_client.get_account(&ata).await {
+        match CacheUtil::get_account_from_cache(rpc_client, &ata, false).await {
             Ok(_) => {
                 println!("✓ ATA already exists for token {mint}: {ata}");
             }
             Err(_) => {
                 // Fetch mint account to determine if it's SPL or Token2022
-                let mint_account = rpc_client.get_account(mint).await.map_err(|e| {
-                    KoraError::RpcError(format!("Failed to fetch mint account for {mint}: {e}"))
-                })?;
+                let mint_account = CacheUtil::get_account_from_cache(rpc_client, mint, false)
+                    .await
+                    .map_err(|e| {
+                        KoraError::RpcError(format!("Failed to fetch mint account for {mint}: {e}"))
+                    })?;
 
                 let token_program = TokenType::get_token_program_from_owner(&mint_account.owner)?;
 

--- a/crates/lib/src/cache.rs
+++ b/crates/lib/src/cache.rs
@@ -125,7 +125,7 @@ impl CacheUtil {
     }
 
     /// Get account from cache with optional force refresh
-    pub async fn get_account_from_cache(
+    pub async fn get_account(
         rpc_client: &RpcClient,
         pubkey: &Pubkey,
         force_refresh: bool,

--- a/crates/lib/src/cache.rs
+++ b/crates/lib/src/cache.rs
@@ -1,0 +1,289 @@
+use deadpool_redis::{Pool, Runtime};
+use redis::AsyncCommands;
+use serde::{Deserialize, Serialize};
+use solana_client::nonblocking::rpc_client::RpcClient;
+use solana_sdk::{account::Account, pubkey::Pubkey};
+use tokio::sync::OnceCell;
+
+use crate::{error::KoraError, state::get_config};
+
+const ACCOUNT_CACHE_KEY: &str = "account";
+
+/// Global cache pool instance
+static CACHE_POOL: OnceCell<Option<Pool>> = OnceCell::const_new();
+
+/// Cached account data with metadata
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CachedAccount {
+    pub account: Account,
+    pub cached_at: i64, // Unix timestamp
+}
+
+/// Cache utility for Solana RPC calls
+pub struct CacheUtil;
+
+impl CacheUtil {
+    /// Initialize the cache pool based on configuration
+    pub async fn init() -> Result<(), KoraError> {
+        let config = get_config()?;
+
+        let pool = if CacheUtil::is_cache_enabled() {
+            let redis_url = config.kora.cache.url.as_ref().unwrap();
+
+            let cfg = deadpool_redis::Config::from_url(redis_url);
+            let pool = cfg.create_pool(Some(Runtime::Tokio1)).map_err(|e| {
+                KoraError::InternalServerError(format!("Failed to create cache pool: {e}"))
+            })?;
+
+            // Test connection
+            let mut conn = pool.get().await.map_err(|e| {
+                KoraError::InternalServerError(format!("Failed to connect to cache: {e}"))
+            })?;
+
+            // Simple connection test - try to get a non-existent key
+            let _: Option<String> = conn.get("__connection_test__").await.map_err(|e| {
+                KoraError::InternalServerError(format!("Cache connection test failed: {e}"))
+            })?;
+
+            log::info!("Cache initialized successfully with Redis at {redis_url}");
+
+            Some(pool)
+        } else {
+            log::info!("Cache disabled or no URL configured");
+            None
+        };
+
+        CACHE_POOL.set(pool).map_err(|_| {
+            KoraError::InternalServerError("Cache pool already initialized".to_string())
+        })?;
+
+        Ok(())
+    }
+
+    async fn get_connection(pool: &Pool) -> Result<deadpool_redis::Connection, KoraError> {
+        pool.get().await.map_err(|e| {
+            KoraError::InternalServerError(format!("Failed to get cache connection: {e}"))
+        })
+    }
+
+    fn get_account_key(pubkey: &Pubkey) -> String {
+        format!("{ACCOUNT_CACHE_KEY}:{pubkey}")
+    }
+
+    /// Get account directly from RPC (bypassing cache)
+    async fn get_account_from_rpc(
+        rpc_client: &RpcClient,
+        pubkey: &Pubkey,
+    ) -> Result<Account, KoraError> {
+        match rpc_client.get_account(pubkey).await {
+            Ok(account) => Ok(account),
+            Err(e) => {
+                Err(KoraError::InternalServerError(format!("Failed to get account {pubkey}: {e}")))
+            }
+        }
+    }
+
+    /// Get data from cache
+    async fn get_from_cache(pool: &Pool, key: &str) -> Result<Option<CachedAccount>, KoraError> {
+        let mut conn = Self::get_connection(pool).await?;
+
+        let cached_data: Option<String> = conn.get(key).await.map_err(|e| {
+            KoraError::InternalServerError(format!("Failed to get from cache: {e}"))
+        })?;
+
+        match cached_data {
+            Some(data) => {
+                let cached_account: CachedAccount = serde_json::from_str(&data).map_err(|e| {
+                    KoraError::InternalServerError(format!(
+                        "Failed to deserialize cached data: {e}"
+                    ))
+                })?;
+                Ok(Some(cached_account))
+            }
+            None => Ok(None),
+        }
+    }
+
+    /// Set data in cache with TTL
+    async fn set_in_cache(
+        pool: &Pool,
+        key: &str,
+        data: &CachedAccount,
+        ttl_seconds: u64,
+    ) -> Result<(), KoraError> {
+        let mut conn = Self::get_connection(pool).await?;
+
+        let serialized = serde_json::to_string(data).map_err(|e| {
+            KoraError::InternalServerError(format!("Failed to serialize cache data: {e}"))
+        })?;
+
+        conn.set_ex::<_, _, ()>(key, serialized, ttl_seconds).await.map_err(|e| {
+            KoraError::InternalServerError(format!("Failed to set cache data: {e}"))
+        })?;
+
+        Ok(())
+    }
+
+    /// Get account from cache with optional force refresh
+    pub async fn get_account_from_cache(
+        rpc_client: &RpcClient,
+        pubkey: &Pubkey,
+        force_refresh: bool,
+    ) -> Result<Account, KoraError> {
+        let config = get_config()?;
+
+        // If cache is disabled or force refresh is requested, go directly to RPC
+        if !CacheUtil::is_cache_enabled() || force_refresh {
+            return Self::get_account_from_rpc(rpc_client, pubkey).await;
+        }
+
+        // Get cache pool - if not initialized, fallback to RPC
+        let pool = match CACHE_POOL.get() {
+            Some(pool) => pool,
+            None => {
+                // Cache not initialized, fallback to RPC
+                return Self::get_account_from_rpc(rpc_client, pubkey).await;
+            }
+        };
+
+        let pool = match pool {
+            Some(pool) => pool,
+            None => {
+                // Cache disabled, fallback to RPC
+                return Self::get_account_from_rpc(rpc_client, pubkey).await;
+            }
+        };
+
+        let cache_key = Self::get_account_key(pubkey);
+
+        // Try to get from cache first
+        if let Ok(Some(cached_account)) = Self::get_from_cache(pool, &cache_key).await {
+            let current_time = chrono::Utc::now().timestamp();
+            let cache_age = current_time - cached_account.cached_at;
+
+            // Check if cache is still valid
+            if cache_age < config.kora.cache.account_ttl as i64 {
+                return Ok(cached_account.account);
+            }
+        }
+
+        // Cache miss or expired, fetch from RPC
+        let account = Self::get_account_from_rpc(rpc_client, pubkey).await?;
+
+        // Cache the result if we got an account
+        let cached_account =
+            CachedAccount { account: account.clone(), cached_at: chrono::Utc::now().timestamp() };
+
+        if let Err(e) =
+            Self::set_in_cache(pool, &cache_key, &cached_account, config.kora.cache.account_ttl)
+                .await
+        {
+            log::warn!("Failed to cache account {pubkey}: {e}");
+            // Don't fail the request if caching fails
+        }
+
+        Ok(account)
+    }
+
+    /// Clear cache for a specific account
+    pub async fn invalidate_account_cache(pubkey: &Pubkey) -> Result<(), KoraError> {
+        let pool = match CACHE_POOL.get() {
+            Some(pool) => pool,
+            None => return Ok(()), // Cache not initialized, nothing to invalidate
+        };
+
+        let pool = match pool {
+            Some(pool) => pool,
+            None => return Ok(()), // Cache disabled, nothing to invalidate
+        };
+
+        let mut conn = Self::get_connection(pool).await?;
+
+        let cache_key = Self::get_account_key(pubkey);
+        let _: u32 = conn.del(&cache_key).await.map_err(|e| {
+            KoraError::InternalServerError(format!("Failed to invalidate cache: {e}"))
+        })?;
+
+        Ok(())
+    }
+
+    /// Check if cache is enabled and available
+    pub fn is_cache_enabled() -> bool {
+        match get_config() {
+            Ok(config) => config.kora.cache.enabled && config.kora.cache.url.is_some(),
+            Err(_) => false,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        config::{Config, KoraConfig, ValidationConfig},
+        fee::price::PriceConfig,
+        oracle::PriceSource,
+        state::update_config,
+    };
+    use serial_test::serial;
+
+    fn create_test_config(cache_enabled: bool, cache_url: Option<String>) -> Config {
+        Config {
+            validation: ValidationConfig {
+                max_allowed_lamports: 1000000,
+                max_signatures: 10,
+                allowed_programs: vec![],
+                allowed_tokens: vec![],
+                allowed_spl_paid_tokens: vec![],
+                disallowed_accounts: vec![],
+                price_source: PriceSource::Mock,
+                fee_payer_policy: crate::config::FeePayerPolicy::default(),
+                price: PriceConfig::default(),
+                token_2022: crate::config::Token2022Config::default(),
+            },
+            kora: KoraConfig {
+                rate_limit: 100,
+                enabled_methods: crate::config::EnabledMethods::default(),
+                auth: crate::config::AuthConfig::default(),
+                payment_address: None,
+                cache: crate::config::CacheConfig {
+                    url: cache_url,
+                    enabled: cache_enabled,
+                    default_ttl: 300,
+                    account_ttl: 60,
+                },
+            },
+            metrics: crate::config::MetricsConfig::default(),
+        }
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_cache_disabled() {
+        let config = create_test_config(false, None);
+        let _ = update_config(config);
+
+        // Cache should report as disabled
+        assert!(!CacheUtil::is_cache_enabled());
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_cache_enabled_no_url() {
+        let config = create_test_config(true, None);
+        let _ = update_config(config);
+
+        // Cache should report as disabled when no URL is provided
+        assert!(!CacheUtil::is_cache_enabled());
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_cache_enabled_with_url() {
+        let config = create_test_config(true, Some("redis://localhost:6379".to_string()));
+        let _ = update_config(config);
+
+        // Cache should report as enabled
+        assert!(CacheUtil::is_cache_enabled());
+    }
+}

--- a/crates/lib/src/constant.rs
+++ b/crates/lib/src/constant.rs
@@ -20,6 +20,10 @@ pub const DEFAULT_METRICS_ENDPOINT: &str = "/metrics";
 pub const DEFAULT_METRICS_PORT: u16 = 8080;
 pub const DEFAULT_METRICS_SCRAPE_INTERVAL: u64 = 60;
 
+// Cache
+pub const DEFAULT_CACHE_DEFAULT_TTL: u64 = 300; // 5 minutes
+pub const DEFAULT_CACHE_ACCOUNT_TTL: u64 = 60; // 1 minute for account data
+
 // Account Indexes within instructions
 // Instruction indexes for the instructions that we support to parse from the transaction
 pub mod instruction_indexes {

--- a/crates/lib/src/fee/fee.rs
+++ b/crates/lib/src/fee/fee.rs
@@ -63,31 +63,29 @@ impl FeeConfigUtil {
             let expected_ata = get_associated_token_address(&owner, &mint);
 
             // Force refresh in case extensions are modified
-            if ata == expected_ata
-                && CacheUtil::get_account_from_cache(rpc_client, &ata, true).await.is_err()
+            if ata == expected_ata && CacheUtil::get_account(rpc_client, &ata, true).await.is_err()
             {
                 // Determine the appropriate token program and get account size
-                let account_size =
-                    match CacheUtil::get_account_from_cache(rpc_client, &mint, true).await {
-                        Ok(mint_account) => {
-                            match TokenType::get_token_program_from_owner(&mint_account.owner) {
-                                Ok(token_program) => token_program
-                                    .get_ata_account_size(&mint, &mint_account)
-                                    .await
-                                    .unwrap_or(SplTokenAccountState::LEN),
-                                Err(_) => {
-                                    return Err(KoraError::InternalServerError(
-                                        "Unknown token program".to_string(),
-                                    ));
-                                }
+                let account_size = match CacheUtil::get_account(rpc_client, &mint, true).await {
+                    Ok(mint_account) => {
+                        match TokenType::get_token_program_from_owner(&mint_account.owner) {
+                            Ok(token_program) => token_program
+                                .get_ata_account_size(&mint, &mint_account)
+                                .await
+                                .unwrap_or(SplTokenAccountState::LEN),
+                            Err(_) => {
+                                return Err(KoraError::InternalServerError(
+                                    "Unknown token program".to_string(),
+                                ));
                             }
                         }
-                        Err(_) => {
-                            return Err(KoraError::InternalServerError(
-                                "Failed to fetch mint account".to_string(),
-                            ));
-                        }
-                    };
+                    }
+                    Err(_) => {
+                        return Err(KoraError::InternalServerError(
+                            "Failed to fetch mint account".to_string(),
+                        ));
+                    }
+                };
 
                 // Get rent cost in lamports for ATA creation with the determined size
                 let rent = Rent::default();
@@ -114,8 +112,7 @@ impl FeeConfigUtil {
                 instruction
             {
                 let destination_account =
-                    CacheUtil::get_account_from_cache(rpc_client, destination_address, false)
-                        .await?;
+                    CacheUtil::get_account(rpc_client, destination_address, false).await?;
 
                 let token_program =
                     TokenType::get_token_program_from_owner(&destination_account.owner)?;

--- a/crates/lib/src/mod.rs
+++ b/crates/lib/src/mod.rs
@@ -1,4 +1,5 @@
 pub mod admin;
+pub mod cache;
 pub mod config;
 pub mod constant;
 pub mod error;
@@ -13,6 +14,7 @@ pub mod state;
 pub mod token;
 pub mod transaction;
 pub mod validator;
+pub use cache::CacheUtil;
 pub use config::Config;
 pub use error::KoraError;
 pub use signer::{Signature, Signer};

--- a/crates/lib/src/rpc_server/method/transfer_transaction.rs
+++ b/crates/lib/src/rpc_server/method/transfer_transaction.rs
@@ -14,7 +14,7 @@ use crate::{
         TransactionUtil, VersionedMessageExt, VersionedTransactionOps, VersionedTransactionResolved,
     },
     validator::transaction_validator::TransactionValidator,
-    KoraError, Signer as _,
+    CacheUtil, KoraError, Signer as _,
 };
 
 #[derive(Debug, Deserialize, ToSchema)]
@@ -76,12 +76,11 @@ pub async fn transfer_transaction(
         let dest_ata =
             token_program.get_associated_token_address(&destination, &token_mint.address());
 
-        let _ = rpc_client
-            .get_account(&source_ata)
+        CacheUtil::get_account_from_cache(rpc_client, &source_ata, false)
             .await
             .map_err(|_| KoraError::AccountNotFound(source_ata.to_string()))?;
 
-        if rpc_client.get_account(&dest_ata).await.is_err() {
+        if CacheUtil::get_account_from_cache(rpc_client, &dest_ata, false).await.is_err() {
             instructions.push(token_program.create_associated_token_account_instruction(
                 &fee_payer,
                 &destination,

--- a/crates/lib/src/rpc_server/method/transfer_transaction.rs
+++ b/crates/lib/src/rpc_server/method/transfer_transaction.rs
@@ -76,11 +76,11 @@ pub async fn transfer_transaction(
         let dest_ata =
             token_program.get_associated_token_address(&destination, &token_mint.address());
 
-        CacheUtil::get_account_from_cache(rpc_client, &source_ata, false)
+        CacheUtil::get_account(rpc_client, &source_ata, false)
             .await
             .map_err(|_| KoraError::AccountNotFound(source_ata.to_string()))?;
 
-        if CacheUtil::get_account_from_cache(rpc_client, &dest_ata, false).await.is_err() {
+        if CacheUtil::get_account(rpc_client, &dest_ata, false).await.is_err() {
             instructions.push(token_program.create_associated_token_account_instruction(
                 &fee_payer,
                 &destination,

--- a/crates/lib/src/tests/common/mod.rs
+++ b/crates/lib/src/tests/common/mod.rs
@@ -63,7 +63,7 @@ pub fn setup_or_get_test_config() -> Config {
             price_source: PriceSource::Mock,
             fee_payer_policy: FeePayerPolicy::default(),
             price: PriceConfig::default(),
-            token2022: Token2022Config::default(),
+            token_2022: Token2022Config::default(),
         },
         kora: KoraConfig::default(),
         metrics: MetricsConfig::default(),

--- a/crates/lib/src/token/token.rs
+++ b/crates/lib/src/token/token.rs
@@ -10,6 +10,7 @@ use crate::{
     transaction::{
         ParsedSPLInstructionData, ParsedSPLInstructionType, VersionedTransactionResolved,
     },
+    CacheUtil,
 };
 use solana_client::nonblocking::rpc_client::RpcClient;
 use solana_sdk::{native_token::LAMPORTS_PER_SOL, pubkey::Pubkey};
@@ -60,7 +61,8 @@ impl TokenUtil {
         rpc_client: &RpcClient,
         mint_pubkey: &Pubkey,
     ) -> Result<Box<dyn TokenMint + Send + Sync>, KoraError> {
-        let mint_account = rpc_client.get_account(mint_pubkey).await?;
+        let mint_account =
+            CacheUtil::get_account_from_cache(rpc_client, mint_pubkey, false).await?;
 
         let token_program = TokenType::get_token_program_from_owner(&mint_account.owner)?;
 
@@ -140,13 +142,13 @@ impl TokenUtil {
         destination_address: &Pubkey,
         mint: &Option<Pubkey>,
     ) -> Result<(), KoraError> {
-        let config = &get_config()?.validation.token2022;
+        let config = &get_config()?.validation.token_2022;
 
         let token_program = Token2022Program::new();
 
-        // Get mint account data and validate mint extensions
+        // Get mint account data and validate mint extensions (force refresh in case extensions are added)
         if let Some(mint) = mint {
-            let mint_account = rpc_client.get_account(mint).await?;
+            let mint_account = CacheUtil::get_account_from_cache(rpc_client, mint, true).await?;
             let mint_data = mint_account.data;
 
             // Unpack the mint state with extensions
@@ -164,8 +166,9 @@ impl TokenUtil {
             }
         }
 
-        // Check source account extensions
-        let source_account = rpc_client.get_account(source_address).await?;
+        // Check source account extensions (force refresh in case extensions are added)
+        let source_account =
+            CacheUtil::get_account_from_cache(rpc_client, source_address, true).await?;
         let source_data = source_account.data;
 
         let source_state = token_program.unpack_token_account(&source_data)?;
@@ -181,8 +184,9 @@ impl TokenUtil {
             }
         }
 
-        // Check destination account extensions
-        let destination_account = rpc_client.get_account(destination_address).await?;
+        // Check destination account extensions (force refresh in case extensions are added)
+        let destination_account =
+            CacheUtil::get_account_from_cache(rpc_client, destination_address, true).await?;
         let destination_data = destination_account.data;
 
         let destination_state = token_program.unpack_token_account(&destination_data)?;
@@ -244,10 +248,10 @@ impl TokenUtil {
                 }
 
                 // Validate the destination account is that of the payment address (or signer if none provided)
-                let destination_account = rpc_client
-                    .get_account(destination_address)
-                    .await
-                    .map_err(|e| KoraError::RpcError(e.to_string()))?;
+                let destination_account =
+                    CacheUtil::get_account_from_cache(rpc_client, destination_address, false)
+                        .await
+                        .map_err(|e| KoraError::RpcError(e.to_string()))?;
 
                 let token_state =
                     token_program.unpack_token_account(&destination_account.data).map_err(|e| {
@@ -264,7 +268,9 @@ impl TokenUtil {
                 // token program will fail. Same with the balance of the source account, if too low the instruction will fail.
                 // This might be useful if the token account is being created within the same transaction, since the source account is not yet created.
                 let (mint_address, actual_amount) = if let Some(mint_address) = *mint {
-                    let mint_account = rpc_client.get_account(&mint_address).await?;
+                    // Force refresh in case extensions are modified
+                    let mint_account =
+                        CacheUtil::get_account_from_cache(rpc_client, &mint_address, true).await?;
                     let mint_state =
                         token_program.unpack_mint(&mint_address, &mint_account.data)?;
 
@@ -284,10 +290,11 @@ impl TokenUtil {
 
                     (mint_address, actual_amount)
                 } else {
-                    let source_account = rpc_client
-                        .get_account(source_address)
-                        .await
-                        .map_err(|e| KoraError::RpcError(e.to_string()))?;
+                    // Force refresh in case extensions are modified
+                    let source_account =
+                        CacheUtil::get_account_from_cache(rpc_client, source_address, true)
+                            .await
+                            .map_err(|e| KoraError::RpcError(e.to_string()))?;
 
                     let token_state =
                         token_program.unpack_token_account(&source_account.data).map_err(|e| {

--- a/crates/lib/src/token/token.rs
+++ b/crates/lib/src/token/token.rs
@@ -61,8 +61,7 @@ impl TokenUtil {
         rpc_client: &RpcClient,
         mint_pubkey: &Pubkey,
     ) -> Result<Box<dyn TokenMint + Send + Sync>, KoraError> {
-        let mint_account =
-            CacheUtil::get_account_from_cache(rpc_client, mint_pubkey, false).await?;
+        let mint_account = CacheUtil::get_account(rpc_client, mint_pubkey, false).await?;
 
         let token_program = TokenType::get_token_program_from_owner(&mint_account.owner)?;
 
@@ -148,7 +147,7 @@ impl TokenUtil {
 
         // Get mint account data and validate mint extensions (force refresh in case extensions are added)
         if let Some(mint) = mint {
-            let mint_account = CacheUtil::get_account_from_cache(rpc_client, mint, true).await?;
+            let mint_account = CacheUtil::get_account(rpc_client, mint, true).await?;
             let mint_data = mint_account.data;
 
             // Unpack the mint state with extensions
@@ -167,8 +166,7 @@ impl TokenUtil {
         }
 
         // Check source account extensions (force refresh in case extensions are added)
-        let source_account =
-            CacheUtil::get_account_from_cache(rpc_client, source_address, true).await?;
+        let source_account = CacheUtil::get_account(rpc_client, source_address, true).await?;
         let source_data = source_account.data;
 
         let source_state = token_program.unpack_token_account(&source_data)?;
@@ -186,7 +184,7 @@ impl TokenUtil {
 
         // Check destination account extensions (force refresh in case extensions are added)
         let destination_account =
-            CacheUtil::get_account_from_cache(rpc_client, destination_address, true).await?;
+            CacheUtil::get_account(rpc_client, destination_address, true).await?;
         let destination_data = destination_account.data;
 
         let destination_state = token_program.unpack_token_account(&destination_data)?;
@@ -249,7 +247,7 @@ impl TokenUtil {
 
                 // Validate the destination account is that of the payment address (or signer if none provided)
                 let destination_account =
-                    CacheUtil::get_account_from_cache(rpc_client, destination_address, false)
+                    CacheUtil::get_account(rpc_client, destination_address, false)
                         .await
                         .map_err(|e| KoraError::RpcError(e.to_string()))?;
 
@@ -270,7 +268,7 @@ impl TokenUtil {
                 let (mint_address, actual_amount) = if let Some(mint_address) = *mint {
                     // Force refresh in case extensions are modified
                     let mint_account =
-                        CacheUtil::get_account_from_cache(rpc_client, &mint_address, true).await?;
+                        CacheUtil::get_account(rpc_client, &mint_address, true).await?;
                     let mint_state =
                         token_program.unpack_mint(&mint_address, &mint_account.data)?;
 
@@ -291,10 +289,9 @@ impl TokenUtil {
                     (mint_address, actual_amount)
                 } else {
                     // Force refresh in case extensions are modified
-                    let source_account =
-                        CacheUtil::get_account_from_cache(rpc_client, source_address, true)
-                            .await
-                            .map_err(|e| KoraError::RpcError(e.to_string()))?;
+                    let source_account = CacheUtil::get_account(rpc_client, source_address, true)
+                        .await
+                        .map_err(|e| KoraError::RpcError(e.to_string()))?;
 
                     let token_state =
                         token_program.unpack_token_account(&source_account.data).map_err(|e| {

--- a/crates/lib/src/transaction/versioned_transaction.rs
+++ b/crates/lib/src/transaction/versioned_transaction.rs
@@ -22,7 +22,7 @@ use crate::{
         ParsedSystemInstructionData, ParsedSystemInstructionType,
     },
     validator::transaction_validator::TransactionValidator,
-    Signer,
+    CacheUtil, Signer,
 };
 use solana_address_lookup_table_interface::state::AddressLookupTable;
 
@@ -331,10 +331,12 @@ impl LookupTableUtil {
 
         // Maybe we can use caching here, there's a chance the lookup tables get updated though, so tbd
         for lookup in lookup_table_lookups {
-            let lookup_table_account = rpc_client
-                .get_account(&lookup.account_key)
-                .await
-                .map_err(|e| KoraError::RpcError(format!("Failed to fetch lookup table: {e}")))?;
+            let lookup_table_account =
+                CacheUtil::get_account_from_cache(rpc_client, &lookup.account_key, false)
+                    .await
+                    .map_err(|e| {
+                        KoraError::RpcError(format!("Failed to fetch lookup table: {e}"))
+                    })?;
 
             // Parse the lookup table account data to get the actual addresses
             let address_lookup_table = AddressLookupTable::deserialize(&lookup_table_account.data)

--- a/crates/lib/src/transaction/versioned_transaction.rs
+++ b/crates/lib/src/transaction/versioned_transaction.rs
@@ -332,11 +332,9 @@ impl LookupTableUtil {
         // Maybe we can use caching here, there's a chance the lookup tables get updated though, so tbd
         for lookup in lookup_table_lookups {
             let lookup_table_account =
-                CacheUtil::get_account_from_cache(rpc_client, &lookup.account_key, false)
-                    .await
-                    .map_err(|e| {
-                        KoraError::RpcError(format!("Failed to fetch lookup table: {e}"))
-                    })?;
+                CacheUtil::get_account(rpc_client, &lookup.account_key, false).await.map_err(
+                    |e| KoraError::RpcError(format!("Failed to fetch lookup table: {e}")),
+                )?;
 
             // Parse the lookup table account data to get the actual addresses
             let address_lookup_table = AddressLookupTable::deserialize(&lookup_table_account.data)

--- a/crates/lib/src/validator/account_validator.rs
+++ b/crates/lib/src/validator/account_validator.rs
@@ -115,11 +115,9 @@ pub async fn validate_account(
     account_pubkey: &Pubkey,
     expected_account_type: Option<AccountType>,
 ) -> Result<(), KoraError> {
-    let account = CacheUtil::get_account_from_cache(rpc_client, account_pubkey, false)
-        .await
-        .map_err(|e| {
-            KoraError::InternalServerError(format!("Failed to get account {account_pubkey}: {e}"))
-        })?;
+    let account = CacheUtil::get_account(rpc_client, account_pubkey, false).await.map_err(|e| {
+        KoraError::InternalServerError(format!("Failed to get account {account_pubkey}: {e}"))
+    })?;
 
     if let Some(expected_type) = expected_account_type {
         expected_type.validate_account_type(&account, account_pubkey)?;

--- a/crates/lib/src/validator/account_validator.rs
+++ b/crates/lib/src/validator/account_validator.rs
@@ -11,7 +11,7 @@ use spl_token_2022::{
     ID as TOKEN_2022_PROGRAM_ID,
 };
 
-use crate::KoraError;
+use crate::{CacheUtil, KoraError};
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum AccountType {
@@ -115,9 +115,11 @@ pub async fn validate_account(
     account_pubkey: &Pubkey,
     expected_account_type: Option<AccountType>,
 ) -> Result<(), KoraError> {
-    let account = rpc_client.get_account(account_pubkey).await.map_err(|e| {
-        KoraError::InternalServerError(format!("Failed to get account {account_pubkey}: {e}"))
-    })?;
+    let account = CacheUtil::get_account_from_cache(rpc_client, account_pubkey, false)
+        .await
+        .map_err(|e| {
+            KoraError::InternalServerError(format!("Failed to get account {account_pubkey}: {e}"))
+        })?;
 
     if let Some(expected_type) = expected_account_type {
         expected_type.validate_account_type(&account, account_pubkey)?;

--- a/crates/lib/src/validator/config_validator.rs
+++ b/crates/lib/src/validator/config_validator.rs
@@ -16,7 +16,7 @@ use spl_token::ID as SPL_TOKEN_PROGRAM_ID;
 use spl_token_2022::ID as TOKEN_2022_PROGRAM_ID;
 
 #[cfg(test)]
-use crate::config::{FeePayerPolicy, ValidationConfig};
+use crate::config::{CacheConfig, FeePayerPolicy, ValidationConfig};
 #[cfg(test)]
 use crate::fee::price::PriceConfig;
 
@@ -128,7 +128,7 @@ impl ConfigValidator {
         }
 
         // Validate Token2022 extensions
-        if let Err(e) = validate_token2022_extensions(&config.validation.token2022) {
+        if let Err(e) = validate_token2022_extensions(&config.validation.token_2022) {
             errors.push(format!("Token2022 extension validation failed: {e}"));
         }
 
@@ -307,7 +307,7 @@ impl ValidationConfig {
             price_source: PriceSource::Mock,
             fee_payer_policy: FeePayerPolicy::default(),
             price: PriceConfig::default(),
-            token2022: Token2022Config::default(),
+            token_2022: Token2022Config::default(),
         }
     }
 
@@ -383,7 +383,7 @@ mod tests {
                 price_source: PriceSource::Jupiter,
                 fee_payer_policy: FeePayerPolicy::default(),
                 price: PriceConfig::default(),
-                token2022: Token2022Config::default(),
+                token_2022: Token2022Config::default(),
             },
             kora: KoraConfig::default(),
             metrics: MetricsConfig::default(),
@@ -421,7 +421,7 @@ mod tests {
                 price_source: PriceSource::Jupiter,
                 fee_payer_policy: FeePayerPolicy::default(),
                 price: PriceConfig::default(),
-                token2022: Token2022Config::default(),
+                token_2022: Token2022Config::default(),
             },
             kora: KoraConfig::default(),
             metrics: MetricsConfig::default(),
@@ -451,7 +451,7 @@ mod tests {
                 price_source: PriceSource::Mock, // Should warn
                 fee_payer_policy: FeePayerPolicy::default(),
                 price: PriceConfig { model: PriceModel::Free },
-                token2022: Token2022Config::default(),
+                token_2022: Token2022Config::default(),
             },
             kora: KoraConfig {
                 rate_limit: 0, // Should warn
@@ -468,6 +468,7 @@ mod tests {
                 },
                 auth: AuthConfig::default(),
                 payment_address: None,
+                cache: CacheConfig::default(),
             },
             metrics: MetricsConfig::default(),
         };
@@ -503,7 +504,7 @@ mod tests {
                 price_source: PriceSource::Jupiter,
                 fee_payer_policy: FeePayerPolicy::default(),
                 price: PriceConfig { model: PriceModel::Free },
-                token2022: Token2022Config::default(),
+                token_2022: Token2022Config::default(),
             },
             kora: KoraConfig::default(),
             metrics: MetricsConfig::default(),
@@ -537,7 +538,7 @@ mod tests {
                 price: PriceConfig {
                     model: PriceModel::Margin { margin: -0.1 }, // Error - negative margin
                 },
-                token2022: Token2022Config::default(),
+                token_2022: Token2022Config::default(),
             },
             metrics: MetricsConfig::default(),
             kora: KoraConfig::default(),
@@ -577,7 +578,7 @@ mod tests {
                         token: "invalid_token_address".to_string(), // Should error
                     },
                 },
-                token2022: Token2022Config::default(),
+                token_2022: Token2022Config::default(),
             },
             metrics: MetricsConfig::default(),
             kora: KoraConfig::default(),
@@ -614,7 +615,7 @@ mod tests {
                         token: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v".to_string(), // Valid but not in allowed
                     },
                 },
-                token2022: Token2022Config::default(),
+                token_2022: Token2022Config::default(),
             },
             metrics: MetricsConfig::default(),
             kora: KoraConfig::default(),
@@ -659,7 +660,7 @@ mod tests {
                         token: "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU".to_string(),
                     },
                 },
-                token2022: Token2022Config::default(),
+                token_2022: Token2022Config::default(),
             },
             metrics: MetricsConfig::default(),
             kora: KoraConfig::default(),
@@ -691,7 +692,7 @@ mod tests {
                 price_source: PriceSource::Jupiter,
                 fee_payer_policy: FeePayerPolicy::default(),
                 price: PriceConfig { model: PriceModel::Margin { margin: 0.1 } },
-                token2022: Token2022Config::default(),
+                token_2022: Token2022Config::default(),
             },
             metrics: MetricsConfig::default(),
             kora: KoraConfig::default(),
@@ -729,7 +730,7 @@ mod tests {
                 price_source: PriceSource::Jupiter,
                 fee_payer_policy: FeePayerPolicy::default(),
                 price: PriceConfig { model: PriceModel::Free },
-                token2022: Token2022Config::default(),
+                token_2022: Token2022Config::default(),
             },
             metrics: MetricsConfig::default(),
             kora: KoraConfig::default(),
@@ -760,7 +761,7 @@ mod tests {
                 price_source: PriceSource::Jupiter,
                 fee_payer_policy: FeePayerPolicy::default(),
                 price: PriceConfig { model: PriceModel::Free },
-                token2022: Token2022Config::default(),
+                token_2022: Token2022Config::default(),
             },
             metrics: MetricsConfig::default(),
             kora: KoraConfig::default(),
@@ -780,7 +781,7 @@ mod tests {
                 price_source: PriceSource::Jupiter,
                 fee_payer_policy: FeePayerPolicy::default(),
                 price: PriceConfig { model: PriceModel::Free },
-                token2022: Token2022Config::default(),
+                token_2022: Token2022Config::default(),
             },
             metrics: MetricsConfig::default(),
             kora: KoraConfig::default(),
@@ -844,7 +845,7 @@ mod tests {
                 price_source: PriceSource::Jupiter,
                 fee_payer_policy: FeePayerPolicy::default(),
                 price: PriceConfig { model: PriceModel::Free },
-                token2022: Token2022Config::default(),
+                token_2022: Token2022Config::default(),
             },
             metrics: MetricsConfig::default(),
             kora: KoraConfig::default(),
@@ -877,7 +878,7 @@ mod tests {
                 price_source: PriceSource::Jupiter,
                 fee_payer_policy: FeePayerPolicy::default(),
                 price: PriceConfig { model: PriceModel::Free },
-                token2022: Token2022Config::default(),
+                token_2022: Token2022Config::default(),
             },
             metrics: MetricsConfig::default(),
             kora: KoraConfig::default(),
@@ -908,7 +909,7 @@ mod tests {
                 price_source: PriceSource::Jupiter,
                 fee_payer_policy: FeePayerPolicy::default(),
                 price: PriceConfig { model: PriceModel::Free },
-                token2022: Token2022Config::default(),
+                token_2022: Token2022Config::default(),
             },
             metrics: MetricsConfig::default(),
             kora: KoraConfig::default(),
@@ -938,7 +939,7 @@ mod tests {
                 price_source: PriceSource::Jupiter,
                 fee_payer_policy: FeePayerPolicy::default(),
                 price: PriceConfig { model: PriceModel::Free },
-                token2022: {
+                token_2022: {
                     let mut config = Token2022Config::default();
                     config.blocked_mint_extensions =
                         vec!["transfer_fee_config".to_string(), "pausable".to_string()];
@@ -972,7 +973,7 @@ mod tests {
                 price_source: PriceSource::Jupiter,
                 fee_payer_policy: FeePayerPolicy::default(),
                 price: PriceConfig { model: PriceModel::Free },
-                token2022: {
+                token_2022: {
                     let mut config = Token2022Config::default();
                     config.blocked_mint_extensions = vec!["invalid_mint_extension".to_string()];
                     config
@@ -1006,7 +1007,7 @@ mod tests {
                 price_source: PriceSource::Jupiter,
                 fee_payer_policy: FeePayerPolicy::default(),
                 price: PriceConfig { model: PriceModel::Free },
-                token2022: {
+                token_2022: {
                     let mut config = Token2022Config::default();
                     config.blocked_account_extensions =
                         vec!["invalid_account_extension".to_string()];

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,13 @@
 services:
+  redis:
+    image: redis:8-alpine
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis_data:/data
+    restart: unless-stopped
+    command: redis-server --appendonly yes
+
   kora:
     build:
       context: .
@@ -12,8 +21,13 @@ services:
       - RUST_LOG=info
     env_file:
       - .env
-    command: 
+    command:
       - sh
       - -c
       - 'kora-rpc --config /app/kora.toml --private-key "$$KORA_PRIVATE_KEY"'
     restart: unless-stopped
+    depends_on:
+      - redis
+
+volumes:
+  redis_data:

--- a/kora.toml
+++ b/kora.toml
@@ -3,6 +3,13 @@ rate_limit = 100
 
 [kora.auth]
 
+# Cache configuration for Redis-based caching
+[kora.cache]
+enabled = false                    # Enable/disable caching (set to true with url to enable)
+url = "redis://localhost:6379"    # Redis connection URL (uncomment and set when enabling cache)
+default_ttl = 300                  # Default TTL in seconds (5 minutes)
+account_ttl = 60                   # Account data TTL in seconds (1 minute)
+
 # Enable/disable specific RPC methods
 [kora.enabled_methods]
 liveness = true

--- a/tests/src/common/fixtures/auth-test.toml
+++ b/tests/src/common/fixtures/auth-test.toml
@@ -6,6 +6,12 @@ rate_limit = 100
 api_key = "test-api-key-123"
 hmac_secret = "test-hmac-secret-456"
 
+# Cache configuration - disabled for testing
+[kora.cache]
+enabled = false
+default_ttl = 300
+account_ttl = 60
+
 [kora.enabled_methods]
 liveness = true
 estimate_transaction_fee = true

--- a/tests/src/common/fixtures/kora-test.toml
+++ b/tests/src/common/fixtures/kora-test.toml
@@ -4,6 +4,12 @@ rate_limit = 100
 
 [kora.auth]
 
+# Cache configuration - disabled for testing
+[kora.cache]
+enabled = false
+default_ttl = 300
+account_ttl = 60
+
 [kora.enabled_methods]
 liveness = false                 # Just to be able to test the false flag
 estimate_transaction_fee = true

--- a/tests/src/common/fixtures/paymaster-address-test.toml
+++ b/tests/src/common/fixtures/paymaster-address-test.toml
@@ -3,6 +3,12 @@
 rate_limit = 100
 payment_address = "CWvWnVwqAb9HzqwCGkn4purGEUuu27aNsPQM252uLerV"
 
+# Cache configuration - disabled for testing
+[kora.cache]
+enabled = false
+default_ttl = 300
+account_ttl = 60
+
 [kora.enabled_methods]
 liveness = false
 estimate_transaction_fee = true


### PR DESCRIPTION
- Added Redis-based caching functionality to improve performance for Solana RPC calls.
- Introduced CacheUtil for managing cache operations, including initialization, retrieval, and invalidation of cached account data.
- Updated Kora configuration to support cache settings, including enabling/disabling and TTL values.
- Integrated caching into various components, replacing direct RPC calls with cache lookups where applicable.
- Enhanced Docker setup to include a Redis service for local development.
- Updated tests to validate caching behavior and configuration parsing.