### PR TITLE
chore: CI Publish fix

### DIFF
--- a/.github/workflows/rust-publish.yml
+++ b/.github/workflows/rust-publish.yml
@@ -44,7 +44,8 @@ jobs:
           # Get last release tag for changelog range
           LAST_TAG=$(git tag -l "v*" --sort=-version:refname | head -1)
           if [ -z "$LAST_TAG" ]; then
-            echo "tag_range=HEAD" >> $GITHUB_OUTPUT
+            # First run of CI - hardcoded commit range from audit commit to HEAD
+            echo "tag_range=024df585e6da5cddd5adba21174acd3f101f3981..HEAD" >> $GITHUB_OUTPUT
           else
             echo "tag_range=$LAST_TAG..HEAD" >> $GITHUB_OUTPUT
           fi


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes changelog generation for first CI run by hardcoding commit range in `rust-publish.yml`.
> 
>   - **Behavior**:
>     - In `rust-publish.yml`, modifies the logic to handle the first CI run by setting `tag_range` to `024df585e6da5cddd5adba21174acd3f101f3981..HEAD` when no previous tag exists.
>   - **Misc**:
>     - Adds a comment explaining the hardcoded commit range for the first CI run.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=solana-foundation%2Fkora&utm_source=github&utm_medium=referral)<sup> for c2004eb24661da3287e4a3407032f81ccf2c5193. You can [customize](https://app.ellipsis.dev/solana-foundation/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->