### PR TITLE
chore: Add sig_verify option to transaction request types

### DIFF
--- a/sdks/ts/docs/README.md
+++ b/sdks/ts/docs/README.md
@@ -431,6 +431,7 @@ Parameters for estimating transaction fees.
 | Property | Type | Description |
 | ------ | ------ | ------ |
 | <a id="fee_token"></a> `fee_token` | `string` | Mint address of the token to calculate fees in |
+| <a id="sig_verify"></a> `sig_verify?` | `boolean` | Optional signer verification during transaction simulation (defaults to false) |
 | <a id="signer_key"></a> `signer_key?` | `string` | Optional signer address for the transaction |
 | <a id="transaction"></a> `transaction` | `string` | Base64-encoded transaction to estimate fees for |
 
@@ -503,6 +504,8 @@ Parameters for getting a payment instruction.
 | Property | Type | Description |
 | ------ | ------ | ------ |
 | <a id="fee_token-1"></a> `fee_token` | `string` | Mint address of the token to calculate fees in |
+| <a id="sig_verify-1"></a> `sig_verify?` | `boolean` | Optional signer verification during transaction simulation (defaults to false) |
+| <a id="signer_key-1"></a> `signer_key?` | `string` | Optional signer address for the transaction |
 | <a id="source_wallet"></a> `source_wallet` | `string` | The wallet owner (not token account) that will be making the token payment |
 | <a id="token_program_id"></a> `token_program_id?` | `string` | The token program id to use for the payment (defaults to TOKEN_PROGRAM_ID) |
 | <a id="transaction-1"></a> `transaction` | `string` | Base64-encoded transaction to estimate fees for |
@@ -594,7 +597,8 @@ Parameters for signing and sending a transaction.
 
 | Property | Type | Description |
 | ------ | ------ | ------ |
-| <a id="signer_key-1"></a> `signer_key?` | `string` | Optional signer address for the transaction |
+| <a id="sig_verify-2"></a> `sig_verify?` | `boolean` | Optional signer verification during transaction simulation (defaults to false) |
+| <a id="signer_key-2"></a> `signer_key?` | `string` | Optional signer address for the transaction |
 | <a id="transaction-2"></a> `transaction` | `string` | Base64-encoded transaction to sign and send |
 
 ***
@@ -621,7 +625,8 @@ Parameters for conditionally signing a transaction based on payment.
 
 | Property | Type | Description |
 | ------ | ------ | ------ |
-| <a id="signer_key-2"></a> `signer_key?` | `string` | Optional signer address for the transaction |
+| <a id="sig_verify-3"></a> `sig_verify?` | `boolean` | Optional signer verification during transaction simulation (defaults to false) |
+| <a id="signer_key-3"></a> `signer_key?` | `string` | Optional signer address for the transaction |
 | <a id="transaction-3"></a> `transaction` | `string` | Base64-encoded transaction |
 
 ***
@@ -648,7 +653,8 @@ Parameters for signing a transaction.
 
 | Property | Type | Description |
 | ------ | ------ | ------ |
-| <a id="signer_key-3"></a> `signer_key?` | `string` | Optional signer address for the transaction |
+| <a id="sig_verify-4"></a> `sig_verify?` | `boolean` | Optional signer verification during transaction simulation (defaults to false) |
+| <a id="signer_key-4"></a> `signer_key?` | `string` | Optional signer address for the transaction |
 | <a id="transaction-5"></a> `transaction` | `string` | Base64-encoded transaction to sign |
 
 ***
@@ -690,7 +696,7 @@ Parameters for creating a token transfer transaction.
 | ------ | ------ | ------ |
 | <a id="amount"></a> `amount` | `number` | Amount to transfer in the token's smallest unit (e.g., lamports for SOL) |
 | <a id="destination"></a> `destination` | `string` | Public key of the destination wallet (not token account) |
-| <a id="signer_key-4"></a> `signer_key?` | `string` | Optional signer address for the transaction |
+| <a id="signer_key-5"></a> `signer_key?` | `string` | Optional signer address for the transaction |
 | <a id="source"></a> `source` | `string` | Public key of the source wallet (not token account) |
 | <a id="token"></a> `token` | `string` | Mint address of the token to transfer |
 

--- a/sdks/ts/src/client.ts
+++ b/sdks/ts/src/client.ts
@@ -310,6 +310,8 @@ export class KoraClient {
      * @param request.fee_token - Mint address of the token to use for payment
      * @param request.source_wallet - Public key of the wallet paying the fees
      * @param request.token_program_id - Optional token program ID (defaults to TOKEN_PROGRAM_ADDRESS)
+     * @param request.signer_key - Optional signer address for the transaction
+     * @param request.sig_verify - Optional signer verification during transaction simulation (defaults to false)
      * @returns Payment instruction details including the instruction, amount, and addresses
      * @throws {Error} When the token is not supported, payment is not required, or invalid addresses are provided
      *
@@ -328,6 +330,8 @@ export class KoraClient {
         fee_token,
         source_wallet,
         token_program_id = TOKEN_PROGRAM_ADDRESS,
+        signer_key,
+        sig_verify,
     }: GetPaymentInstructionRequest): Promise<GetPaymentInstructionResponse> {
         assertIsAddress(source_wallet);
         assertIsAddress(fee_token);
@@ -336,6 +340,8 @@ export class KoraClient {
         const { fee_in_token, payment_address, signer_pubkey } = await this.estimateTransactionFee({
             transaction,
             fee_token,
+            sig_verify,
+            signer_key,
         });
         assertIsAddress(payment_address);
 

--- a/sdks/ts/src/types/index.ts
+++ b/sdks/ts/src/types/index.ts
@@ -28,6 +28,8 @@ export interface SignTransactionRequest {
     transaction: string;
     /** Optional signer address for the transaction */
     signer_key?: string;
+    /** Optional signer verification during transaction simulation (defaults to false) */
+    sig_verify?: boolean;
 }
 
 /**
@@ -38,6 +40,8 @@ export interface SignAndSendTransactionRequest {
     transaction: string;
     /** Optional signer address for the transaction */
     signer_key?: string;
+    /** Optional signer verification during transaction simulation (defaults to false) */
+    sig_verify?: boolean;
 }
 
 /**
@@ -48,6 +52,8 @@ export interface SignTransactionIfPaidRequest {
     transaction: string;
     /** Optional signer address for the transaction */
     signer_key?: string;
+    /** Optional signer verification during transaction simulation (defaults to false) */
+    sig_verify?: boolean;
 }
 
 /**
@@ -60,6 +66,8 @@ export interface EstimateTransactionFeeRequest {
     fee_token: string;
     /** Optional signer address for the transaction */
     signer_key?: string;
+    /** Optional signer verification during transaction simulation (defaults to false) */
+    sig_verify?: boolean;
 }
 
 /**
@@ -74,6 +82,10 @@ export interface GetPaymentInstructionRequest {
     source_wallet: string;
     /** The token program id to use for the payment (defaults to TOKEN_PROGRAM_ID) */
     token_program_id?: string;
+    /** Optional signer address for the transaction */
+    signer_key?: string;
+    /** Optional signer verification during transaction simulation (defaults to false) */
+    sig_verify?: boolean;
 }
 
 /**


### PR DESCRIPTION
Adds the optional `sig_verify` boolean to transaction-related request interfaces and methods in TS SDK. Updated Documentation to reflect this new parameter.