### PR TITLE
chore: Improved test efficiency

### DIFF
--- a/.github/badges/coverage.json
+++ b/.github/badges/coverage.json
@@ -1,1 +1,1 @@
-{"schemaVersion": 1, "label": "coverage", "message": "86.3%", "color": "green"}
+{"schemaVersion": 1, "label": "coverage", "message": "26.2%", "color": "red"}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -22,13 +22,10 @@ env:
   CI: true
 
 jobs:
-  test:
-    name: Rust Tests & Coverage
+  build-and-lint:
+    name: Build & Lint
     runs-on: ubuntu-latest
-    timeout-minutes: 30
-    permissions:
-      contents: read
-      pull-requests: write
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -41,135 +38,207 @@ jobs:
         run: make lint
       - name: Build
         run: make build
-      
-      - name: Setup Solana CLI
-        uses: ./.github/actions/setup-solana
 
-      - name: Install cargo-llvm-cov for coverage
+  unit-tests:
+    name: Unit Tests
+    needs: build-and-lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
+      - uses: Swatinem/rust-cache@v2
+      - name: Install cargo-llvm-cov
         run: cargo install cargo-llvm-cov
-
       - name: Run unit tests with coverage
         run: |
           echo "🧪 Running unit tests with coverage instrumentation..."
           cargo llvm-cov clean --workspace
           cargo llvm-cov test --no-report --workspace --lib
+      - name: Generate unit test coverage
+        run: |
+          mkdir -p coverage
+          cargo llvm-cov report --lcov --output-path coverage/unit-lcov.info
+      - name: Upload unit test coverage
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-unit
+          path: coverage/unit-lcov.info
+          retention-days: 1
 
+  integration-tests:
+    name: Integration Tests
+    needs: build-and-lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        test:
+          - name: "rpc"
+            config: "tests/src/common/fixtures/kora-test.toml"
+            signers: "tests/src/common/fixtures/signers.toml"
+            init_atas: false
+            setup_multi: false
+          - name: "tokens"
+            config: "tests/src/common/fixtures/kora-test.toml"
+            signers: "tests/src/common/fixtures/signers.toml"
+            init_atas: false
+            setup_multi: false
+          - name: "external"
+            config: "tests/src/common/fixtures/kora-test.toml"
+            signers: "tests/src/common/fixtures/signers.toml"
+            init_atas: false
+            setup_multi: false
+          - name: "auth"
+            config: "tests/src/common/fixtures/auth-test.toml"
+            signers: "tests/src/common/fixtures/signers.toml"
+            init_atas: false
+            setup_multi: false
+          - name: "payment_address"
+            config: "tests/src/common/fixtures/paymaster-address-test.toml"
+            signers: "tests/src/common/fixtures/signers.toml"
+            init_atas: true
+            setup_multi: false
+          - name: "multi_signer"
+            config: "tests/src/common/fixtures/kora-test.toml"
+            signers: "tests/src/common/fixtures/multi-signers.toml"
+            init_atas: false
+            setup_multi: true
+    env:
+      TEST_SERVER_URL: http://127.0.0.1:8080
+    steps:
+      - uses: actions/checkout@v4
+      
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
+          
+      - uses: Swatinem/rust-cache@v2
+      
+      - name: Setup Solana CLI
+        uses: ./.github/actions/setup-solana
+        
+      - name: Install cargo-llvm-cov
+        run: cargo install cargo-llvm-cov
+        
       - name: Setup Solana test validator
         uses: ./.github/actions/setup-solana-validator
-
-      - name: Setup test environment
+        
+      - name: Create multi-signer key if needed
+        if: matrix.test.setup_multi
         run: |
-          echo "🔧 Setting up test environment..."
-          # Create second signer key for multi-signer tests
           if [ ! -f "tests/src/common/local-keys/signer2-local.json" ]; then
             echo "Creating second signer key..."
             solana-keygen new --outfile tests/src/common/local-keys/signer2-local.json --no-bip39-passphrase --silent
           fi
-          KORA_PRIVATE_KEY="$(cat tests/src/common/local-keys/fee-payer-local.json)" cargo run -p tests --bin setup_test_env
-
-      - name: Setup Kora RPC server (regular config)
-        uses: ./.github/actions/setup-kora-rpc
-        with:
-          config-file: "tests/src/common/fixtures/kora-test.toml"
-
-      - name: Run RPC integration tests
+          
+      - name: Setup test environment
         run: |
-          echo "🧪 Running RPC integration tests..."
-          cargo llvm-cov test --no-report -p tests --test rpc
-
-      - name: Run token integration tests
-        run: |
-          echo "🧪 Running token integration tests..."
-          cargo llvm-cov test --no-report -p tests --test tokens
-
-      - name: Run external integration tests
-        run: |
-          echo "🧪 Running external integration tests..."
-          cargo llvm-cov test --no-report -p tests --test external
-
-      - name: Stop Kora RPC server
-        run: |
-          if [ ! -z "$KORA_PID" ]; then
-            kill $KORA_PID || true
+          echo "🔧 Setting up test environment for ${{ matrix.test.name }}..."
+          if [ "${{ matrix.test.setup_multi }}" = "true" ]; then
+            export KORA_PRIVATE_KEY="$(cat tests/src/common/local-keys/fee-payer-local.json)"
+            export KORA_PRIVATE_KEY_2="$(cat tests/src/common/local-keys/signer2-local.json)"
+            cargo run -p tests --bin setup_test_env
+          else
+            KORA_PRIVATE_KEY="$(cat tests/src/common/local-keys/fee-payer-local.json)" cargo run -p tests --bin setup_test_env
           fi
-          sleep 2
-
-      - name: Setup Kora RPC server (auth config)
+          
+      - name: Setup Kora RPC server
         uses: ./.github/actions/setup-kora-rpc
         with:
-          config-file: "tests/src/common/fixtures/auth-test.toml"
-
-      - name: Run auth integration tests
+          config-file: ${{ matrix.test.config }}
+          signers-config: ${{ matrix.test.signers }}
+          initialize-atas: ${{ matrix.test.init_atas }}
+          port: "8080"
+          test-server-url: "http://127.0.0.1:8080"
+          
+      - name: Run ${{ matrix.test.name }} integration tests
         run: |
-          echo "🧪 Running auth integration tests..."
-          cargo llvm-cov test --no-report -p tests --test auth
-
-      - name: Stop Kora RPC server
+          echo "🧪 Running ${{ matrix.test.name }} integration tests..."
+          cargo llvm-cov test --no-report -p tests --test ${{ matrix.test.name }}
+          
+      - name: Generate coverage report
         run: |
-          if [ ! -z "$KORA_PID" ]; then
-            kill $KORA_PID || true
-          fi
-          sleep 2
-
-      - name: Setup Kora RPC server (payment address config)
-        uses: ./.github/actions/setup-kora-rpc
-        with:
-          config-file: "tests/src/common/fixtures/paymaster-address-test.toml"
-          initialize-atas: "true"
-
-      - name: Run payment address integration tests
-        run: |
-          echo "🧪 Running payment address integration tests..."
-          cargo llvm-cov test --no-report -p tests --test payment_address
-
-      - name: Stop Kora RPC server
-        run: |
-          if [ ! -z "$KORA_PID" ]; then
-            kill $KORA_PID || true
-          fi
-          sleep 2
-
-      - name: Setup multi-signer test environment
-        run: |
-          echo "🔧 Setting up multi-signer test environment..."
-          export KORA_PRIVATE_KEY="$(cat tests/src/common/local-keys/fee-payer-local.json)"
-          export KORA_PRIVATE_KEY_2="$(cat tests/src/common/local-keys/signer2-local.json)"
-          cargo run -p tests --bin setup_test_env
-
-      - name: Setup Kora RPC server (multi-signer config)
-        uses: ./.github/actions/setup-kora-rpc
-        with:
-          config-file: "tests/src/common/fixtures/kora-test.toml"
-          signers-config: "tests/src/common/fixtures/multi-signers.toml"
-
-      - name: Run multi-signer integration tests
-        run: |
-          echo "🧪 Running multi-signer integration tests..."
-          cargo llvm-cov test --no-report -p tests --test multi_signer
-
-      - name: Generate coverage reports
-        run: |
-          echo "📊 Generating coverage reports..."
+          echo "📊 Generating coverage report for ${{ matrix.test.name }}..."
           mkdir -p coverage
-          cargo llvm-cov report --lcov --output-path coverage/lcov.info
+          cargo llvm-cov report --lcov --output-path coverage/${{ matrix.test.name }}-lcov.info
+          
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-${{ matrix.test.name }}
+          path: coverage/${{ matrix.test.name }}-lcov.info
+          retention-days: 1
+          
+      - name: Cleanup
+        if: always()
+        uses: ./.github/actions/cleanup-test-env
+        
+      - name: Show failure logs
+        if: failure()
+        uses: ./.github/actions/show-failure-logs
+        with:
+          test-type: "${{ matrix.test.name }} integration"
 
-      - name: Display coverage summary
+  # Coverage Collection & Reporting
+  coverage-report:
+    name: Coverage Report
+    needs: [unit-tests, integration-tests]
+    runs-on: ubuntu-latest
+    if: always()
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Download all coverage artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: coverage-*
+          path: coverage-artifacts
+          merge-multiple: false
+          
+      - name: Merge coverage reports
+        run: |
+          echo "📊 Merging coverage reports..."
+          mkdir -p coverage
+          
+          # Merge all lcov files
+          find coverage-artifacts -name "*.info" -type f | while read file; do
+            echo "Processing: $file"
+            cat "$file" >> coverage/merged.info
+          done
+          
+          # Generate final report
+          if [ -f "coverage/merged.info" ]; then
+            cp coverage/merged.info coverage/lcov.info
+            echo "✅ Coverage report merged successfully"
+          else
+            echo "❌ No coverage files found"
+            touch coverage/lcov.info
+          fi
+          
+      - name: Display coverage summary  
         run: |
           echo "📊 Coverage Summary:"
-          if [ -f "coverage/lcov.info" ]; then
+          if [ -f "coverage/lcov.info" ] && [ -s "coverage/lcov.info" ]; then
             echo "✅ Coverage report generated successfully"
             echo "📄 Generated: coverage/lcov.info"
           else
-            echo "❌ Coverage report not found"
+            echo "❌ Coverage report not found or empty"
           fi
-
-      - name: Upload coverage artifacts
+          
+      - name: Upload merged coverage
         uses: actions/upload-artifact@v4
         with:
           name: rust-coverage-report
           path: coverage/
           retention-days: 30
-
+          
       - name: Update PR description with coverage badge
         if: github.event_name == 'pull_request'
         uses: actions/github-script@v7
@@ -220,12 +289,21 @@ jobs:
               body: newBody
             });
 
-      - name: Cleanup test environment
-        if: always()
-        uses: ./.github/actions/cleanup-test-env
-
-      - name: Show failure logs
-        if: failure()
-        uses: ./.github/actions/show-failure-logs
-        with:
-          test-type: "Rust integration"
+  # Final status check - ensures all tests pass
+  tests-complete:
+    name: All Tests Complete
+    needs: [unit-tests, integration-tests]
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - name: Check test results
+        run: |
+          if [[ "${{ needs.unit-tests.result }}" != "success" ||
+                "${{ needs.integration-tests.result }}" != "success" ]]; then
+            echo "❌ One or more test suites failed"
+            echo "Unit Tests: ${{ needs.unit-tests.result }}"
+            echo "Integration Tests: ${{ needs.integration-tests.result }}"
+            exit 1
+          else
+            echo "✅ All tests passed!"
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -18,8 +18,7 @@ coverage/
 .DS_Store
 
 # Make test files
-.validator.pid
-.kora.pid
+*.pid
 test-ledger/
 .local/
 tests/src/common/fixtures/lookup_tables.json

--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,9 @@ include makefiles/CLIENT.makefile
 include makefiles/DOCUMENTATION.makefile
 include makefiles/COVERAGE.makefile
 include makefiles/METRICS.makefile
+include makefiles/DEBUG_COMMANDS.makefile
 
-.PHONY: check lint test build run clean all install generate-key setup-test-env test-integration test-all test-ts coverage coverage-clean build-bin build-lib build-cli run-presigned openapi gen-ts-client run-metrics
+.PHONY: check lint test build run clean all install generate-key setup-test-env test-integration test-all test-ts coverage coverage-clean build-bin build-lib build-cli run-presigned openapi gen-ts-client run-metrics debug-test-integration debug-test-regular debug-test-token debug-test-auth debug-test-payment debug-test-multi-signer debug-test-all
 
 # Default target
 all: check test build

--- a/makefiles/BUILD.makefile
+++ b/makefiles/BUILD.makefile
@@ -1,6 +1,6 @@
 # install
 install:
-	cargo install --path crates/cli
+	cargo install --path crates/cli --bin kora
 
 # Check code formatting
 check:
@@ -27,14 +27,6 @@ build-lib:
 # Build cli
 build-cli:
 	cargo build -p kora-cli
-
-# Build tk-rs
-build-tk:
-	cargo build -p tk-rs
-
-# Run presigned release binary
-run-presigned:
-	cargo run --bin presigned
 
 # Run with default configuration
 run:

--- a/makefiles/CLIENT.makefile
+++ b/makefiles/CLIENT.makefile
@@ -1,8 +1,6 @@
 
 # Generate TypeScript client
-gen-ts-client:
-	@echo "🔧 Generating OpenAPI spec with docs feature..."
-	cargo run -p kora-cli --bin kora --features docs -- openapi -o openapi.json
+gen-ts-client: openapi
 	@echo "🚀 Generating TypeScript client..."
 	docker run --rm -v "${PWD}:/local" openapitools/openapi-generator-cli generate \
 		-i /local/crates/lib/src/rpc_server/openapi/spec/combined_api.json \

--- a/makefiles/DEBUG.makefile
+++ b/makefiles/DEBUG.makefile
@@ -1,0 +1,89 @@
+# DEBUG.makefile - Verbose test execution with debug logging
+# This makefile provides the same test functionality as the main makefiles
+# but with verbose output and RUST_LOG=debug for debugging purposes
+# 
+# Usage: make -f makefiles/DEBUG.makefile debug-test-integration
+
+# Include utils but override quiet settings
+include makefiles/UTILS.makefile
+
+# Override quiet settings for verbose output
+override QUIET_OUTPUT := 
+override TEST_OUTPUT_FILTER := 
+
+# Export RUST_LOG=debug for all subprocesses
+export RUST_LOG := debug
+
+# Clean up any existing processes before starting debug tests
+define debug_cleanup
+	@killall kora 2>/dev/null || true
+	@killall solana-test-validator 2>/dev/null || true
+endef
+
+debug-test-regular:
+	$(call print_header,DEBUG REGULAR TESTS)
+	$(debug_cleanup)
+	@$(call start_solana_validator)
+	@cargo run -p tests --bin setup_test_env
+	@$(call run_integration_phase,1,Regular Tests,$(REGULAR_CONFIG),,--test rpc,)
+	@$(call stop_solana_validator)
+
+debug-test-token:
+	$(call print_header,DEBUG TOKEN TESTS)
+	$(debug_cleanup)
+	@$(call start_solana_validator)
+	@cargo run -p tests --bin setup_test_env
+	@$(call run_integration_phase,1,Token Tests,$(REGULAR_CONFIG),,--test tokens,)
+	@$(call stop_solana_validator)
+
+debug-test-auth:
+	$(call print_header,DEBUG AUTHENTICATION TESTS)
+	$(debug_cleanup)
+	@$(call start_solana_validator)
+	@cargo run -p tests --bin setup_test_env
+	@$(call run_integration_phase,1,Authentication Tests,$(AUTH_CONFIG),,--test auth,)
+	@$(call stop_solana_validator)
+
+debug-test-payment:
+	$(call print_header,DEBUG PAYMENT ADDRESS TESTS)
+	$(debug_cleanup)
+	@$(call start_solana_validator)
+	@cargo run -p tests --bin setup_test_env
+	@$(call run_integration_phase,1,Payment Address Tests,$(PAYMENT_ADDRESS_CONFIG),,--test payment_address,true)
+	@$(call stop_solana_validator)
+
+debug-test-multi-signer:
+	$(call print_header,DEBUG Multi-Signer Test Suite)
+	$(debug_cleanup)
+	@$(call start_solana_validator)
+	@$(call run_multi_signer_phase,1,Multi-Signer Tests,$(REGULAR_CONFIG),$(MULTI_SIGNERS_CONFIG),--test multi-signer)
+	@$(call stop_solana_validator)
+
+debug-test-integration:
+	$(call print_header,DEBUG KORA INTEGRATION TEST SUITE)
+	$(debug_cleanup)
+	$(call print_step,Initializing test infrastructure with debug logging)
+	@$(call start_solana_validator)
+	$(call print_substep,Setting up base test environment (DEBUG)...)
+	@KORA_PRIVATE_KEY="$$(cat tests/src/common/local-keys/fee-payer-local.json)" cargo run -p tests --bin setup_test_env
+	$(call print_success,Infrastructure ready)
+	
+	@$(call run_integration_phase,1,RPC tests,$(REGULAR_CONFIG),,--test rpc,)
+	@$(call run_integration_phase,2,token tests,$(REGULAR_CONFIG),,--test tokens,)
+	@$(call run_integration_phase,3,external tests,$(REGULAR_CONFIG),,--test external,)
+	@$(call run_integration_phase,4,auth tests,$(AUTH_CONFIG),,--test auth,)
+	@$(call run_integration_phase,5,payment address tests,$(PAYMENT_ADDRESS_CONFIG),,--test payment_address,true)
+	@$(call run_multi_signer_phase,6,multi-signer tests,$(REGULAR_CONFIG),$(MULTI_SIGNERS_CONFIG),--test multi_signer)
+
+	$(call print_header,DEBUG TEST SUITE COMPLETE)
+	@$(call stop_solana_validator)
+
+debug-setup-test-env:
+	$(call print_step,Setting up test environment with debug logging...)
+	@KORA_PRIVATE_KEY="$$(cat tests/src/common/local-keys/fee-payer-local.json)" \
+	cargo run -p tests --bin setup_test_env
+	$(call print_success,Test environment ready (DEBUG))
+
+debug-test-all: debug-test-integration
+
+.PHONY: debug-test-integration debug-test-regular debug-test-token debug-test-auth debug-test-payment debug-test-multi-signer debug-test-all debug-setup-test-env

--- a/makefiles/DEBUG_COMMANDS.makefile
+++ b/makefiles/DEBUG_COMMANDS.makefile
@@ -1,0 +1,24 @@
+
+# Debug test convenience targets
+debug-test-integration:
+	@make -f makefiles/DEBUG.makefile debug-test-integration
+
+debug-test-regular:
+	@make -f makefiles/DEBUG.makefile debug-test-regular
+
+debug-test-token:
+	@make -f makefiles/DEBUG.makefile debug-test-token
+
+debug-test-auth:
+	@make -f makefiles/DEBUG.makefile debug-test-auth
+
+debug-test-payment:
+	@make -f makefiles/DEBUG.makefile debug-test-payment
+
+debug-test-multi-signer:
+	@make -f makefiles/DEBUG.makefile debug-test-multi-signer
+
+debug-test-all:
+	@make -f makefiles/DEBUG.makefile debug-test-all
+
+.PHONY: debug-test-integration debug-test-regular debug-test-token debug-test-auth debug-test-payment debug-test-multi-signer debug-test-all

--- a/makefiles/METRICS.makefile
+++ b/makefiles/METRICS.makefile
@@ -13,5 +13,3 @@ update-metrics-config:
 run-metrics: update-metrics-config
 	cd crates/lib/src/metrics && docker compose -f docker-compose.metrics.yml down
 	cd crates/lib/src/metrics && docker compose -f docker-compose.metrics.yml up
-
-# install ts sdk

--- a/makefiles/RUST_TESTS.makefile
+++ b/makefiles/RUST_TESTS.makefile
@@ -5,21 +5,64 @@ test:
 # Run all integration tests with clean output
 test-integration:
 	$(call print_header,KORA INTEGRATION TEST SUITE)
-	$(call print_step,Initializing test infrastructure)
+	$(call print_step,Initializing shared test infrastructure)
 	@$(call start_solana_validator)
 	$(call print_substep,Setting up base test environment...)
-	@KORA_PRIVATE_KEY="$$(cat tests/src/common/local-keys/fee-payer-local.json)" cargo run -p tests --bin setup_test_env $(QUIET_OUTPUT)
+	@cargo run -p tests --bin setup_test_env $(QUIET_OUTPUT)
+	@if [ ! -f "tests/src/common/local-keys/signer2-local.json" ]; then \
+		$(call print_substep,Creating signer2-local.json for multi-signer tests...); \
+		solana-keygen new --outfile tests/src/common/local-keys/signer2-local.json --no-bip39-passphrase --silent; \
+	fi
+	$(call print_substep,Setting up multi-signer test environment...)
+	@KORA_PRIVATE_KEY="$$(cat tests/src/common/local-keys/fee-payer-local.json)" \
+	 KORA_PRIVATE_KEY_2="$$(cat tests/src/common/local-keys/signer2-local.json)" \
+	 cargo run -p tests --bin setup_test_env $(QUIET_OUTPUT)
 	$(call print_success,Infrastructure ready)
 	
-	@$(call run_integration_phase,1,RPC tests,$(REGULAR_CONFIG),,--test rpc,)
-	@$(call run_integration_phase,2,token tests,$(REGULAR_CONFIG),,--test tokens,)
-	@$(call run_integration_phase,3,external tests,$(REGULAR_CONFIG),,--test external,)
-	@$(call run_integration_phase,4,auth tests,$(AUTH_CONFIG),,--test auth,)
-	@$(call run_integration_phase,5,payment address tests,$(PAYMENT_ADDRESS_CONFIG),,--test payment_address,true)
-	@$(call run_multi_signer_phase,6,multi-signer tests,$(REGULAR_CONFIG),$(MULTI_SIGNERS_CONFIG),--test multi_signer)
-
-	$(call print_header,TEST SUITE COMPLETE)
+	$(call print_step,Starting all test servers in parallel...)
+	@$(call start_kora_parallel,RPC,$(REGULAR_CONFIG),$(RPC_PORT),,$(TEST_SIGNERS_CONFIG))
+	@$(call start_kora_parallel,Tokens,$(REGULAR_CONFIG),$(TOKENS_PORT),,$(TEST_SIGNERS_CONFIG))
+	@$(call start_kora_parallel,External,$(REGULAR_CONFIG),$(EXTERNAL_PORT),,$(TEST_SIGNERS_CONFIG))
+	@$(call start_kora_parallel,Auth,$(AUTH_CONFIG),$(AUTH_PORT),,$(TEST_SIGNERS_CONFIG))
+	@$(call start_kora_parallel,Payment,$(PAYMENT_ADDRESS_CONFIG),$(PAYMENT_PORT),true,$(TEST_SIGNERS_CONFIG))
+	@$(call start_kora_parallel,Multi-Signer,$(REGULAR_CONFIG),$(MULTI_SIGNER_PORT),,$(MULTI_SIGNERS_CONFIG))
+	@sleep 8
+	$(call print_success,All servers ready)
+	
+	$(call print_step,Running all test suites in parallel...)
+	$(call print_substep,RPC Tests running...)
+	$(call print_substep,Tokens Tests running...)
+	$(call print_substep,External Tests running...)
+	$(call print_substep,Auth Tests running...)
+	$(call print_substep,Payment Tests running...)
+	$(call print_substep,Multi-Signer Tests running...)
+	@START_TIME=$$(date +%s); \
+	 TEST_SERVER_URL=http://127.0.0.1:$(RPC_PORT) cargo test -p tests --test rpc --quiet >/dev/null 2>&1 & \
+	 RPC_PID=$$!; \
+	 TEST_SERVER_URL=http://127.0.0.1:$(TOKENS_PORT) cargo test -p tests --test tokens --quiet >/dev/null 2>&1 & \
+	 TOKENS_PID=$$!; \
+	 TEST_SERVER_URL=http://127.0.0.1:$(EXTERNAL_PORT) cargo test -p tests --test external --quiet >/dev/null 2>&1 & \
+	 EXTERNAL_PID=$$!; \
+	 TEST_SERVER_URL=http://127.0.0.1:$(AUTH_PORT) cargo test -p tests --test auth --quiet >/dev/null 2>&1 & \
+	 AUTH_PID=$$!; \
+	 TEST_SERVER_URL=http://127.0.0.1:$(PAYMENT_PORT) cargo test -p tests --test payment_address --quiet >/dev/null 2>&1 & \
+	 PAYMENT_PID=$$!; \
+	 TEST_SERVER_URL=http://127.0.0.1:$(MULTI_SIGNER_PORT) cargo test -p tests --test multi_signer --quiet >/dev/null 2>&1 & \
+	 MULTI_PID=$$!; \
+	 wait $$RPC_PID && printf "  $(GREEN)✓$(RESET) RPC Tests: $(GREEN)PASSED$(RESET)\n" || printf "  $(RED)✗$(RESET) RPC Tests: $(RED)FAILED$(RESET)\n"; \
+	 wait $$TOKENS_PID && printf "  $(GREEN)✓$(RESET) Tokens Tests: $(GREEN)PASSED$(RESET)\n" || printf "  $(RED)✗$(RESET) Tokens Tests: $(RED)FAILED$(RESET)\n"; \
+	 wait $$EXTERNAL_PID && printf "  $(GREEN)✓$(RESET) External Tests: $(GREEN)PASSED$(RESET)\n" || printf "  $(RED)✗$(RESET) External Tests: $(RED)FAILED$(RESET)\n"; \
+	 wait $$AUTH_PID && printf "  $(GREEN)✓$(RESET) Auth Tests: $(GREEN)PASSED$(RESET)\n" || printf "  $(RED)✗$(RESET) Auth Tests: $(RED)FAILED$(RESET)\n"; \
+	 wait $$PAYMENT_PID && printf "  $(GREEN)✓$(RESET) Payment Tests: $(GREEN)PASSED$(RESET)\n" || printf "  $(RED)✗$(RESET) Payment Tests: $(RED)FAILED$(RESET)\n"; \
+	 wait $$MULTI_PID && printf "  $(GREEN)✓$(RESET) Multi-Signer Tests: $(GREEN)PASSED$(RESET)\n" || printf "  $(RED)✗$(RESET) Multi-Signer Tests: $(RED)FAILED$(RESET)\n"; \
+	 END_TIME=$$(date +%s); \
+	 DURATION=$$((END_TIME - START_TIME)); \
+	 printf "  $(YELLOW)•$(RESET) All tests completed in $${DURATION}s\n"
+	
+	$(call print_step,Cleaning up...)
+	@$(call stop_all_parallel_servers)
 	@$(call stop_solana_validator)
+	$(call print_header,PARALLEL TESTS COMPLETE)
 
 # Individual test targets for development
 test-regular:


### PR DESCRIPTION
- Added debug make commands to not quiet the output
- Parallel testing and debug

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Improved test efficiency by enabling parallel testing and adding debug commands in GitHub Actions and Makefiles.
> 
>   - **GitHub Actions**:
>     - Split `rust.yml` workflow into separate jobs for `build-and-lint`, `unit-tests`, `integration-tests`, and `coverage-report`.
>     - Added parallel execution for integration tests using a matrix strategy in `rust.yml`.
>     - Updated coverage badge logic in `rust.yml` to reflect new coverage percentage.
>   - **Makefiles**:
>     - Added `DEBUG.makefile` and `DEBUG_COMMANDS.makefile` for verbose test execution with debug logging.
>     - Updated `Makefile` to include debug test commands.
>     - Modified `RUST_TESTS.makefile` to run integration tests in parallel.
>     - Added new targets in `UTILS.makefile` for starting and stopping parallel test servers.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=solana-foundation%2Fkora&utm_source=github&utm_medium=referral)<sup> for 8a8a9ff104a296e6695cada67430a682f6deff13. You can [customize](https://app.ellipsis.dev/solana-foundation/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

----


<!-- ELLIPSIS_HIDDEN -->


## 📊 Test Coverage
![Coverage](https://img.shields.io/badge/coverage-26.3%25-red)

**Coverage: 26.3%**

[View Detailed Coverage Report](https://github.com/solana-foundation/kora/actions/runs/17331236027)