### PR TITLE
feat: (PRO-262) Implement usage limit feature with Redis support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2989,7 +2989,6 @@ dependencies = [
  "prometheus",
  "rand 0.9.2",
  "redis",
- "redis-test",
  "regex",
  "reqwest 0.12.23",
  "serde",
@@ -4209,18 +4208,6 @@ dependencies = [
  "tokio",
  "tokio-util",
  "url",
-]
-
-[[package]]
-name = "redis-test"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b193b65f0e4d429e6caf18c7ca552f58df58079db6500cbb89b653ac371d0ef1"
-dependencies = [
- "rand 0.9.2",
- "redis",
- "socket2 0.6.0",
- "tempfile",
 ]
 
 [[package]]

--- a/crates/lib/Cargo.toml
+++ b/crates/lib/Cargo.toml
@@ -85,4 +85,3 @@ tempfile = "3.2"
 tokio = { version = "1.0", features = ["macros", "rt-multi-thread"] }
 mockito = "1.2.0"
 serial_test = "3.2.0"
-redis-test = "0.12.0"

--- a/crates/lib/src/constant.rs
+++ b/crates/lib/src/constant.rs
@@ -25,6 +25,9 @@ pub const DEFAULT_CACHE_DEFAULT_TTL: u64 = 300; // 5 minutes
 pub const DEFAULT_CACHE_ACCOUNT_TTL: u64 = 60; // 1 minute for account data
 pub const DEFAULT_FEE_PAYER_BALANCE_METRICS_EXPIRY_SECONDS: u64 = 30; // 30 seconds
 
+pub const DEFAULT_USAGE_LIMIT_DEFAULT_MAX_TRANSACTIONS: u64 = 0; // 0 = unlimited
+pub const DEFAULT_USAGE_LIMIT_FALLBACK_IF_UNAVAILABLE: bool = false;
+
 // Account Indexes within instructions
 // Instruction indexes for the instructions that we support to parse from the transaction
 pub mod instruction_indexes {

--- a/crates/lib/src/error.rs
+++ b/crates/lib/src/error.rs
@@ -58,6 +58,9 @@ pub enum KoraError {
 
     #[error("Rate limit exceeded")]
     RateLimitExceeded,
+
+    #[error("Usage limit exceeded: {0}")]
+    UsageLimitExceeded(String),
 }
 
 impl From<ClientError> for KoraError {

--- a/crates/lib/src/mod.rs
+++ b/crates/lib/src/mod.rs
@@ -17,6 +17,7 @@ pub mod signer;
 pub mod state;
 pub mod token;
 pub mod transaction;
+pub mod usage_limit;
 pub mod validator;
 pub use cache::CacheUtil;
 pub use config::Config;

--- a/crates/lib/src/rpc_server/method/estimate_transaction_fee.rs
+++ b/crates/lib/src/rpc_server/method/estimate_transaction_fee.rs
@@ -5,12 +5,18 @@ use crate::{
     error::KoraError,
     fee::fee::FeeConfigUtil,
     rpc_server::middleware_utils::default_sig_verify,
-    state::{get_config, get_request_signer_with_signer_key},
+    state::get_request_signer_with_signer_key,
     transaction::{TransactionUtil, VersionedTransactionResolved},
 };
 
 use serde::{Deserialize, Serialize};
 use solana_client::nonblocking::rpc_client::RpcClient;
+
+#[cfg(not(test))]
+use crate::state::get_config;
+
+#[cfg(test)]
+use crate::tests::config_mock::mock_state::get_config;
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct EstimateTransactionFeeRequest {

--- a/crates/lib/src/rpc_server/method/sign_transaction_if_paid.rs
+++ b/crates/lib/src/rpc_server/method/sign_transaction_if_paid.rs
@@ -2,6 +2,7 @@ use crate::{
     rpc_server::middleware_utils::default_sig_verify,
     state::get_request_signer_with_signer_key,
     transaction::{TransactionUtil, VersionedTransactionOps, VersionedTransactionResolved},
+    usage_limit::UsageTracker,
     KoraError,
 };
 use serde::{Deserialize, Serialize};
@@ -33,6 +34,10 @@ pub async fn sign_transaction_if_paid(
     request: SignTransactionIfPaidRequest,
 ) -> Result<SignTransactionIfPaidResponse, KoraError> {
     let transaction_requested = TransactionUtil::decode_b64_transaction(&request.transaction)?;
+
+    // Check usage limit for transaction sender
+    UsageTracker::check_transaction_usage_limit(&transaction_requested).await?;
+
     let signer = get_request_signer_with_signer_key(request.signer_key.as_deref())?;
 
     let mut resolved_transaction = VersionedTransactionResolved::from_transaction(
@@ -58,7 +63,7 @@ pub async fn sign_transaction_if_paid(
 mod tests {
     use super::*;
     use crate::tests::{
-        common::{setup_or_get_test_signer, RpcMockBuilder},
+        common::{setup_or_get_test_signer, setup_or_get_test_usage_limiter, RpcMockBuilder},
         config_mock::ConfigMockBuilder,
         transaction_mock::create_mock_encoded_transaction,
     };
@@ -67,6 +72,8 @@ mod tests {
     async fn test_sign_transaction_if_paid_decode_error() {
         let _m = ConfigMockBuilder::new().build_and_setup();
         let _ = setup_or_get_test_signer();
+
+        let _ = setup_or_get_test_usage_limiter().await;
 
         let rpc_client = Arc::new(RpcMockBuilder::new().build());
 
@@ -85,6 +92,8 @@ mod tests {
     async fn test_sign_transaction_if_paid_invalid_signer_key() {
         let _m = ConfigMockBuilder::new().build_and_setup();
         let _ = setup_or_get_test_signer();
+
+        let _ = setup_or_get_test_usage_limiter().await;
 
         let rpc_client = Arc::new(RpcMockBuilder::new().build());
 

--- a/crates/lib/src/tests/config_mock.rs
+++ b/crates/lib/src/tests/config_mock.rs
@@ -2,7 +2,7 @@ use crate::{
     config::{
         AuthConfig, CacheConfig, Config, EnabledMethods, FeePayerBalanceMetricsConfig,
         FeePayerPolicy, KoraConfig, MetricsConfig, SplTokenConfig, Token2022Config,
-        ValidationConfig,
+        UsageLimitConfig, ValidationConfig,
     },
     fee::price::PriceConfig,
     oracle::PriceSource,
@@ -106,6 +106,7 @@ impl ConfigMockBuilder {
                         default_ttl: 300,
                         account_ttl: 60,
                     },
+                    usage_limit: UsageLimitConfig::default(),
                 },
                 metrics: MetricsConfig::default(),
             },
@@ -193,6 +194,26 @@ impl ConfigMockBuilder {
 
     pub fn with_fee_payer_policy(mut self, policy: FeePayerPolicy) -> Self {
         self.config.validation.fee_payer_policy = policy;
+        self
+    }
+
+    pub fn with_usage_limit_enabled(mut self, enabled: bool) -> Self {
+        self.config.kora.usage_limit.enabled = enabled;
+        self
+    }
+
+    pub fn with_usage_limit_cache_url(mut self, cache_url: Option<String>) -> Self {
+        self.config.kora.usage_limit.cache_url = cache_url;
+        self
+    }
+
+    pub fn with_usage_limit_fallback(mut self, fallback_if_unavailable: bool) -> Self {
+        self.config.kora.usage_limit.fallback_if_unavailable = fallback_if_unavailable;
+        self
+    }
+
+    pub fn with_usage_limit_max_transactions(mut self, max_transactions: u64) -> Self {
+        self.config.kora.usage_limit.default_max_transactions = max_transactions;
         self
     }
 
@@ -312,6 +333,7 @@ impl KoraConfigBuilder {
                     default_ttl: 300,
                     account_ttl: 60,
                 },
+                usage_limit: UsageLimitConfig::default(),
             },
         }
     }

--- a/crates/lib/src/tests/redis_cache_mock.rs
+++ b/crates/lib/src/tests/redis_cache_mock.rs
@@ -1,39 +1,7 @@
 use crate::error::KoraError;
 use mockall::mock;
-use redis_test::MockRedisConnection;
 use solana_client::nonblocking::rpc_client::RpcClient;
 use solana_sdk::{account::Account, pubkey::Pubkey};
-
-/// Redis cache mock for testing scenarios where caching behavior is tested
-///
-/// It provides a mockall-based replacement for the real CacheUtil to avoid Redis dependencies in tests.
-///
-/// Usage:
-/// ```rust
-/// #[cfg(test)]
-/// use crate::tests::redis_cache_mock::MockCacheUtil as CacheUtil;
-/// ```
-pub struct RedisCacheMock {
-    mock_connection: MockRedisConnection,
-}
-
-impl RedisCacheMock {
-    /// Create basic mock for cache.rs testing
-    pub fn new() -> Self {
-        Self { mock_connection: MockRedisConnection::new(vec![]) }
-    }
-
-    /// Get mock connection for testing
-    pub fn get_mock_connection(&self) -> &MockRedisConnection {
-        &self.mock_connection
-    }
-}
-
-impl Default for RedisCacheMock {
-    fn default() -> Self {
-        Self::new()
-    }
-}
 
 mock! {
     pub CacheUtil {

--- a/crates/lib/src/usage_limit/mod.rs
+++ b/crates/lib/src/usage_limit/mod.rs
@@ -1,0 +1,5 @@
+pub mod usage_store;
+pub mod usage_tracker;
+
+pub use usage_store::{InMemoryUsageStore, RedisUsageStore, UsageStore};
+pub use usage_tracker::UsageTracker;

--- a/crates/lib/src/usage_limit/usage_store.rs
+++ b/crates/lib/src/usage_limit/usage_store.rs
@@ -1,0 +1,140 @@
+use std::{collections::HashMap, sync::Mutex};
+
+use async_trait::async_trait;
+use deadpool_redis::{Connection, Pool};
+use redis::AsyncCommands;
+
+use crate::error::KoraError;
+
+/// Trait for storing and retrieving usage counts
+#[async_trait]
+pub trait UsageStore: Send + Sync {
+    /// Increment usage count for a key and return the new value
+    async fn increment(&self, key: &str) -> Result<u32, KoraError>;
+
+    /// Get current usage count for a key (returns 0 if not found)
+    async fn get(&self, key: &str) -> Result<u32, KoraError>;
+
+    /// Clear all usage data (mainly for testing)
+    async fn clear(&self) -> Result<(), KoraError>;
+}
+
+/// Redis-based implementation for production
+pub struct RedisUsageStore {
+    pool: Pool,
+}
+
+impl RedisUsageStore {
+    pub fn new(pool: Pool) -> Self {
+        Self { pool }
+    }
+
+    async fn get_connection(&self) -> Result<Connection, KoraError> {
+        self.pool.get().await.map_err(|e| {
+            KoraError::InternalServerError(format!("Failed to get Redis connection: {e}"))
+        })
+    }
+}
+
+#[async_trait]
+impl UsageStore for RedisUsageStore {
+    async fn increment(&self, key: &str) -> Result<u32, KoraError> {
+        let mut conn = self.get_connection().await?;
+        let count: u32 = conn.incr(key, 1).await.map_err(|e| {
+            KoraError::InternalServerError(format!("Failed to increment usage for {key}: {e}"))
+        })?;
+        Ok(count)
+    }
+
+    async fn get(&self, key: &str) -> Result<u32, KoraError> {
+        let mut conn = self.get_connection().await?;
+        let count: Option<u32> = conn.get(key).await.map_err(|e| {
+            KoraError::InternalServerError(format!("Failed to get usage for {key}: {e}"))
+        })?;
+        Ok(count.unwrap_or(0))
+    }
+
+    async fn clear(&self) -> Result<(), KoraError> {
+        let mut conn = self.get_connection().await?;
+        let _: () = conn
+            .flushdb()
+            .await
+            .map_err(|e| KoraError::InternalServerError(format!("Failed to clear Redis: {e}")))?;
+        Ok(())
+    }
+}
+
+/// In-memory implementation for testing
+pub struct InMemoryUsageStore {
+    data: Mutex<HashMap<String, u32>>,
+}
+
+impl InMemoryUsageStore {
+    pub fn new() -> Self {
+        Self { data: Mutex::new(HashMap::new()) }
+    }
+}
+
+impl Default for InMemoryUsageStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl UsageStore for InMemoryUsageStore {
+    async fn increment(&self, key: &str) -> Result<u32, KoraError> {
+        let mut data = self.data.lock().map_err(|e| {
+            KoraError::InternalServerError(format!("Failed to lock usage store: {e}"))
+        })?;
+        let count = data.entry(key.to_string()).or_insert(0);
+        *count += 1;
+        Ok(*count)
+    }
+
+    async fn get(&self, key: &str) -> Result<u32, KoraError> {
+        let data = self.data.lock().map_err(|e| {
+            KoraError::InternalServerError(format!("Failed to lock usage store: {e}"))
+        })?;
+        Ok(data.get(key).copied().unwrap_or(0))
+    }
+
+    async fn clear(&self) -> Result<(), KoraError> {
+        let mut data = self.data.lock().map_err(|e| {
+            KoraError::InternalServerError(format!("Failed to lock usage store: {e}"))
+        })?;
+        data.clear();
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_in_memory_usage_store() {
+        let store = InMemoryUsageStore::new();
+
+        // Initial count should be 0
+        assert_eq!(store.get("wallet1").await.unwrap(), 0);
+
+        // Increment should return 1
+        assert_eq!(store.increment("wallet1").await.unwrap(), 1);
+        assert_eq!(store.get("wallet1").await.unwrap(), 1);
+
+        // Increment again should return 2
+        assert_eq!(store.increment("wallet1").await.unwrap(), 2);
+        assert_eq!(store.get("wallet1").await.unwrap(), 2);
+
+        // Different key should be independent
+        assert_eq!(store.increment("wallet2").await.unwrap(), 1);
+        assert_eq!(store.get("wallet2").await.unwrap(), 1);
+        assert_eq!(store.get("wallet1").await.unwrap(), 2);
+
+        // Clear should reset everything
+        store.clear().await.unwrap();
+        assert_eq!(store.get("wallet1").await.unwrap(), 0);
+        assert_eq!(store.get("wallet2").await.unwrap(), 0);
+    }
+}

--- a/crates/lib/src/usage_limit/usage_tracker.rs
+++ b/crates/lib/src/usage_limit/usage_tracker.rs
@@ -1,0 +1,300 @@
+use std::{collections::HashSet, sync::Arc};
+
+use deadpool_redis::Runtime;
+use redis::AsyncCommands;
+use solana_sdk::{pubkey::Pubkey, transaction::VersionedTransaction};
+use tokio::sync::OnceCell;
+
+use super::usage_store::{RedisUsageStore, UsageStore};
+use crate::{error::KoraError, get_all_signers};
+
+#[cfg(not(test))]
+use crate::state::get_config;
+
+#[cfg(test)]
+use crate::tests::config_mock::mock_state::get_config;
+
+/// Global usage limiter instance
+static USAGE_LIMITER: OnceCell<Option<UsageTracker>> = OnceCell::const_new();
+
+pub struct UsageTracker {
+    store: Arc<dyn UsageStore>,
+    default_max_transactions: u64,
+    kora_signers: HashSet<Pubkey>,
+}
+
+impl UsageTracker {
+    pub fn new(
+        store: Arc<dyn UsageStore>,
+        default_max_transactions: u64,
+        kora_signers: HashSet<Pubkey>,
+    ) -> Self {
+        Self { store, default_max_transactions, kora_signers }
+    }
+
+    fn get_usage_key(&self, wallet: &Pubkey) -> String {
+        format!("kora:usage_limit:{wallet}")
+    }
+
+    async fn increment_usage(&self, wallet: &Pubkey) -> Result<u32, KoraError> {
+        let key = self.get_usage_key(wallet);
+        self.store.increment(&key).await
+    }
+
+    async fn check_usage_limit(&self, wallet: &Pubkey) -> Result<(), KoraError> {
+        // Skip check if unlimited (0)
+        if self.default_max_transactions == 0 {
+            return Ok(());
+        }
+
+        let current_count = self.increment_usage(wallet).await?;
+
+        if current_count > self.default_max_transactions as u32 {
+            return Err(KoraError::UsageLimitExceeded(format!(
+                "Wallet {wallet} exceeded limit: {current_count}/{}",
+                self.default_max_transactions
+            )));
+        }
+
+        log::debug!(
+            "Usage check passed for {wallet}: {current_count}/{}",
+            self.default_max_transactions
+        );
+
+        Ok(())
+    }
+
+    fn get_usage_limiter() -> Result<Option<&'static UsageTracker>, KoraError> {
+        match USAGE_LIMITER.get() {
+            Some(limiter) => Ok(limiter.as_ref()),
+            None => {
+                Err(KoraError::InternalServerError("Usage limiter not initialized".to_string()))
+            }
+        }
+    }
+
+    /// Extract sender from transaction
+    fn extract_transaction_sender(
+        &self,
+        transaction: &VersionedTransaction,
+    ) -> Result<Pubkey, KoraError> {
+        let account_keys = transaction.message.static_account_keys();
+
+        if account_keys.is_empty() {
+            return Err(KoraError::InvalidTransaction(
+                "Transaction has no account keys".to_string(),
+            ));
+        }
+
+        for signer in
+            account_keys.iter().take(transaction.message.header().num_required_signatures as usize)
+        {
+            if !self.kora_signers.contains(signer) {
+                return Ok(*signer);
+            }
+        }
+
+        Err(KoraError::InvalidTransaction(
+            "No user signers found (all signers are Kora fee payers)".to_string(),
+        ))
+    }
+
+    /// Initialize the global usage limiter
+    pub async fn init_usage_limiter() -> Result<(), KoraError> {
+        let config = get_config()?;
+
+        if !config.kora.usage_limit.enabled {
+            log::info!("Usage limiting disabled");
+            USAGE_LIMITER.set(None).map_err(|_| {
+                KoraError::InternalServerError("Usage limiter already initialized".to_string())
+            })?;
+            return Ok(());
+        }
+
+        let usage_limiter = if let Some(cache_url) = &config.kora.usage_limit.cache_url {
+            let cfg = deadpool_redis::Config::from_url(cache_url);
+            let pool = cfg.create_pool(Some(Runtime::Tokio1)).map_err(|e| {
+                KoraError::InternalServerError(format!("Failed to create Redis pool: {e}"))
+            })?;
+
+            // Test Redis connection
+            let mut conn = pool.get().await.map_err(|e| {
+                KoraError::InternalServerError(format!("Failed to connect to Redis: {e}"))
+            })?;
+
+            // Simple connection test
+            let _: Option<String> = conn.get("__usage_limiter_test__").await.map_err(|e| {
+                KoraError::InternalServerError(format!("Redis connection test failed: {e}"))
+            })?;
+
+            log::info!(
+                "Usage limiter initialized with Redis at {} (max: {} transactions)",
+                cache_url,
+                config.kora.usage_limit.default_max_transactions
+            );
+
+            let kora_signers =
+                get_all_signers()?.iter().map(|signer| signer.signer.solana_pubkey()).collect();
+
+            let store = Arc::new(RedisUsageStore::new(pool));
+            Some(UsageTracker::new(
+                store,
+                config.kora.usage_limit.default_max_transactions,
+                kora_signers,
+            ))
+        } else {
+            log::info!("Usage limiting enabled but no cache_url configured - disabled");
+            None
+        };
+
+        USAGE_LIMITER.set(usage_limiter).map_err(|_| {
+            KoraError::InternalServerError("Usage limiter already initialized".to_string())
+        })?;
+
+        Ok(())
+    }
+
+    /// Check usage limit for transaction sender
+    pub async fn check_transaction_usage_limit(
+        transaction: &VersionedTransaction,
+    ) -> Result<(), KoraError> {
+        let config = get_config()?;
+
+        if let Some(limiter) = Self::get_usage_limiter()? {
+            let sender = limiter.extract_transaction_sender(transaction)?;
+            limiter.check_usage_limit(&sender).await?;
+            Ok(())
+        } else if config.kora.usage_limit.enabled
+            && !config.kora.usage_limit.fallback_if_unavailable
+        {
+            // Usage limiting enabled but limiter unavailable and fallback disabled
+            Err(KoraError::InternalServerError(
+                "Usage limiter unavailable and fallback disabled".to_string(),
+            ))
+        } else {
+            // Usage limiting disabled or fallback allowed
+            Ok(())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        tests::{config_mock::ConfigMockBuilder, transaction_mock::create_mock_transaction},
+        usage_limit::InMemoryUsageStore,
+    };
+
+    #[tokio::test]
+    async fn test_get_usage_key_format() {
+        let wallet = Pubkey::new_unique();
+        let expected_key = format!("kora:usage_limit:{wallet}");
+
+        assert_eq!(expected_key, format!("kora:usage_limit:{wallet}"));
+    }
+
+    #[tokio::test]
+    async fn test_usage_limit_enforcement() {
+        let store = Arc::new(InMemoryUsageStore::new());
+        let kora_signers = HashSet::new();
+        let tracker = UsageTracker::new(store, 2, kora_signers);
+
+        let wallet = Pubkey::new_unique();
+
+        // First transaction should succeed
+        assert!(tracker.check_usage_limit(&wallet).await.is_ok());
+
+        // Second transaction should succeed (at limit)
+        assert!(tracker.check_usage_limit(&wallet).await.is_ok());
+
+        // Third transaction should fail (over limit)
+        let result = tracker.check_usage_limit(&wallet).await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("exceeded limit"));
+    }
+
+    #[tokio::test]
+    async fn test_independent_wallet_limits() {
+        let store = Arc::new(InMemoryUsageStore::new());
+        let kora_signers = HashSet::new();
+        let tracker = UsageTracker::new(store, 2, kora_signers);
+
+        let wallet1 = Pubkey::new_unique();
+        let wallet2 = Pubkey::new_unique();
+
+        // Use up wallet1's limit
+        assert!(tracker.check_usage_limit(&wallet1).await.is_ok());
+        assert!(tracker.check_usage_limit(&wallet1).await.is_ok());
+        assert!(tracker.check_usage_limit(&wallet1).await.is_err());
+
+        // Wallet2 should still be able to make transactions
+        assert!(tracker.check_usage_limit(&wallet2).await.is_ok());
+        assert!(tracker.check_usage_limit(&wallet2).await.is_ok());
+        assert!(tracker.check_usage_limit(&wallet2).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_unlimited_usage() {
+        let store = Arc::new(InMemoryUsageStore::new());
+        let kora_signers = HashSet::new();
+        let tracker = UsageTracker::new(store, 0, kora_signers); // 0 = unlimited
+
+        let wallet = Pubkey::new_unique();
+
+        // Should allow many transactions when unlimited
+        for _ in 0..10 {
+            assert!(tracker.check_usage_limit(&wallet).await.is_ok());
+        }
+    }
+
+    #[tokio::test]
+    async fn test_usage_limiter_disabled_fallback() {
+        // Test that when usage limiting is disabled, transactions are allowed
+        let _m = ConfigMockBuilder::new().with_usage_limit_enabled(false).build_and_setup();
+
+        // Initialize the usage limiter - it should set to None when disabled
+        let _ = UsageTracker::init_usage_limiter().await;
+
+        let result = UsageTracker::check_transaction_usage_limit(&create_mock_transaction()).await;
+        match &result {
+            Ok(_) => {}
+            Err(e) => println!("Test failed with error: {e}"),
+        }
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_usage_limiter_fallback_allowed() {
+        let _m = ConfigMockBuilder::new()
+            .with_usage_limit_enabled(true)
+            .with_usage_limit_cache_url(None)
+            .with_usage_limit_fallback(true)
+            .build_and_setup();
+
+        // Initialize with no cache_url - should set limiter to None
+        let _ = UsageTracker::init_usage_limiter().await;
+
+        let result = UsageTracker::check_transaction_usage_limit(&create_mock_transaction()).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_usage_limiter_fallback_denied() {
+        let _m = ConfigMockBuilder::new()
+            .with_usage_limit_enabled(true)
+            .with_usage_limit_cache_url(None)
+            .with_usage_limit_fallback(false)
+            .build_and_setup();
+
+        // Initialize with no cache_url - should set limiter to None
+        let _ = UsageTracker::init_usage_limiter().await;
+
+        let result = UsageTracker::check_transaction_usage_limit(&create_mock_transaction()).await;
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("Usage limiter unavailable and fallback disabled"));
+    }
+}

--- a/crates/lib/src/validator/config_validator.rs
+++ b/crates/lib/src/validator/config_validator.rs
@@ -334,7 +334,7 @@ mod tests {
     use crate::{
         config::{
             AuthConfig, CacheConfig, Config, EnabledMethods, FeePayerPolicy, KoraConfig,
-            MetricsConfig, SplTokenConfig, ValidationConfig,
+            MetricsConfig, SplTokenConfig, UsageLimitConfig, ValidationConfig,
         },
         fee::price::PriceConfig,
         state::update_config,
@@ -449,6 +449,7 @@ mod tests {
                 auth: AuthConfig::default(),
                 payment_address: None,
                 cache: CacheConfig::default(),
+                usage_limit: UsageLimitConfig::default(),
             },
             metrics: MetricsConfig::default(),
         };

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,8 +5,9 @@ services:
       - "6379:6379"
     volumes:
       - redis_data:/data
+      - ./redis.conf:/usr/local/etc/redis/redis.conf:ro
     restart: unless-stopped
-    command: redis-server --appendonly yes
+    command: redis-server /usr/local/etc/redis/redis.conf
 
   kora:
     build:


### PR DESCRIPTION
- Removed `redis-test` dependency from Cargo files.
- Updated Docker configuration to use a custom Redis configuration file.
- Introduced `UsageLimitConfig` to manage per-wallet transaction limits.
- Added `UsageTracker` for enforcing usage limits based on transactions.
- Implemented `UsageStore` trait with Redis and in-memory implementations for tracking usage.
- Enhanced RPC methods to check usage limits before processing transactions.
- Added tests for usage limit functionality and configuration parsing.
- Updated configuration validation to include usage limit settings.