### PR TITLE
feat: (PRO-474) Enhance payment instruction analysis and transfer fee calculation

### DIFF
--- a/crates/lib/src/transaction/versioned_transaction.rs
+++ b/crates/lib/src/transaction/versioned_transaction.rs
@@ -605,8 +605,10 @@ mod tests {
                 AccountMeta::new_readonly(Pubkey::new_unique(), false),
             ],
         );
-        let message =
-            VersionedMessage::Legacy(Message::new(&[instruction.clone()], Some(&keypair.pubkey())));
+        let message = VersionedMessage::Legacy(Message::new(
+            std::slice::from_ref(&instruction),
+            Some(&keypair.pubkey()),
+        ));
         let transaction = VersionedTransaction::try_new(message.clone(), &[&keypair]).unwrap();
 
         let resolved = VersionedTransactionResolved::from_kora_built_transaction(&transaction);
@@ -671,8 +673,10 @@ mod tests {
             &[1, 2, 3],
             vec![AccountMeta::new(keypair.pubkey(), true)],
         );
-        let message =
-            VersionedMessage::Legacy(Message::new(&[instruction.clone()], Some(&keypair.pubkey())));
+        let message = VersionedMessage::Legacy(Message::new(
+            std::slice::from_ref(&instruction),
+            Some(&keypair.pubkey()),
+        ));
         let transaction = VersionedTransaction::try_new(message, &[&keypair]).unwrap();
 
         // Mock RPC client that will be used for inner instructions

--- a/tests/payment_address/main.rs
+++ b/tests/payment_address/main.rs
@@ -8,6 +8,7 @@
 //        - Fee payer policy enforcement for payment scenarios
 
 mod payment_address_legacy_tests;
+mod payment_address_multi_payment_tests;
 mod payment_address_v0_lut_tests;
 mod payment_address_v0_tests;
 

--- a/tests/payment_address/payment_address_multi_payment_tests.rs
+++ b/tests/payment_address/payment_address_multi_payment_tests.rs
@@ -1,0 +1,159 @@
+use crate::common::*;
+use jsonrpsee::rpc_params;
+use kora_lib::token::{TokenInterface, TokenProgram};
+use solana_sdk::{pubkey::Pubkey, signature::Signer};
+use spl_associated_token_account::get_associated_token_address;
+use std::str::FromStr;
+
+#[tokio::test]
+async fn test_sign_transaction_if_paid_with_multiple_payments_legacy() {
+    let ctx = TestContext::new().await.expect("Failed to create test context");
+    let sender = SenderTestHelper::get_test_sender_keypair();
+    let payment_address = Pubkey::from_str(TEST_PAYMENT_ADDRESS).unwrap();
+    let test_mint = USDCMintTestHelper::get_test_usdc_mint_pubkey();
+
+    let sender_token_account = get_associated_token_address(&sender.pubkey(), &test_mint);
+    let payment_address_token_account = get_associated_token_address(&payment_address, &test_mint);
+
+    let token_interface = TokenProgram::new();
+
+    let required_fee = get_fee_for_default_transaction_in_usdc();
+    let payment_1 = required_fee / 2;
+    let payment_2 = required_fee - payment_1 + 10;
+
+    let payment_instruction_1 = token_interface
+        .create_transfer_instruction(
+            &sender_token_account,
+            &payment_address_token_account,
+            &sender.pubkey(),
+            payment_1,
+        )
+        .unwrap();
+
+    let payment_instruction_2 = token_interface
+        .create_transfer_instruction(
+            &sender_token_account,
+            &payment_address_token_account,
+            &sender.pubkey(),
+            payment_2,
+        )
+        .unwrap();
+
+    let fee_payer = FeePayerTestHelper::get_fee_payer_pubkey();
+
+    let encoded_tx = ctx
+        .transaction_builder()
+        .with_fee_payer(fee_payer)
+        .with_signer(&sender)
+        .with_instruction(payment_instruction_1)
+        .with_instruction(payment_instruction_2)
+        .build()
+        .await
+        .expect("Failed to create signed legacy transaction");
+
+    let response: serde_json::Value = ctx
+        .rpc_call("signTransactionIfPaid", rpc_params![encoded_tx])
+        .await
+        .expect("Failed to sign transaction");
+
+    response.assert_success();
+    response.assert_has_field("signed_transaction");
+}
+
+#[tokio::test]
+async fn test_sign_transaction_if_paid_with_multiple_payments_insufficient_legacy() {
+    let ctx = TestContext::new().await.expect("Failed to create test context");
+    let sender = SenderTestHelper::get_test_sender_keypair();
+    let payment_address = Pubkey::from_str(TEST_PAYMENT_ADDRESS).unwrap();
+    let test_mint = USDCMintTestHelper::get_test_usdc_mint_pubkey();
+
+    let sender_token_account = get_associated_token_address(&sender.pubkey(), &test_mint);
+    let payment_address_token_account = get_associated_token_address(&payment_address, &test_mint);
+
+    let token_interface = TokenProgram::new();
+
+    let required_fee = get_fee_for_default_transaction_in_usdc();
+    let payment_1 = required_fee / 3;
+    let payment_2 = required_fee / 3;
+
+    let payment_instruction_1 = token_interface
+        .create_transfer_instruction(
+            &sender_token_account,
+            &payment_address_token_account,
+            &sender.pubkey(),
+            payment_1,
+        )
+        .unwrap();
+
+    let payment_instruction_2 = token_interface
+        .create_transfer_instruction(
+            &sender_token_account,
+            &payment_address_token_account,
+            &sender.pubkey(),
+            payment_2,
+        )
+        .unwrap();
+
+    let fee_payer = FeePayerTestHelper::get_fee_payer_pubkey();
+
+    let encoded_tx = ctx
+        .transaction_builder()
+        .with_fee_payer(fee_payer)
+        .with_signer(&sender)
+        .with_instruction(payment_instruction_1)
+        .with_instruction(payment_instruction_2)
+        .build()
+        .await
+        .expect("Failed to create signed legacy transaction");
+
+    let response: Result<serde_json::Value, _> =
+        ctx.rpc_call("signTransactionIfPaid", rpc_params![encoded_tx]).await;
+
+    assert!(response.is_err(), "Should fail with insufficient payment");
+}
+
+#[tokio::test]
+async fn test_sign_transaction_if_paid_with_multiple_sources_legacy() {
+    let ctx = TestContext::new().await.expect("Failed to create test context");
+    let sender = SenderTestHelper::get_test_sender_keypair();
+    let payment_address = Pubkey::from_str(TEST_PAYMENT_ADDRESS).unwrap();
+    let test_mint = USDCMintTestHelper::get_test_usdc_mint_pubkey();
+    let test_mint2 = USDCMint2022TestHelper::get_test_usdc_mint_2022_pubkey();
+
+    let required_fee = get_fee_for_default_transaction_in_usdc();
+    let payment_amount = required_fee / 2;
+    // We need to add 50 lamports, because on that mint for 2022 the transfer fee config is 1%
+    let payment_amount_2 = payment_amount + 50;
+
+    let fee_payer = FeePayerTestHelper::get_fee_payer_pubkey();
+
+    let encoded_tx = ctx
+        .transaction_builder()
+        .with_fee_payer(fee_payer)
+        .with_signer(&sender)
+        .with_spl_transfer_checked(
+            &test_mint,
+            &sender.pubkey(),
+            &payment_address,
+            payment_amount,
+            6,
+        )
+        .with_spl_token_2022_transfer_checked(
+            &test_mint2,
+            &sender.pubkey(),
+            &payment_address,
+            payment_amount_2,
+            6,
+        )
+        .build()
+        .await
+        .expect("Failed to create signed legacy transaction");
+
+    let response: serde_json::Value = ctx
+        .rpc_call("signTransactionIfPaid", rpc_params![encoded_tx])
+        .await
+        .expect("Failed to sign transaction");
+
+    response.assert_success();
+    response.assert_has_field("signed_transaction");
+}

--- a/tests/src/common/fixtures/paymaster-address-test.toml
+++ b/tests/src/common/fixtures/paymaster-address-test.toml
@@ -34,9 +34,11 @@ allowed_programs = [
 ]
 allowed_tokens = [
     "9BgeTKqmFsPVnfYscfM6NvsgmZxei7XfdciShQ6D3bxJ", # Test USDC mint for local testing
+    "95kSi2m5MDiKAs8bucgzengMTP5M5FiQnJps9duYcmfG", # Test USDC 2022 mint for local testing
 ]
 allowed_spl_paid_tokens = [
     "9BgeTKqmFsPVnfYscfM6NvsgmZxei7XfdciShQ6D3bxJ", # Test USDC mint for local testing
+    "95kSi2m5MDiKAs8bucgzengMTP5M5FiQnJps9duYcmfG", # Test USDC 2022 mint for local testing
 ]
 
 disallowed_accounts = [


### PR DESCRIPTION
- Now support multi transfers for a payment (so user can transfer from 2 different token accounts to pay for the txn fee)
- Refactored `has_payment_instruction` to `analyze_payment_instructions`, which now returns a tuple indicating the presence of payment instructions and the total transfer fees.
- Improved fee calculation logic for SPL token transfers, including handling for Token2022 fees.
- Added logging for overflow scenarios during payment accumulation.
- Introduced new tests for analyzing payment instructions, including cases with multiple payments and insufficient funds.
- Updated related test cases to reflect the new method and its functionality.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enhance payment instruction analysis and transfer fee calculation by supporting multiple transfers, refactoring functions, improving fee calculations, and updating tests.
> 
>   - **Behavior**:
>     - Support multiple transfers for a payment, allowing users to transfer from different token accounts for transaction fees.
>     - Refactor `has_payment_instruction` to `analyze_payment_instructions` in `fee.rs`, returning a tuple for payment presence and total transfer fees.
>     - Improve SPL token transfer fee calculation, including Token2022 fees.
>     - Add logging for overflow scenarios during payment accumulation.
>   - **Tests**:
>     - Add tests for analyzing payment instructions with multiple payments and insufficient funds in `payment_address_multi_payment_tests.rs`.
>     - Update existing tests to reflect changes in `fee.rs` and `token.rs`.
>   - **Misc**:
>     - Update `paymaster-address-test.toml` to include new test configurations for multi-payment scenarios.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=solana-foundation%2Fkora&utm_source=github&utm_medium=referral)<sup> for eb2fa4eb23023a576e4f0e54aa6eb3d32b35befb. You can [customize](https://app.ellipsis.dev/solana-foundation/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

## 📊 Unit Test Coverage
![Coverage](https://img.shields.io/badge/coverage-80.7%25-green)

**Unit Test Coverage: 80.7%**

[View Detailed Coverage Report](https://github.com/solana-foundation/kora/actions/runs/18757887307)