### PR TITLE
chore: add npm link/badge to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 ![Coverage](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/solana-foundation/kora/main/.github/badges/coverage.json)
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/solana-foundation/kora)
 [![Crates.io](https://img.shields.io/crates/v/kora-cli.svg)](https://crates.io/crates/kora-cli)
+[![npm](https://img.shields.io/npm/v/@solana/kora)](https://www.npmjs.com/package/@solana/kora)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
   <br />
@@ -160,7 +161,8 @@ Kora has been audited by [Runtime Verification](https://runtimeverification.com/
 ## Other Resources
 
 - [Kora CLI Crates.io](https://crates.io/crates/kora-cli) - Rust crate for running a Kora node
-- @solana/kora NPM Package Coming Soon
+- [Kora Lib Crates.io](https://crates.io/crates/kora-lib) - Rust crate for the Kora library
+- [@solana/kora](https://www.npmjs.com/package/@solana/kora) - TypeScript SDK for Kora
 
 ---
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add npm badge and link to `@solana/kora` TypeScript SDK in README.
> 
>   - **README.md**:
>     - Add npm badge linking to `@solana/kora` on npm.
>     - Update "Other Resources" section to include `@solana/kora` TypeScript SDK link.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=solana-foundation%2Fkora&utm_source=github&utm_medium=referral)<sup> for 5cbd637a3e7ddf88482ff1a0139f1b21f913ef95. You can [customize](https://app.ellipsis.dev/solana-foundation/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->