### PR TITLE
feat: (PRO-231): add get_signer_payer method

### DIFF
--- a/crates/lib/src/config.rs
+++ b/crates/lib/src/config.rs
@@ -194,6 +194,7 @@ pub struct EnabledMethods {
     pub liveness: bool,
     pub estimate_transaction_fee: bool,
     pub get_supported_tokens: bool,
+    pub get_payer_signer: bool,
     pub sign_transaction: bool,
     pub sign_and_send_transaction: bool,
     pub transfer_transaction: bool,
@@ -208,6 +209,7 @@ impl EnabledMethods {
             self.liveness,
             self.estimate_transaction_fee,
             self.get_supported_tokens,
+            self.get_payer_signer,
             self.sign_transaction,
             self.sign_and_send_transaction,
             self.transfer_transaction,
@@ -221,13 +223,14 @@ impl EnabledMethods {
 
 impl IntoIterator for &EnabledMethods {
     type Item = bool;
-    type IntoIter = std::array::IntoIter<bool, 9>;
+    type IntoIter = std::array::IntoIter<bool, 10>;
 
     fn into_iter(self) -> Self::IntoIter {
         [
             self.liveness,
             self.estimate_transaction_fee,
             self.get_supported_tokens,
+            self.get_payer_signer,
             self.sign_transaction,
             self.sign_and_send_transaction,
             self.transfer_transaction,
@@ -245,6 +248,7 @@ impl Default for EnabledMethods {
             liveness: true,
             estimate_transaction_fee: true,
             get_supported_tokens: true,
+            get_payer_signer: true,
             sign_transaction: true,
             sign_and_send_transaction: true,
             transfer_transaction: true,

--- a/crates/lib/src/config.rs
+++ b/crates/lib/src/config.rs
@@ -418,6 +418,7 @@ mod tests {
             estimate_transaction_fee = false
             get_supported_tokens = true
             sign_transaction = true
+            get_payer_signer = true
             sign_and_send_transaction = false
             transfer_transaction = true
             get_blockhash = true

--- a/crates/lib/src/rpc_server/method/get_payer_signer.rs
+++ b/crates/lib/src/rpc_server/method/get_payer_signer.rs
@@ -1,0 +1,30 @@
+use crate::{
+    error::KoraError,
+    state::{get_config, get_signer_pool},
+};
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct GetPayerSignerResponse {
+    /// The recommended signer's public key
+    pub signer: String,
+    /// The payment destination address (same as signer if no separate paymaster is configured)
+    pub payment_destination: String,
+}
+
+pub async fn get_payer_signer() -> Result<GetPayerSignerResponse, KoraError> {
+    let config = get_config()?;
+    let pool = get_signer_pool()?;
+
+    // Get the next signer according to the configured strategy
+    let signer_meta = pool.get_next_signer()?;
+    let signer_pubkey = signer_meta.signer.solana_pubkey().to_string();
+
+    // Determine payment destination
+    // If a payment address is configured, use it; otherwise use the signer address
+    let payment_destination =
+        config.kora.payment_address.as_ref().cloned().unwrap_or_else(|| signer_pubkey.clone());
+
+    Ok(GetPayerSignerResponse { signer: signer_pubkey, payment_destination })
+}

--- a/crates/lib/src/rpc_server/method/mod.rs
+++ b/crates/lib/src/rpc_server/method/mod.rs
@@ -1,6 +1,7 @@
 pub mod estimate_transaction_fee;
 pub mod get_blockhash;
 pub mod get_config;
+pub mod get_payer_signer;
 pub mod get_supported_tokens;
 pub mod sign_and_send_transaction;
 pub mod sign_transaction;

--- a/crates/lib/src/rpc_server/openapi/docs.rs
+++ b/crates/lib/src/rpc_server/openapi/docs.rs
@@ -16,6 +16,7 @@ use crate::rpc_server::{
     method::{
         get_blockhash::GetBlockhashResponse,
         get_config::GetConfigResponse,
+        get_payer_signer::GetPayerSignerResponse,
         get_supported_tokens::GetSupportedTokensResponse,
         sign_and_send_transaction::{
             SignAndSendTransactionRequest, SignAndSendTransactionResponse,
@@ -49,6 +50,7 @@ const JSON_CONTENT_TYPE: &str = "application/json";
         PriceSource,
         GetBlockhashResponse,
         GetConfigResponse,
+        GetPayerSignerResponse,
         GetSupportedTokensResponse,
         SignAndSendTransactionRequest,
         SignAndSendTransactionResponse,

--- a/crates/lib/src/rpc_server/rpc.rs
+++ b/crates/lib/src/rpc_server/rpc.rs
@@ -15,6 +15,7 @@ use crate::rpc_server::method::{
     },
     get_blockhash::{get_blockhash, GetBlockhashResponse},
     get_config::{get_config, GetConfigResponse},
+    get_payer_signer::{get_payer_signer, GetPayerSignerResponse},
     get_supported_tokens::{get_supported_tokens, GetSupportedTokensResponse},
     sign_and_send_transaction::{
         sign_and_send_transaction, SignAndSendTransactionRequest, SignAndSendTransactionResponse,
@@ -69,6 +70,13 @@ impl KoraRpc {
         info!("Get supported tokens request received");
         let result = get_supported_tokens().await;
         info!("Get supported tokens response: {result:?}");
+        result
+    }
+
+    pub async fn get_payer_signer(&self) -> Result<GetPayerSignerResponse, KoraError> {
+        info!("Get payer signer request received");
+        let result = get_payer_signer().await;
+        info!("Get payer signer response: {result:?}");
         result
     }
 
@@ -148,6 +156,11 @@ impl KoraRpc {
                 name: "getSupportedTokens".to_string(),
                 request: None,
                 response: GetSupportedTokensResponse::schema().1,
+            },
+            OpenApiSpec {
+                name: "getPayerSigner".to_string(),
+                request: None,
+                response: GetPayerSignerResponse::schema().1,
             },
             OpenApiSpec {
                 name: "signTransaction".to_string(),

--- a/crates/lib/src/rpc_server/server.rs
+++ b/crates/lib/src/rpc_server/server.rs
@@ -143,6 +143,13 @@ fn build_rpc_module(rpc: KoraRpc) -> Result<RpcModule<KoraRpc>, anyhow::Error> {
     register_method_if_enabled!(
         module,
         enabled_methods,
+        get_payer_signer,
+        "getPayerSigner",
+        get_payer_signer
+    );
+    register_method_if_enabled!(
+        module,
+        enabled_methods,
         sign_transaction,
         "signTransaction",
         sign_transaction,

--- a/crates/lib/src/validator/config_validator.rs
+++ b/crates/lib/src/validator/config_validator.rs
@@ -465,6 +465,7 @@ mod tests {
                     get_blockhash: false,
                     get_config: false,
                     sign_transaction_if_paid: false, // All false - should warn
+                    get_payer_signer: false,
                 },
                 auth: AuthConfig::default(),
                 payment_address: None,

--- a/docs/operators/SIGNERS.md
+++ b/docs/operators/SIGNERS.md
@@ -418,20 +418,20 @@ RUST_LOG=debug kora rpc --with-turnkey-signer
 Clients can specify a preferred signer for consistency across related operations:
 
 ```typescript
-// Fetch the signers by calling getConfig
-const config = await client.getConfig();
-console.log(config.fee_payers);
+// Fetch the signers by calling getPayerSigner
+const { signer, payment_destination } = await client.getPayerSigner();
+console.log(signer, payment_destination);
 
 // Estimate with specific signer
 const estimate = await client.estimateTransactionFee({
   transaction: tx,
-  signer_key: "4gBe...xyz"  // Public key of preferred signer (one of the signers in the signer pool)
+  signer_key: signer  // Public key of preferred signer (one of the signers in the signer pool)
 });
 
 // Sign with same signer
 const signed = await client.signTransaction({
   transaction: tx,
-  signer_key: "4gBe...xyz"  // Same signer for consistency
+  signer_key: signer  // Same signer for consistency
 });
 ```
 

--- a/sdks/ts/README.md
+++ b/sdks/ts/README.md
@@ -97,6 +97,12 @@ Get the current Kora configuration.
 const config = await client.getConfig();
 ```
 
+#### `getPayerSigner()`
+Get the payer signer and payment destination.
+```typescript
+const { signer, payment_destination } = await client.getPayerSigner();
+```
+
 #### `getSupportedTokens()`
 Get list of supported tokens.
 ```typescript

--- a/sdks/ts/src/client.ts
+++ b/sdks/ts/src/client.ts
@@ -16,6 +16,7 @@ import {
     RpcRequest,
     AuthenticationHeaders,
     KoraClientOptions,
+    GetPayerSignerResponse,
 } from './types/index.js';
 import crypto from 'crypto';
 
@@ -122,6 +123,17 @@ export class KoraClient {
      */
     async getConfig(): Promise<Config> {
         return this.rpcRequest<Config, undefined>('getConfig', undefined);
+    }
+
+    /**
+     * Retrieves the payer signer and payment destination from the Kora server.
+     * @returns Object containing the payer signer and payment destination
+     * @throws {Error} When the RPC call fails
+     *
+     * @example
+     */
+    async getPayerSigner(): Promise<GetPayerSignerResponse> {
+        return this.rpcRequest<GetPayerSignerResponse, undefined>('getPayerSigner', undefined);
     }
 
     /**

--- a/sdks/ts/src/types/index.ts
+++ b/sdks/ts/src/types/index.ts
@@ -149,9 +149,9 @@ export interface EstimateTransactionFeeResponse {
  */
 export interface GetPayerSignerResponse {
     /** Public key of the payer signer */
-    signer: string;
+    signer_address: string;
     /** Public key of the payment destination */
-    payment_destination: string;
+    payment_address: string;
 }
 
 /**

--- a/sdks/ts/src/types/index.ts
+++ b/sdks/ts/src/types/index.ts
@@ -145,6 +145,16 @@ export interface EstimateTransactionFeeResponse {
 }
 
 /**
+ * Response containing the payer signer and payment destination.
+ */
+export interface GetPayerSignerResponse {
+    /** Public key of the payer signer */
+    signer: string;
+    /** Public key of the payment destination */
+    payment_destination: string;
+}
+
+/**
  * Configuration Types
  */
 

--- a/sdks/ts/test/integration.test.ts
+++ b/sdks/ts/test/integration.test.ts
@@ -79,9 +79,9 @@ describe(`KoraClient Integration Tests (${AUTH_ENABLED ? 'with auth' : 'without 
         });
 
         it('should get payer signer', async () => {
-            const { signer, payment_destination } = await client.getPayerSigner();
-            expect(signer).toBeDefined();
-            expect(payment_destination).toBeDefined();
+            const { signer_address, payment_address } = await client.getPayerSigner();
+            expect(signer_address).toBeDefined();
+            expect(payment_address).toBeDefined();
         });
 
         it('should get supported tokens', async () => {

--- a/sdks/ts/test/integration.test.ts
+++ b/sdks/ts/test/integration.test.ts
@@ -78,6 +78,12 @@ describe(`KoraClient Integration Tests (${AUTH_ENABLED ? 'with auth' : 'without 
             expect(config.enabled_methods.sign_transaction_if_paid).toBeDefined();
         });
 
+        it('should get payer signer', async () => {
+            const { signer, payment_destination } = await client.getPayerSigner();
+            expect(signer).toBeDefined();
+            expect(payment_destination).toBeDefined();
+        });
+
         it('should get supported tokens', async () => {
             const { tokens } = await client.getSupportedTokens();
             expect(Array.isArray(tokens)).toBe(true);

--- a/sdks/ts/test/unit.test.ts
+++ b/sdks/ts/test/unit.test.ts
@@ -4,6 +4,7 @@ import {
     EstimateTransactionFeeRequest,
     GetBlockhashResponse,
     GetSupportedTokensResponse,
+    GetPayerSignerResponse,
     SignTransactionRequest,
     SignTransactionResponse,
     SignAndSendTransactionRequest,
@@ -170,6 +171,27 @@ describe('KoraClient Unit Tests', () => {
             };
 
             await testSuccessfulRpcMethod('getSupportedTokens', () => client.getSupportedTokens(), mockResponse);
+        });
+    });
+
+    describe('getPayerSigner', () => {
+        it('should return payer signer and payment destination', async () => {
+            const mockResponse: GetPayerSignerResponse = {
+                signer: 'DemoKMZWkk483QoFPLRPQ2XVKB7bWnuXwSjvDE1JsWk7',
+                payment_destination: 'PayKMZWkk483QoFPLRPQ2XVKB7bWnuXwSjvDE1JsWk7',
+            };
+
+            await testSuccessfulRpcMethod('getPayerSigner', () => client.getPayerSigner(), mockResponse);
+        });
+
+        it('should return same address for signer and payment_destination when no separate paymaster', async () => {
+            const mockResponse: GetPayerSignerResponse = {
+                signer: 'DemoKMZWkk483QoFPLRPQ2XVKB7bWnuXwSjvDE1JsWk7',
+                payment_destination: 'DemoKMZWkk483QoFPLRPQ2XVKB7bWnuXwSjvDE1JsWk7',
+            };
+
+            await testSuccessfulRpcMethod('getPayerSigner', () => client.getPayerSigner(), mockResponse);
+            expect(mockResponse.signer).toBe(mockResponse.payment_destination);
         });
     });
 

--- a/sdks/ts/test/unit.test.ts
+++ b/sdks/ts/test/unit.test.ts
@@ -177,8 +177,8 @@ describe('KoraClient Unit Tests', () => {
     describe('getPayerSigner', () => {
         it('should return payer signer and payment destination', async () => {
             const mockResponse: GetPayerSignerResponse = {
-                signer: 'DemoKMZWkk483QoFPLRPQ2XVKB7bWnuXwSjvDE1JsWk7',
-                payment_destination: 'PayKMZWkk483QoFPLRPQ2XVKB7bWnuXwSjvDE1JsWk7',
+                signer_address: 'DemoKMZWkk483QoFPLRPQ2XVKB7bWnuXwSjvDE1JsWk7',
+                payment_address: 'PayKMZWkk483QoFPLRPQ2XVKB7bWnuXwSjvDE1JsWk7',
             };
 
             await testSuccessfulRpcMethod('getPayerSigner', () => client.getPayerSigner(), mockResponse);
@@ -186,12 +186,12 @@ describe('KoraClient Unit Tests', () => {
 
         it('should return same address for signer and payment_destination when no separate paymaster', async () => {
             const mockResponse: GetPayerSignerResponse = {
-                signer: 'DemoKMZWkk483QoFPLRPQ2XVKB7bWnuXwSjvDE1JsWk7',
-                payment_destination: 'DemoKMZWkk483QoFPLRPQ2XVKB7bWnuXwSjvDE1JsWk7',
+                signer_address: 'DemoKMZWkk483QoFPLRPQ2XVKB7bWnuXwSjvDE1JsWk7',
+                payment_address: 'DemoKMZWkk483QoFPLRPQ2XVKB7bWnuXwSjvDE1JsWk7',
             };
 
             await testSuccessfulRpcMethod('getPayerSigner', () => client.getPayerSigner(), mockResponse);
-            expect(mockResponse.signer).toBe(mockResponse.payment_destination);
+            expect(mockResponse.signer_address).toBe(mockResponse.payment_address);
         });
     });
 

--- a/tests/integration/rpc_integration_tests.rs
+++ b/tests/integration/rpc_integration_tests.rs
@@ -297,6 +297,19 @@ async fn test_get_config() {
 }
 
 #[tokio::test]
+async fn test_get_payer_signer() {
+    let client = ClientTestHelper::get_test_client().await;
+
+    let response: serde_json::Value =
+        client.request("getPayerSigner", rpc_params![]).await.expect("Failed to get payer signer");
+    assert!(response["signer"].as_str().is_some(), "Expected signer in response");
+    assert!(
+        response["payment_destination"].as_str().is_some(),
+        "Expected payment_destination in response"
+    );
+}
+
+#[tokio::test]
 async fn test_sign_transaction_if_paid() {
     let client = ClientTestHelper::get_test_client().await;
     let rpc_client = RPCTestHelper::get_rpc_client().await;

--- a/tests/integration/rpc_integration_tests.rs
+++ b/tests/integration/rpc_integration_tests.rs
@@ -302,11 +302,8 @@ async fn test_get_payer_signer() {
 
     let response: serde_json::Value =
         client.request("getPayerSigner", rpc_params![]).await.expect("Failed to get payer signer");
-    assert!(response["signer"].as_str().is_some(), "Expected signer in response");
-    assert!(
-        response["payment_destination"].as_str().is_some(),
-        "Expected payment_destination in response"
-    );
+    assert!(response["signer_address"].as_str().is_some(), "Expected signer_address in response");
+    assert!(response["payment_address"].as_str().is_some(), "Expected payment_address in response");
 }
 
 #[tokio::test]

--- a/tests/multi-signers/multi_signer_tests.rs
+++ b/tests/multi-signers/multi_signer_tests.rs
@@ -21,11 +21,8 @@ async fn test_multi_signer_get_payer_signer() {
 
     let response: serde_json::Value =
         client.request("getPayerSigner", rpc_params![]).await.expect("Failed to get payer signer");
-    assert!(response["signer"].as_str().is_some(), "Expected signer in response");
-    assert!(
-        response["payment_destination"].as_str().is_some(),
-        "Expected payment_destination in response"
-    );
+    assert!(response["signer_address"].as_str().is_some(), "Expected signer_address in response");
+    assert!(response["payment_address"].as_str().is_some(), "Expected payment_address in response");
 }
 
 #[tokio::test]

--- a/tests/multi-signers/multi_signer_tests.rs
+++ b/tests/multi-signers/multi_signer_tests.rs
@@ -14,6 +14,20 @@ async fn test_multi_signer_get_config() {
     assert!(response["fee_payers"].is_array());
     assert!(response["fee_payers"].as_array().unwrap().len() == 2);
 }
+
+#[tokio::test]
+async fn test_multi_signer_get_payer_signer() {
+    let client = ClientTestHelper::get_test_client().await;
+
+    let response: serde_json::Value =
+        client.request("getPayerSigner", rpc_params![]).await.expect("Failed to get payer signer");
+    assert!(response["signer"].as_str().is_some(), "Expected signer in response");
+    assert!(
+        response["payment_destination"].as_str().is_some(),
+        "Expected payment_destination in response"
+    );
+}
+
 #[tokio::test]
 async fn test_multi_signer_round_robin_behavior() {
     let client = ClientTestHelper::get_test_client().await;

--- a/tests/src/common/fixtures/auth-test.toml
+++ b/tests/src/common/fixtures/auth-test.toml
@@ -21,6 +21,7 @@ sign_and_send_transaction = true
 transfer_transaction = true
 get_blockhash = true
 get_config = true
+get_payer_signer = true
 sign_transaction_if_paid = true
 
 [validation]

--- a/tests/src/common/fixtures/kora-test.toml
+++ b/tests/src/common/fixtures/kora-test.toml
@@ -19,6 +19,7 @@ sign_and_send_transaction = true
 transfer_transaction = true
 get_blockhash = true
 get_config = true
+get_payer_signer = true
 sign_transaction_if_paid = true
 
 [validation]

--- a/tests/src/common/fixtures/paymaster-address-test.toml
+++ b/tests/src/common/fixtures/paymaster-address-test.toml
@@ -18,6 +18,7 @@ sign_and_send_transaction = true
 transfer_transaction = true
 get_blockhash = true
 get_config = true
+get_payer_signer = true
 sign_transaction_if_paid = true
 
 [validation]


### PR DESCRIPTION
Implements a new RPC method `getPayerSigner()` that returns the recommended signer address and payment destination based on the configured signer selection strategy.

### Problem

Previously, clients had to manually select a signer from the configuration, either randomly or by hardcoding, which bypassed the intended signer selection strategies (round-robin, weighted, random).

###  Solution

- Added getPayerSigner() RPC method that leverages the existing SignerPool.get_next_signer() functionality
- Returns both signer address and payment_destination address
- Payment destination defaults to signer address unless a separate payment_address is configured

### Testing

Added some basic tests consistent w/ existing test suite--should enhance w/ bigger testing PR. 


<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Introduces `getPayerSigner()` RPC method to streamline signer and payment destination retrieval, updating SDK, tests, and documentation accordingly.
> 
>   - **Behavior**:
>     - Adds `getPayerSigner()` RPC method in `get_payer_signer.rs` to return recommended signer and payment destination.
>     - Defaults payment destination to signer address if no separate address is configured.
>   - **Configuration**:
>     - Updates `EnabledMethods` in `config.rs` to include `get_payer_signer`.
>     - Adds `get_payer_signer` to default enabled methods in `auth-test.toml`, `kora-test.toml`, and `paymaster-address-test.toml`.
>   - **SDK**:
>     - Adds `getPayerSigner()` method to `client.ts`.
>     - Updates `GetPayerSignerResponse` in `types/index.ts`.
>     - Adds tests for `getPayerSigner()` in `unit.test.ts` and `integration.test.ts`.
>   - **Documentation**:
>     - Updates `SIGNERS.md` and `README.md` to include `getPayerSigner()` usage.
>   - **Testing**:
>     - Adds integration tests in `rpc_integration_tests.rs` and `multi_signer_tests.rs` for `getPayerSigner()` functionality.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=solana-foundation%2Fkora&utm_source=github&utm_medium=referral)<sup> for 13560e1eb0fc1732abc16c0369d75ed6a17af772. You can [customize](https://app.ellipsis.dev/solana-foundation/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->