### PR TITLE
feat: (PRO-412) Cap max body size per request to prevent potential ov…

### DIFF
--- a/crates/lib/src/constant.rs
+++ b/crates/lib/src/constant.rs
@@ -28,6 +28,9 @@ pub const DEFAULT_FEE_PAYER_BALANCE_METRICS_EXPIRY_SECONDS: u64 = 30; // 30 seco
 pub const DEFAULT_USAGE_LIMIT_MAX_TRANSACTIONS: u64 = 0; // 0 = unlimited
 pub const DEFAULT_USAGE_LIMIT_FALLBACK_IF_UNAVAILABLE: bool = false;
 
+// Request body size limit
+pub const DEFAULT_MAX_REQUEST_BODY_SIZE: usize = 2 * 1024 * 1024; // 2 MB
+
 // Account Indexes within instructions
 // Instruction indexes for the instructions that we support to parse from the transaction
 pub mod instruction_indexes {

--- a/crates/lib/src/rpc_server/server.rs
+++ b/crates/lib/src/rpc_server/server.rs
@@ -89,6 +89,7 @@ pub async fn run_rpc_server(rpc: KoraRpc, port: u16) -> Result<ServerHandles, an
 
     // Configure and build the server with HTTP support
     let server = ServerBuilder::default()
+        .max_request_body_size(config.kora.max_request_body_size as u32)
         .set_middleware(middleware)
         .http_only() // Explicitly enable HTTP
         .build(addr)

--- a/crates/lib/src/tests/config_mock.rs
+++ b/crates/lib/src/tests/config_mock.rs
@@ -4,6 +4,7 @@ use crate::{
         FeePayerPolicy, KoraConfig, MetricsConfig, SplTokenConfig, Token2022Config,
         UsageLimitConfig, ValidationConfig,
     },
+    constant::DEFAULT_MAX_REQUEST_BODY_SIZE,
     fee::price::PriceConfig,
     oracle::PriceSource,
     signer::{
@@ -97,6 +98,7 @@ impl ConfigMockBuilder {
                 },
                 kora: KoraConfig {
                     rate_limit: 100,
+                    max_request_body_size: DEFAULT_MAX_REQUEST_BODY_SIZE,
                     enabled_methods: EnabledMethods::default(),
                     auth: AuthConfig::default(),
                     payment_address: None,
@@ -324,6 +326,7 @@ impl KoraConfigBuilder {
         Self {
             config: KoraConfig {
                 rate_limit: 100,
+                max_request_body_size: DEFAULT_MAX_REQUEST_BODY_SIZE,
                 enabled_methods: EnabledMethods::default(),
                 auth: AuthConfig::default(),
                 payment_address: None,

--- a/crates/lib/src/tests/toml_mock.rs
+++ b/crates/lib/src/tests/toml_mock.rs
@@ -36,6 +36,7 @@ struct ValidationSection {
 
 struct KoraSection {
     rate_limit: u64,
+    max_request_body_size: Option<usize>,
     enabled_methods: Option<String>,
     cache_config: Option<String>,
     usage_limit_config: Option<String>,
@@ -61,6 +62,7 @@ impl Default for KoraSection {
     fn default() -> Self {
         Self {
             rate_limit: 100,
+            max_request_body_size: None,
             enabled_methods: None,
             cache_config: None,
             usage_limit_config: None,
@@ -180,6 +182,11 @@ impl ConfigBuilder {
         self
     }
 
+    pub fn with_max_request_body_size(mut self, size: usize) -> Self {
+        self.kora.max_request_body_size = Some(size);
+        self
+    }
+
     pub fn build_toml(&self) -> String {
         let programs_list = self
             .validation
@@ -246,6 +253,10 @@ impl ConfigBuilder {
         }
 
         toml.push_str(&format!("[kora]\nrate_limit = {}\n", self.kora.rate_limit));
+
+        if let Some(size) = self.kora.max_request_body_size {
+            toml.push_str(&format!("max_request_body_size = {size}\n"));
+        }
 
         if let Some(ref methods_config) = self.kora.enabled_methods {
             toml.push_str(&format!("{methods_config}\n"));

--- a/crates/lib/src/validator/config_validator.rs
+++ b/crates/lib/src/validator/config_validator.rs
@@ -346,6 +346,7 @@ mod tests {
             AuthConfig, CacheConfig, Config, EnabledMethods, FeePayerPolicy, KoraConfig,
             MetricsConfig, SplTokenConfig, UsageLimitConfig, ValidationConfig,
         },
+        constant::DEFAULT_MAX_REQUEST_BODY_SIZE,
         fee::price::PriceConfig,
         state::update_config,
         tests::common::{
@@ -451,6 +452,7 @@ mod tests {
             },
             kora: KoraConfig {
                 rate_limit: 0, // Should warn
+                max_request_body_size: DEFAULT_MAX_REQUEST_BODY_SIZE,
                 enabled_methods: EnabledMethods {
                     liveness: false,
                     estimate_transaction_fee: false,

--- a/tests/adversarial/body_size_limit.rs
+++ b/tests/adversarial/body_size_limit.rs
@@ -1,0 +1,29 @@
+use crate::common::*;
+use serde_json::json;
+
+/// Test that oversized request bodies are rejected with 413 Payload Too Large
+#[tokio::test]
+async fn test_request_body_oversized_rejected() {
+    // Create a very large JSON payload (4 MB, exceeds 2 MB limit)
+    let large_string = "x".repeat(4 * 1024 * 1024);
+
+    let request_body = json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "signTransaction",
+        "params": {
+            "transaction": large_string,
+        }
+    });
+
+    let client = reqwest::Client::new();
+    let response =
+        client.post(TestClient::get_default_server_url()).json(&request_body).send().await;
+
+    // Should get 413 Payload Too Large
+    assert_eq!(
+        response.unwrap().status(),
+        reqwest::StatusCode::PAYLOAD_TOO_LARGE,
+        "Oversized request should return 413 Payload Too Large"
+    );
+}

--- a/tests/adversarial/main.rs
+++ b/tests/adversarial/main.rs
@@ -5,7 +5,9 @@
 //        - Program validation attacks (disallowed programs)
 //        - Invalid token states (frozen)
 //        - Fee payer exploitation
+//        - Request body size limit (DDOS protection)
 
+mod body_size_limit;
 mod fee_payer_exploitation;
 mod program_validation;
 mod token_states;


### PR DESCRIPTION
…erloading of the server
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Introduces a feature to cap request body size at 2 MB to prevent server overload, with configuration and tests to ensure compliance.
> 
>   - **Behavior**:
>     - Adds `max_request_body_size` to `KoraConfig` in `config.rs` with a default of 2 MB.
>     - Configures server in `server.rs` to enforce `max_request_body_size`.
>     - New test `test_request_body_oversized_rejected` in `body_size_limit.rs` to ensure oversized requests return 413.
>   - **Constants**:
>     - Defines `DEFAULT_MAX_REQUEST_BODY_SIZE` in `constant.rs` as 2 MB.
>   - **Tests**:
>     - Adds `body_size_limit.rs` to test oversized request handling.
>     - Updates `config_mock.rs` and `toml_mock.rs` to support `max_request_body_size` configuration.
>     - Adds tests in `config.rs` to verify default and custom `max_request_body_size`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=solana-foundation%2Fkora&utm_source=github&utm_medium=referral)<sup> for b3da35e64eda6547a5d7b3a564ebd8dedf318a3d. You can [customize](https://app.ellipsis.dev/solana-foundation/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

## 📊 Unit Test Coverage
![Coverage](https://img.shields.io/badge/coverage-85.4%25-green)

**Unit Test Coverage: 85.4%**

[View Detailed Coverage Report](https://github.com/solana-foundation/kora/actions/runs/18382665397)