### PR TITLE
chore/Fix Kora server cleanup in test integration makefile

### DIFF
--- a/makefiles/UTILS.makefile
+++ b/makefiles/UTILS.makefile
@@ -128,14 +128,18 @@ define stop_kora_server
 	@if [ -f .kora.pid ]; then \
 		PID=$$(cat .kora.pid); \
 		if kill -0 $$PID 2>/dev/null; then \
-			kill $$PID 2>/dev/null || true; \
-			sleep 1; \
-			kill -9 $$PID 2>/dev/null || true; \
+			kill -TERM $$PID 2>/dev/null || true; \
+			sleep 2; \
+			if kill -0 $$PID 2>/dev/null; then \
+				kill -9 $$PID 2>/dev/null || true; \
+			fi; \
 		fi; \
 		rm -f .kora.pid; \
 	fi; \
-	pkill -f "kora" 2>/dev/null || true; \
-	sleep 2
+	pkill -f "kora.*rpc.*start" 2>/dev/null || true; \
+	sleep 1; \
+	lsof -ti:$(TEST_PORT) | xargs kill -9 2>/dev/null || true; \
+	sleep 1
 endef
 
 define run_integration_phase


### PR DESCRIPTION
- Improve `stop_kora_server` function to properly terminate server processes after test runs
- Replace broad pkill pattern with more specific targeting to avoid killing unrelated processes
- Add port-based cleanup as fallback to ensure no processes remain on test port 8080
- Use graceful shutdown (SIGTERM) before force kill (SIGKILL) for cleaner process termination

## Problem
The previous implementation used `pkill -f "kora"` which was too broad and could miss the actual server process, leaving it running after test-integration completed. @dev-jodee pretty sure this was causing the `make test-all` w/ the TS test...the Kora server was staying open after `test-integration`.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Improve `stop_kora_server` in `UTILS.makefile` for precise and graceful termination of Kora server processes after tests.
> 
>   - **Behavior**:
>     - Improve `stop_kora_server` in `UTILS.makefile` to ensure proper termination of Kora server processes after tests.
>     - Replace `pkill -f "kora"` with `pkill -f "kora.*rpc.*start"` for more specific process targeting.
>     - Add port-based cleanup using `lsof -ti:$(TEST_PORT)` to kill processes on port 8080.
>     - Use SIGTERM before SIGKILL for graceful shutdown.
>   - **Problem**:
>     - Previous implementation could miss server processes, leaving them running after tests.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=solana-foundation%2Fkora&utm_source=github&utm_medium=referral)<sup> for a5930792c1764038f83b3e64b0c549595573e833. You can [customize](https://app.ellipsis.dev/solana-foundation/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->