### PR TITLE
chore: Update GitHub Actions workflow for coverage badge handling

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,19 +1,14 @@
 name: Update Coverage Badge
 
 on:
-  pull_request:
-    branches:
-      - main
   workflow_run:
     workflows: ["Rust CI"]
     types:
       - completed
-    branches:
-      - main
 
 jobs:
   update-badge:
-    if: github.event_name == 'pull_request' || github.event.workflow_run.conclusion == 'success'
+    if: github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -21,7 +16,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event_name == 'pull_request' && github.head_ref || 'main' }}
+          ref: ${{ github.event.workflow_run.head_branch }}
 
       - name: Download coverage artifacts
         uses: actions/download-artifact@v4
@@ -60,16 +55,19 @@ jobs:
           mkdir -p .github/badges
           echo "{\"schemaVersion\": 1, \"label\": \"coverage\", \"message\": \"${COVERAGE}%\", \"color\": \"$COLOR\"}" > .github/badges/coverage.json
           
-          # For PRs: commit and push badge to PR branch
-          # For main: no-op (badge already updated via PR merge)
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
+          # Only commit and push badge updates for non-main branches (PRs)
+          # For main branch, the badge will be updated when the PR merges
+          if [ "${{ github.event.workflow_run.head_branch }}" != "main" ]; then
             git config user.name github-actions
             git config user.email github-actions@github.com
             git add .github/badges/coverage.json
             if ! git diff --staged --quiet; then
               git commit -m "Update coverage badge [skip ci]"
-              git push
+              # Push to the PR branch
+              git push origin HEAD:${{ github.event.workflow_run.head_branch }}
+            else
+              echo "✅ No changes to coverage badge"
             fi
           else
-            echo "✅ Badge already updated via PR merge - no action needed"
+            echo "✅ Running on main branch - badge updates happen via PR merges"
           fi

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,6 +1,9 @@
 name: Update Coverage Badge
 
 on:
+  pull_request:
+    branches:
+      - main
   workflow_run:
     workflows: ["Rust CI"]
     types:
@@ -10,7 +13,7 @@ on:
 
 jobs:
   update-badge:
-    if: github.event.workflow_run.conclusion == 'success'
+    if: github.event_name == 'pull_request' || github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -18,7 +21,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          ref: main
+          ref: ${{ github.event_name == 'pull_request' && github.head_ref || 'main' }}
 
       - name: Download coverage artifacts
         uses: actions/download-artifact@v4
@@ -57,8 +60,16 @@ jobs:
           mkdir -p .github/badges
           echo "{\"schemaVersion\": 1, \"label\": \"coverage\", \"message\": \"${COVERAGE}%\", \"color\": \"$COLOR\"}" > .github/badges/coverage.json
           
-          # Commit and push the badge file
-          git config user.name github-actions
-          git config user.email github-actions@github.com
-          git add .github/badges/coverage.json
-          git diff --staged --quiet || (git commit -m "Update coverage badge [skip ci]" && git push)
+          # For PRs: commit and push badge to PR branch
+          # For main: no-op (badge already updated via PR merge)
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            git config user.name github-actions
+            git config user.email github-actions@github.com
+            git add .github/badges/coverage.json
+            if ! git diff --staged --quiet; then
+              git commit -m "Update coverage badge [skip ci]"
+              git push
+            fi
+          else
+            echo "✅ Badge already updated via PR merge - no action needed"
+          fi


### PR DESCRIPTION
- Modify coverage.yml to trigger on pull requests to main.
- Adjust badge update logic to commit and push to the PR branch for pull requests, while ensuring no action is taken for merges to main.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Update GitHub Actions workflow to handle coverage badge updates for pull requests and merges differently.
> 
>   - **Workflow Trigger**:
>     - Modify `.github/workflows/coverage.yml` to trigger on pull requests to `main` instead of only on `main` branch.
>   - **Badge Update Logic**:
>     - Adjust logic to commit and push badge updates to the PR branch for pull requests.
>     - Ensure no badge update action is taken for merges to `main`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=solana-foundation%2Fkora&utm_source=github&utm_medium=referral)<sup> for ae292303d07cef88ce3c944bd7bcdcca9cc747ef. You can [customize](https://app.ellipsis.dev/solana-foundation/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->