### PR TITLE
feat: (PRO-203) Implement TurnkeyError handling and enhance PrivySign…

### DIFF
--- a/.github/badges/coverage.json
+++ b/.github/badges/coverage.json
@@ -1,1 +1,1 @@
-{"schemaVersion": 1, "label": "coverage", "message": "85.5%", "color": "green"}
+{"schemaVersion": 1, "label": "coverage", "message": "85.7%", "color": "green"}

--- a/crates/lib/src/error.rs
+++ b/crates/lib/src/error.rs
@@ -199,6 +199,12 @@ impl From<crate::signer::privy::types::PrivyError> for KoraError {
     }
 }
 
+impl From<crate::signer::turnkey::types::TurnkeyError> for KoraError {
+    fn from(err: crate::signer::turnkey::types::TurnkeyError) -> Self {
+        KoraError::SigningError(err.to_string())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/lib/src/signer/privy/signer.rs
+++ b/crates/lib/src/signer/privy/signer.rs
@@ -51,7 +51,16 @@ impl PrivySigner {
             .await?;
 
         if !response.status().is_success() {
-            return Err(PrivyError::ApiError(response.status().as_u16()));
+            let status = response.status().as_u16();
+            let error_text = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "Failed to read error response".to_string());
+
+            log::error!(
+                "Privy API get_public_key error - status: {status}, response: {error_text}"
+            );
+            return Err(PrivyError::ApiError(status));
         }
 
         let wallet_info: WalletResponse = response.json().await?;
@@ -91,6 +100,12 @@ impl PrivySigner {
 
         if !response.status().is_success() {
             let status = response.status().as_u16();
+            let error_text = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "Failed to read error response".to_string());
+
+            log::error!("Privy API sign_solana error - status: {status}, response: {error_text}");
             return Err(PrivyError::ApiError(status));
         }
 

--- a/crates/lib/src/signer/turnkey/config.rs
+++ b/crates/lib/src/signer/turnkey/config.rs
@@ -63,12 +63,7 @@ impl SignerConfigTrait for TurnkeySignerHandler {
             organization_id,
             private_key_id,
             public_key,
-        )
-        .map_err(|e| {
-            KoraError::ValidationError(format!(
-                "Failed to create Turnkey signer '{signer_name}': {e}"
-            ))
-        })?;
+        );
 
         Ok(KoraSigner::Turnkey(signer))
     }

--- a/crates/lib/src/signer/turnkey/types.rs
+++ b/crates/lib/src/signer/turnkey/types.rs
@@ -1,3 +1,5 @@
+use hex::FromHexError;
+use p256::ecdsa::signature;
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
 
@@ -54,4 +56,71 @@ pub struct ActivityResult {
 pub struct SignResult {
     pub r: String,
     pub s: String,
+}
+
+#[derive(Debug)]
+pub enum TurnkeyError {
+    ApiError(u16),
+    RequestError(reqwest::Error),
+    JsonError(serde_json::Error),
+    InvalidSignature,
+    InvalidHex(FromHexError),
+    InvalidStamp(anyhow::Error),
+    SigningKeyError(signature::Error),
+    InvalidResponse,
+    InvalidPrivateKeyLength,
+    InvalidPublicKey,
+    Other(anyhow::Error),
+}
+
+impl std::fmt::Display for TurnkeyError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            TurnkeyError::ApiError(status) => write!(f, "API error: {status}"),
+            TurnkeyError::InvalidResponse => write!(f, "Invalid response"),
+            TurnkeyError::InvalidPublicKey => write!(f, "Invalid public key"),
+            TurnkeyError::InvalidSignature => write!(f, "Invalid signature"),
+            TurnkeyError::InvalidPrivateKeyLength => write!(f, "Invalid private key length"),
+            TurnkeyError::RequestError(e) => write!(f, "Request error: {e}"),
+            TurnkeyError::JsonError(e) => write!(f, "JSON error: {e}"),
+            TurnkeyError::InvalidStamp(e) => write!(f, "Invalid stamp: {e}"),
+            TurnkeyError::InvalidHex(e) => write!(f, "Invalid Hex: {e}"),
+            TurnkeyError::SigningKeyError(e) => write!(f, "Signing key error: {e}"),
+            TurnkeyError::Other(e) => write!(f, "{e}"),
+        }
+    }
+}
+
+impl std::error::Error for TurnkeyError {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_turnkey_error_display() {
+        let error = TurnkeyError::ApiError(429);
+        assert_eq!(error.to_string(), "API error: 429");
+
+        let error = TurnkeyError::InvalidResponse;
+        assert_eq!(error.to_string(), "Invalid response");
+
+        let error = TurnkeyError::InvalidSignature;
+        assert_eq!(error.to_string(), "Invalid signature");
+    }
+
+    #[test]
+    fn test_turnkey_error_conversion_to_kora_error() {
+        use crate::error::KoraError;
+
+        let turnkey_error = TurnkeyError::ApiError(429);
+        let kora_error: KoraError = turnkey_error.into();
+
+        match kora_error {
+            KoraError::SigningError(msg) => {
+                assert_eq!(msg, "API error: 429");
+            }
+            _ => panic!("Expected SigningError"),
+        }
+    }
 }

--- a/crates/lib/src/validator/transaction_validator.rs
+++ b/crates/lib/src/validator/transaction_validator.rs
@@ -347,26 +347,6 @@ mod tests {
         update_config(config).unwrap();
     }
 
-    fn setup_spl_token_config() {
-        let config = ConfigMockBuilder::new()
-            .with_price_source(PriceSource::Mock)
-            .with_allowed_programs(vec![spl_token::id().to_string()])
-            .with_max_allowed_lamports(1_000_000)
-            .with_fee_payer_policy(FeePayerPolicy::default())
-            .build();
-        update_config(config).unwrap();
-    }
-
-    fn setup_token2022_config() {
-        let config = ConfigMockBuilder::new()
-            .with_price_source(PriceSource::Mock)
-            .with_allowed_programs(vec![spl_token_2022::id().to_string()])
-            .with_max_allowed_lamports(1_000_000)
-            .with_fee_payer_policy(FeePayerPolicy::default())
-            .build();
-        update_config(config).unwrap();
-    }
-
     fn setup_config_with_policy(policy: FeePayerPolicy) {
         let config = ConfigMockBuilder::new()
             .with_price_source(PriceSource::Mock)


### PR DESCRIPTION
…… (#221)

* feat: (PRO-203) Implement TurnkeyError handling and enhance PrivySigner error logging

- Added TurnkeyError enum for comprehensive error handling in TurnkeySigner.
- Updated sign and create_stamp methods to return TurnkeyError variants.
- Enhanced error logging in PrivySigner for API call failures, including status and response details.
- Refactored TurnkeySigner initialization to remove unnecessary error handling, improving clarity.
- Added tests for TurnkeyError display and conversion to KoraError.

* Update coverage badge [skip ci]

---------