### PR TITLE
chore: add manual sdk publish

### DIFF
--- a/.github/workflows/ts-sdk-publish-manual.yml
+++ b/.github/workflows/ts-sdk-publish-manual.yml
@@ -1,0 +1,173 @@
+name: Publish TypeScript SDK (Manual)
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version bump type or specific version (patch, minor, major, or semver like 1.2.3)'
+        required: true
+        default: 'patch'
+        type: string
+      publish-to-npm:
+        description: 'Publish to npm registry'
+        required: true
+        default: true
+        type: boolean
+      create-github-release:
+        description: 'Create GitHub release'
+        required: true
+        default: true
+        type: boolean
+
+permissions:
+  contents: write
+  id-token: write
+
+# Prevent concurrent publishes
+concurrency:
+  group: ts-sdk-publish
+  cancel-in-progress: false
+
+jobs:
+  # Run tests before publishing
+  typescript-integration:
+    uses: ./.github/workflows/typescript-integration.yml
+    secrets: inherit
+
+  typescript-unit:
+    uses: ./.github/workflows/typescript-unit.yml
+    secrets: inherit
+
+  publish:
+    name: Publish TypeScript SDK
+    runs-on: ubuntu-latest
+    needs: [typescript-integration, typescript-unit]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Git user
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 'lts/*'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.12.3
+          run_install: false
+
+      - name: Get pnpm store directory
+        shell: bash
+        working-directory: sdks
+        run: |
+          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+
+      - name: Setup pnpm cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      - name: Install dependencies
+        working-directory: sdks
+        run: pnpm install --frozen-lockfile
+
+      - name: Bump version
+        id: version
+        working-directory: sdks/ts
+        run: |
+          # Determine if input is a bump type or specific version
+          if [[ "${{ github.event.inputs.version }}" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-.*)?$ ]]; then
+            # Specific version provided
+            pnpm version ${{ github.event.inputs.version }} --no-git-tag-version
+          else
+            # Bump type (patch, minor, major)
+            pnpm version ${{ github.event.inputs.version }} --no-git-tag-version
+          fi
+
+          # Get the new version
+          NEW_VERSION=$(node -p "require('./package.json').version")
+          echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
+          echo "📦 New version: $NEW_VERSION"
+
+      - name: Build TypeScript SDK
+        working-directory: sdks
+        run: pnpm --filter "@solana/kora" build
+
+      - name: Run type check
+        working-directory: sdks/ts
+        run: pnpm type-check
+
+      - name: Commit version bump
+        working-directory: sdks/ts
+        run: |
+          git add package.json
+          git commit -m "chore(ts-sdk): release v${{ steps.version.outputs.new_version }}"
+          git tag "ts-sdk-v${{ steps.version.outputs.new_version }}"
+
+      - name: Push changes
+        run: |
+          git push origin HEAD:${{ github.ref_name }}
+          git push origin "ts-sdk-v${{ steps.version.outputs.new_version }}"
+
+      - name: Publish to npm
+        if: ${{ github.event.inputs.publish-to-npm == 'true' }}
+        working-directory: sdks/ts
+        run: |
+          echo "📦 Publishing @solana/kora@${{ steps.version.outputs.new_version }} to npm..."
+          pnpm publish --access public --no-git-checks
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Create GitHub Release
+        if: ${{ github.event.inputs.create-github-release == 'true' }}
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const tagName = `ts-sdk-v${{ steps.version.outputs.new_version }}`;
+            const releaseName = `TypeScript SDK v${{ steps.version.outputs.new_version }}`;
+
+            await github.rest.repos.createRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              tag_name: tagName,
+              name: releaseName,
+              body: `Release of @solana/kora v${{ steps.version.outputs.new_version }}`,
+              draft: false,
+              prerelease: false,
+            });
+
+            console.log(`✅ Created release: ${releaseName}`);
+
+      - name: Publish summary
+        run: |
+          echo "## 🎉 TypeScript SDK Published" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Version**: \`${{ steps.version.outputs.new_version }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "**Package**: \`@solana/kora\`" >> $GITHUB_STEP_SUMMARY
+          echo "**Tag**: \`ts-sdk-v${{ steps.version.outputs.new_version }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          if [ "${{ github.event.inputs.publish-to-npm }}" == "true" ]; then
+            echo "✅ Published to npm: https://www.npmjs.com/package/@solana/kora/v/${{ steps.version.outputs.new_version }}" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "⏭️ Skipped npm publish (dry run)" >> $GITHUB_STEP_SUMMARY
+          fi
+          if [ "${{ github.event.inputs.create-github-release }}" == "true" ]; then
+            echo "✅ GitHub release created: https://github.com/${{ github.repository }}/releases/tag/ts-sdk-v${{ steps.version.outputs.new_version }}" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "⏭️ Skipped GitHub release creation" >> $GITHUB_STEP_SUMMARY
+          fi


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds a manual GitHub Actions workflow for publishing the TypeScript SDK, including version bumping, building, testing, and optional npm and GitHub release publishing.
> 
>   - **Workflow**:
>     - Adds `ts-sdk-publish-manual.yml` for manual TypeScript SDK publishing.
>     - Triggered by `workflow_dispatch` with inputs for version bump type, npm publish, and GitHub release.
>   - **Jobs**:
>     - Runs `typescript-integration` and `typescript-unit` tests before publishing.
>     - `publish` job includes steps for checking out code, setting up Node.js and pnpm, installing dependencies, bumping version, building, type-checking, and committing changes.
>   - **Publishing**:
>     - Publishes to npm if `publish-to-npm` is true, using `pnpm publish`.
>     - Creates GitHub release if `create-github-release` is true, using `actions/github-script`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=solana-foundation%2Fkora&utm_source=github&utm_medium=referral)<sup> for e1cfa42afdaa7acb52d0673cd3efab4057a7ad02. You can [customize](https://app.ellipsis.dev/solana-foundation/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->