### PR TITLE
bugfix (PRO-250): Improve error handling for account retrieval

### DIFF
--- a/crates/lib/src/error.rs
+++ b/crates/lib/src/error.rs
@@ -62,7 +62,14 @@ pub enum KoraError {
 
 impl From<ClientError> for KoraError {
     fn from(e: ClientError) -> Self {
-        KoraError::RpcError(e.to_string())
+        let error_string = e.to_string();
+        if error_string.contains("AccountNotFound")
+            || error_string.contains("could not find account")
+        {
+            KoraError::AccountNotFound(error_string)
+        } else {
+            KoraError::RpcError(error_string)
+        }
     }
 }
 

--- a/crates/lib/src/rpc_server/method/transfer_transaction.rs
+++ b/crates/lib/src/rpc_server/method/transfer_transaction.rs
@@ -148,13 +148,18 @@ pub async fn transfer_transaction(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tests::common::{
-        setup_or_get_test_config, setup_or_get_test_signer, RpcMockBuilder,
+    use crate::{
+        state::update_config,
+        tests::{
+            common::{setup_or_get_test_signer, RpcMockBuilder},
+            config_mock::ConfigMockBuilder,
+        },
     };
 
     #[tokio::test]
     async fn test_transfer_transaction_invalid_source() {
-        let _ = setup_or_get_test_config();
+        let config = ConfigMockBuilder::new().build();
+        update_config(config).expect("Failed to set clean config");
         let _ = setup_or_get_test_signer();
 
         let rpc_client = Arc::new(RpcMockBuilder::new().build());
@@ -182,7 +187,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_transfer_transaction_invalid_destination() {
-        let _ = setup_or_get_test_config();
+        let config = ConfigMockBuilder::new().build();
+        update_config(config).expect("Failed to set clean config");
         let _ = setup_or_get_test_signer();
 
         let rpc_client = Arc::new(RpcMockBuilder::new().build());
@@ -209,7 +215,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_transfer_transaction_invalid_token() {
-        let _ = setup_or_get_test_config();
+        let config = ConfigMockBuilder::new().build();
+        update_config(config).expect("Failed to set clean config");
         let _ = setup_or_get_test_signer();
 
         let rpc_client = Arc::new(RpcMockBuilder::new().build());

--- a/crates/lib/src/validator/account_validator.rs
+++ b/crates/lib/src/validator/account_validator.rs
@@ -115,9 +115,7 @@ pub async fn validate_account(
     account_pubkey: &Pubkey,
     expected_account_type: Option<AccountType>,
 ) -> Result<(), KoraError> {
-    let account = CacheUtil::get_account(rpc_client, account_pubkey, false).await.map_err(|e| {
-        KoraError::InternalServerError(format!("Failed to get account {account_pubkey}: {e}"))
-    })?;
+    let account = CacheUtil::get_account(rpc_client, account_pubkey, false).await?;
 
     if let Some(expected_type) = expected_account_type {
         expected_type.validate_account_type(&account, account_pubkey)?;
@@ -372,7 +370,8 @@ mod tests {
         let result =
             validate_account(&rpc_client, &account_pubkey, Some(AccountType::System)).await;
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("Failed to get account"));
+        let error_msg = result.unwrap_err().to_string();
+        assert!(error_msg.contains("Account") && error_msg.contains("not found"));
     }
 
     #[tokio::test]

--- a/crates/lib/src/validator/config_validator.rs
+++ b/crates/lib/src/validator/config_validator.rs
@@ -746,7 +746,7 @@ mod tests {
         // Should have token validation errors (account not found), but no program validation errors
         assert!(errors.iter().any(|e| e.contains("Token")
             && e.contains("validation failed")
-            && e.contains("AccountNotFound")));
+            && e.contains("not found")));
         assert!(!errors.iter().any(|e| e.contains("Program") && e.contains("validation failed")));
     }
 
@@ -829,7 +829,7 @@ mod tests {
         let result = ConfigValidator::validate_with_result(&rpc_client, false).await;
         assert!(result.is_err());
         let errors = result.unwrap_err();
-        assert!(errors.iter().any(|e| e.contains("Failed to get account")));
+        assert!(errors.len() >= 2, "Should have validation errors for programs and tokens");
     }
 
     #[tokio::test]


### PR DESCRIPTION
- Update `CacheUtil::get_account` to return `AccountNotFound` error instead of `InternalServerError` when an account is not found.
- Refactor error conversion in `KoraError` to handle account not found scenarios more gracefully.
- Adjust tests to validate the new error handling behavior for account retrieval and fee estimation processes.