### PR TITLE
chore: (PRO-248) add Compute Budget Program to examples

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -338,6 +338,8 @@ allowed_programs = [
     "11111111111111111111111111111111",      # System Program
     "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",  # Token Program
     "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL",  # Associated Token Program
+    "AddressLookupTab1e1111111111111111111111111",   # Address Lookup Table Program
+    "ComputeBudget11111111111111111111111111111111", # Compute Budget Program
 ]
 
 # Supported tokens for fee payment (by mint address)

--- a/docs/getting-started/QUICK_START.md
+++ b/docs/getting-started/QUICK_START.md
@@ -187,7 +187,9 @@ Kora Config: {
     allowed_programs: [
       '11111111111111111111111111111111',
       'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA',
-      'ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL'
+      'ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL',
+      'AddressLookupTab1e1111111111111111111111111',
+      'ComputeBudget11111111111111111111111111111111'
     ],
     allowed_tokens: [
       'usdCAEFbouFGxdkbHCRtMTcN7DJHd3aCmP9vqjLgmAp' 

--- a/docs/operators/CONFIGURATION.md
+++ b/docs/operators/CONFIGURATION.md
@@ -169,6 +169,7 @@ allowed_programs = [
     "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb",   # Token-2022 Program
     "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL",  # Associated Token Program
     "AddressLookupTab1e1111111111111111111111111",   # Address Lookup Table Program
+    "ComputeBudget11111111111111111111111111111111", # Compute Budget Program
 ]
 allowed_tokens = [
     "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",  # USDC (mainnet)
@@ -193,7 +194,7 @@ disallowed_accounts = [
 | `allowed_spl_paid_tokens` | SPL tokens accepted as payment for transaction fees | ✅ | Array of b58-encoded string |
 | `disallowed_accounts` | Accounts that are explicitly blocked from transactions | ✅ | Array of b58-encoded string |
 
-> *Note: Empty arrays are allowed, but you will need to specify at least one whitelisted `allowed_programs`, `allowed_tokens`, `allowed_spl_paid_tokens` for the Kora node to be able to process transactions. You need to specify the System Program or Token Program for the Kora node to be able to process transfers.*
+> *Note: Empty arrays are allowed, but you will need to specify at least one whitelisted `allowed_programs`, `allowed_tokens`, `allowed_spl_paid_tokens` for the Kora node to be able to process transactions. You need to specify the System Program or Token Program for the Kora node to be able to process transfers. To enable common instruction types (e.g., Compute Budget, Address Lookup Table), you need to specify the Compute Budget Program or Address Lookup Table Program, etc.*
 
 ## Token-2022 Extension Blocking
 
@@ -406,6 +407,8 @@ allowed_programs = [
     "11111111111111111111111111111111",              # System Program
     "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",   # SPL Token
     "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL",  # Associated Token
+    "AddressLookupTab1e1111111111111111111111111",   # Address Lookup Table
+    "ComputeBudget11111111111111111111111111111111", # Compute Budget
     "MyProgram111111111111111111111111111111111", 
     # Add your specific program IDs here
 ]

--- a/docs/operators/deploy/sample/kora.toml
+++ b/docs/operators/deploy/sample/kora.toml
@@ -14,14 +14,15 @@ price_source = "Mock"
 max_allowed_lamports = 1000000
 max_signatures = 10
 allowed_programs = [
-    "11111111111111111111111111111111",             # System Program
-    "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",  # Token Program
-    "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL", # Associated Token Program
-    "AddressLookupTab1e1111111111111111111111111",  # Address Lookup Table Program
+    "11111111111111111111111111111111",              # System Program
+    "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",   # Token Program
+    "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL",  # Associated Token Program
+    "AddressLookupTab1e1111111111111111111111111",   # Address Lookup Table Program
+    "ComputeBudget11111111111111111111111111111111", # Compute Budget Program
 ]
 allowed_tokens = [
     "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v", # mainnet USDC
-    "So11111111111111111111111111111111111111112", # SOL
+    "So11111111111111111111111111111111111111112",  # SOL
     "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU", # devnet USDC
 ]
 allowed_spl_paid_tokens = [

--- a/kora.toml
+++ b/kora.toml
@@ -29,9 +29,11 @@ max_signatures = 10
 price_source = "Mock"
 
 allowed_programs = [
-    "11111111111111111111111111111111",             # System Program
-    "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",  # Token Program
-    "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL", # Associated Token Program
+    "11111111111111111111111111111111",              # System Program
+    "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",   # Token Program
+    "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL",  # Associated Token Program
+    "AddressLookupTab1e1111111111111111111111111",   # Address Lookup Table Program
+    "ComputeBudget11111111111111111111111111111111", # Compute Budget Program
 ]
 allowed_tokens = [
     "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v", # USDC


### PR DESCRIPTION
Nit: add Compute Budget program to sample tomls for clarity that it' must be explicitly declared in order to use CU/priority fee instructions
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add Compute Budget Program to configuration files for explicit declaration in CU/priority fee instructions.
> 
>   - **Configuration**:
>     - Add `ComputeBudget11111111111111111111111111111111` to `allowed_programs` in `CLAUDE.md`, `QUICK_START.md`, `CONFIGURATION.md`, and `kora.toml`.
>     - Update `kora.toml` in `sample/kora.toml` to include Compute Budget Program.
>   - **Documentation**:
>     - Update comments in `CONFIGURATION.md` to reflect the need for specifying Compute Budget Program for common instruction types.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=solana-foundation%2Fkora&utm_source=github&utm_medium=referral)<sup> for f80abf56859d88aa2e23df8e95fffa981dd95a67. You can [customize](https://app.ellipsis.dev/solana-foundation/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->