### PR TITLE
refactor: limit access to config's singleton

### DIFF
--- a/crates/lib/src/admin/token_util.rs
+++ b/crates/lib/src/admin/token_util.rs
@@ -1,4 +1,5 @@
 use crate::{
+    config::Config,
     error::KoraError,
     state::{get_request_signer_with_signer_key, get_signer_pool},
     token::token::TokenType,
@@ -91,10 +92,13 @@ pub async fn initialize_atas_with_chunk_size(
     compute_unit_limit: Option<u32>,
     chunk_size: usize,
 ) -> Result<(), KoraError> {
+    let config = get_config()?;
+
     for address in addresses_to_initialize_atas {
         println!("Initializing ATAs for address: {address}");
 
-        let atas_to_create = find_missing_atas(rpc_client, address).await?;
+        #[allow(clippy::needless_borrow)]
+        let atas_to_create = find_missing_atas(&config, rpc_client, address).await?;
 
         if atas_to_create.is_empty() {
             println!("✓ All required ATAs already exist for address: {address}");
@@ -245,11 +249,10 @@ async fn create_atas_for_signer(
 }
 
 pub async fn find_missing_atas(
+    config: &Config,
     rpc_client: &RpcClient,
     payment_address: &Pubkey,
 ) -> Result<Vec<ATAToCreate>, KoraError> {
-    let config = get_config()?;
-
     // Parse all allowed SPL paid token mints
     let mut token_mints = Vec::new();
     for token_str in &config.validation.allowed_spl_paid_tokens {
@@ -273,14 +276,14 @@ pub async fn find_missing_atas(
     for mint in &token_mints {
         let ata = get_associated_token_address(payment_address, mint);
 
-        match CacheUtil::get_account(rpc_client, &ata, false).await {
+        match CacheUtil::get_account(config, rpc_client, &ata, false).await {
             Ok(_) => {
                 println!("✓ ATA already exists for token {mint}: {ata}");
             }
             Err(_) => {
                 // Fetch mint account to determine if it's SPL or Token2022
                 let mint_account =
-                    CacheUtil::get_account(rpc_client, mint, false).await.map_err(|e| {
+                    CacheUtil::get_account(config, rpc_client, mint, false).await.map_err(|e| {
                         KoraError::RpcError(format!("Failed to fetch mint account for {mint}: {e}"))
                     })?;
 
@@ -328,7 +331,8 @@ mod tests {
         let rpc_client = create_mock_rpc_client_account_not_found();
         let payment_address = Pubkey::new_unique();
 
-        let result = find_missing_atas(&rpc_client, &payment_address).await.unwrap();
+        let config = get_config().unwrap();
+        let result = find_missing_atas(&config, &rpc_client, &payment_address).await.unwrap();
 
         assert!(result.is_empty(), "Should return empty vec when no SPL tokens configured");
     }
@@ -366,9 +370,10 @@ mod tests {
         cache_ctx
             .expect()
             .times(3)
-            .returning(move |_, _, _| responses_clone.lock().unwrap().pop_front().unwrap());
+            .returning(move |_, _, _, _| responses_clone.lock().unwrap().pop_front().unwrap());
 
-        let result = find_missing_atas(&rpc_client, &payment_address).await;
+        let config = get_config().unwrap();
+        let result = find_missing_atas(&config, &rpc_client, &payment_address).await;
 
         assert!(result.is_ok(), "Should handle SPL tokens with proper mocking");
         let atas = result.unwrap();

--- a/crates/lib/src/cache.rs
+++ b/crates/lib/src/cache.rs
@@ -5,7 +5,7 @@ use solana_client::nonblocking::rpc_client::RpcClient;
 use solana_sdk::{account::Account, pubkey::Pubkey};
 use tokio::sync::OnceCell;
 
-use crate::{error::KoraError, sanitize_error};
+use crate::{config::Config, error::KoraError, sanitize_error};
 
 #[cfg(not(test))]
 use crate::state::get_config;
@@ -33,7 +33,8 @@ impl CacheUtil {
     pub async fn init() -> Result<(), KoraError> {
         let config = get_config()?;
 
-        let pool = if CacheUtil::is_cache_enabled() {
+        #[allow(clippy::needless_borrow)]
+        let pool = if CacheUtil::is_cache_enabled(&config) {
             let redis_url = config.kora.cache.url.as_ref().ok_or(KoraError::ConfigError)?;
 
             let cfg = deadpool_redis::Config::from_url(redis_url);
@@ -179,23 +180,19 @@ impl CacheUtil {
     }
 
     /// Check if cache is enabled and available
-    fn is_cache_enabled() -> bool {
-        match get_config() {
-            Ok(config) => config.kora.cache.enabled && config.kora.cache.url.is_some(),
-            Err(_) => false,
-        }
+    fn is_cache_enabled(config: &Config) -> bool {
+        config.kora.cache.enabled && config.kora.cache.url.is_some()
     }
 
     /// Get account from cache with optional force refresh
     pub async fn get_account(
+        config: &Config,
         rpc_client: &RpcClient,
         pubkey: &Pubkey,
         force_refresh: bool,
     ) -> Result<Account, KoraError> {
-        let config = get_config()?;
-
         // If cache is disabled or force refresh is requested, go directly to RPC
-        if !CacheUtil::is_cache_enabled() {
+        if !CacheUtil::is_cache_enabled(config) {
             return Self::get_account_from_rpc(rpc_client, pubkey).await;
         }
 
@@ -264,7 +261,8 @@ mod tests {
     async fn test_is_cache_enabled_disabled() {
         let _m = ConfigMockBuilder::new().with_cache_enabled(false).build_and_setup();
 
-        assert!(!CacheUtil::is_cache_enabled());
+        let config = get_config().unwrap();
+        assert!(!CacheUtil::is_cache_enabled(&config));
     }
 
     #[tokio::test]
@@ -275,7 +273,8 @@ mod tests {
             .build_and_setup();
 
         // Without URL, cache should be disabled
-        assert!(!CacheUtil::is_cache_enabled());
+        let config = get_config().unwrap();
+        assert!(!CacheUtil::is_cache_enabled(&config));
     }
 
     #[tokio::test]
@@ -286,7 +285,8 @@ mod tests {
             .build_and_setup();
 
         // Give time for config to be set up
-        assert!(CacheUtil::is_cache_enabled());
+        let config = get_config().unwrap();
+        assert!(CacheUtil::is_cache_enabled(&config));
     }
 
     #[tokio::test]
@@ -336,7 +336,8 @@ mod tests {
 
         let rpc_client = RpcMockBuilder::new().with_account_info(&expected_account).build();
 
-        let result = CacheUtil::get_account(&rpc_client, &pubkey, false).await;
+        let config = get_config().unwrap();
+        let result = CacheUtil::get_account(&config, &rpc_client, &pubkey, false).await;
 
         assert!(result.is_ok());
         let account = result.unwrap();
@@ -355,7 +356,8 @@ mod tests {
         let rpc_client = RpcMockBuilder::new().with_account_info(&expected_account).build();
 
         // force_refresh = true should always go to RPC
-        let result = CacheUtil::get_account(&rpc_client, &pubkey, true).await;
+        let config = get_config().unwrap();
+        let result = CacheUtil::get_account(&config, &rpc_client, &pubkey, true).await;
 
         assert!(result.is_ok());
         let account = result.unwrap();

--- a/crates/lib/src/metrics/balance.rs
+++ b/crates/lib/src/metrics/balance.rs
@@ -2,7 +2,7 @@
 use crate::state::get_config;
 #[cfg(test)]
 use crate::tests::config_mock::mock_state::get_config;
-use crate::{cache::CacheUtil, error::KoraError, state::get_signers_info};
+use crate::{cache::CacheUtil, config::Config, error::KoraError, state::get_signers_info};
 use prometheus::{register_gauge_vec, GaugeVec};
 use solana_client::nonblocking::rpc_client::RpcClient;
 use solana_sdk::pubkey::Pubkey;
@@ -44,7 +44,10 @@ impl BalanceTracker {
     }
 
     /// Track all signers' balances and update Prometheus metrics
-    pub async fn track_all_signer_balances(rpc_client: &Arc<RpcClient>) -> Result<(), KoraError> {
+    pub async fn track_all_signer_balances(
+        config: &Config,
+        rpc_client: &Arc<RpcClient>,
+    ) -> Result<(), KoraError> {
         if !BalanceTracker::is_enabled() {
             return Ok(());
         }
@@ -64,7 +67,7 @@ impl BalanceTracker {
                     ))
                 })?;
 
-                match CacheUtil::get_account(rpc_client, &pubkey, false).await {
+                match CacheUtil::get_account(config, rpc_client, &pubkey, false).await {
                     Ok(account) => {
                         balance_results.push((signer_info, account.lamports));
                     }
@@ -120,6 +123,9 @@ impl BalanceTracker {
         let interval_seconds = config.metrics.fee_payer_balance.expiry_seconds;
         log::info!("Starting multi-signer balance tracking background task with {interval_seconds}s interval");
 
+        // Clone config to move into the spawned task
+        let config = config.clone();
+
         // Spawn a background task that runs forever
         let handle = tokio::spawn(async move {
             let mut interval = interval(Duration::from_secs(interval_seconds));
@@ -128,7 +134,9 @@ impl BalanceTracker {
                 interval.tick().await;
 
                 // Track all signer balances, but don't let errors crash the loop
-                if let Err(e) = BalanceTracker::track_all_signer_balances(&rpc_client).await {
+                if let Err(e) =
+                    BalanceTracker::track_all_signer_balances(&config, &rpc_client).await
+                {
                     log::warn!("Failed to track signer balances in background task: {e}");
                 }
             }
@@ -295,8 +303,9 @@ mod tests {
             )
             .build_and_setup();
 
+        let config = get_config().unwrap();
         let mock_rpc = RpcMockBuilder::new().build();
-        let result = BalanceTracker::track_all_signer_balances(&mock_rpc).await;
+        let result = BalanceTracker::track_all_signer_balances(&config, &mock_rpc).await;
         assert!(result.is_ok());
     }
 
@@ -317,10 +326,11 @@ mod tests {
         setup_test_signer_pool();
         let _ = BalanceTracker::init().await;
 
+        let config = get_config().unwrap();
         let account = create_mock_account_with_balance(1_000_000_000); // 1 SOL
         let mock_rpc = RpcMockBuilder::new().with_account_info(&account).build();
 
-        let result = BalanceTracker::track_all_signer_balances(&mock_rpc).await;
+        let result = BalanceTracker::track_all_signer_balances(&config, &mock_rpc).await;
         assert!(result.is_ok());
     }
 
@@ -341,9 +351,10 @@ mod tests {
         setup_test_signer_pool();
         let _ = BalanceTracker::init().await;
 
+        let config = get_config().unwrap();
         let mock_rpc = RpcMockBuilder::new().with_account_not_found().build();
 
-        let result = BalanceTracker::track_all_signer_balances(&mock_rpc).await;
+        let result = BalanceTracker::track_all_signer_balances(&config, &mock_rpc).await;
         assert!(result.is_ok());
     }
 

--- a/crates/lib/src/rpc_server/method/estimate_transaction_fee.rs
+++ b/crates/lib/src/rpc_server/method/estimate_transaction_fee.rs
@@ -55,29 +55,34 @@ pub async fn estimate_transaction_fee(
     let validation_config = &config.validation;
     let fee_payer = signer.pubkey();
 
+    #[allow(clippy::needless_borrow)]
     let mut resolved_transaction = VersionedTransactionResolved::from_transaction(
         &transaction,
+        &config,
         rpc_client,
         request.sig_verify,
     )
     .await?;
 
+    #[allow(clippy::needless_borrow)]
     let fee_calculation = FeeConfigUtil::estimate_kora_fee(
-        rpc_client,
         &mut resolved_transaction,
         &fee_payer,
         validation_config.is_payment_required(),
-        validation_config.price_source.clone(),
+        rpc_client,
+        &config,
     )
     .await?;
 
     let fee_in_lamports = fee_calculation.total_fee_lamports;
 
+    #[allow(clippy::needless_borrow)]
     // Calculate fee in token if requested
     let fee_in_token = FeeConfigUtil::calculate_fee_in_token(
-        rpc_client,
         fee_in_lamports,
         request.fee_token.as_deref(),
+        rpc_client,
+        &config,
     )
     .await?;
 

--- a/crates/lib/src/rpc_server/method/sign_transaction.rs
+++ b/crates/lib/src/rpc_server/method/sign_transaction.rs
@@ -1,6 +1,6 @@
 use crate::{
     rpc_server::middleware_utils::default_sig_verify,
-    state::get_request_signer_with_signer_key,
+    state::{get_config, get_request_signer_with_signer_key},
     transaction::{TransactionUtil, VersionedTransactionOps, VersionedTransactionResolved},
     usage_limit::UsageTracker,
     KoraError,
@@ -35,20 +35,23 @@ pub async fn sign_transaction(
 ) -> Result<SignTransactionResponse, KoraError> {
     let transaction = TransactionUtil::decode_b64_transaction(&request.transaction)?;
 
+    let config = get_config()?;
+
     // Check usage limit for transaction sender
-    UsageTracker::check_transaction_usage_limit(&transaction).await?;
+    UsageTracker::check_transaction_usage_limit(config, &transaction).await?;
 
     let signer = get_request_signer_with_signer_key(request.signer_key.as_deref())?;
 
     let mut resolved_transaction = VersionedTransactionResolved::from_transaction(
         &transaction,
+        config,
         rpc_client,
         request.sig_verify,
     )
     .await?;
 
     let (signed_transaction, _) =
-        resolved_transaction.sign_transaction(&signer, rpc_client).await?;
+        resolved_transaction.sign_transaction(config, &signer, rpc_client).await?;
 
     let encoded = TransactionUtil::encode_versioned_transaction(&signed_transaction)?;
 

--- a/crates/lib/src/tests/cache_mock.rs
+++ b/crates/lib/src/tests/cache_mock.rs
@@ -1,4 +1,4 @@
-use crate::error::KoraError;
+use crate::{config::Config, error::KoraError};
 use mockall::mock;
 use solana_client::nonblocking::rpc_client::RpcClient;
 use solana_sdk::{account::Account, pubkey::Pubkey};
@@ -7,6 +7,7 @@ mock! {
     pub CacheUtil {
         pub async fn init() -> Result<(), KoraError>;
         pub async fn get_account(
+            config: &Config,
             rpc_client: &RpcClient,
             pubkey: &Pubkey,
             force_refresh: bool,

--- a/crates/lib/src/usage_limit/usage_tracker.rs
+++ b/crates/lib/src/usage_limit/usage_tracker.rs
@@ -6,7 +6,7 @@ use solana_sdk::{pubkey::Pubkey, transaction::VersionedTransaction};
 use tokio::sync::OnceCell;
 
 use super::usage_store::{RedisUsageStore, UsageStore};
-use crate::{error::KoraError, sanitize_error, state::get_signer_pool};
+use crate::{config::Config, error::KoraError, sanitize_error, state::get_signer_pool};
 
 #[cfg(not(test))]
 use crate::state::get_config;
@@ -205,10 +205,9 @@ impl UsageTracker {
 
     /// Check usage limit for transaction sender
     pub async fn check_transaction_usage_limit(
+        config: &Config,
         transaction: &VersionedTransaction,
     ) -> Result<(), KoraError> {
-        let config = get_config()?;
-
         if let Some(limiter) = Self::get_usage_limiter()? {
             let sender = limiter.extract_transaction_sender(transaction)?;
             if let Some(sender) = sender {
@@ -307,7 +306,9 @@ mod tests {
         // Initialize the usage limiter - it should set to None when disabled
         let _ = UsageTracker::init_usage_limiter().await;
 
-        let result = UsageTracker::check_transaction_usage_limit(&create_mock_transaction()).await;
+        let config = get_config().unwrap();
+        let result =
+            UsageTracker::check_transaction_usage_limit(&config, &create_mock_transaction()).await;
         match &result {
             Ok(_) => {}
             Err(e) => println!("Test failed with error: {e}"),
@@ -326,7 +327,9 @@ mod tests {
         // Initialize with no cache_url - should set limiter to None
         let _ = UsageTracker::init_usage_limiter().await;
 
-        let result = UsageTracker::check_transaction_usage_limit(&create_mock_transaction()).await;
+        let config = get_config().unwrap();
+        let result =
+            UsageTracker::check_transaction_usage_limit(&config, &create_mock_transaction()).await;
         assert!(result.is_ok());
     }
 
@@ -341,7 +344,9 @@ mod tests {
         // Initialize with no cache_url - should set limiter to None
         let _ = UsageTracker::init_usage_limiter().await;
 
-        let result = UsageTracker::check_transaction_usage_limit(&create_mock_transaction()).await;
+        let config = get_config().unwrap();
+        let result =
+            UsageTracker::check_transaction_usage_limit(&config, &create_mock_transaction()).await;
         assert!(result.is_err());
         assert!(result
             .unwrap_err()

--- a/crates/lib/src/validator/account_validator.rs
+++ b/crates/lib/src/validator/account_validator.rs
@@ -11,7 +11,7 @@ use spl_token_interface::{
     ID as SPL_TOKEN_PROGRAM_ID,
 };
 
-use crate::{CacheUtil, KoraError};
+use crate::{config::Config, CacheUtil, KoraError};
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum AccountType {
@@ -132,11 +132,12 @@ impl AccountType {
 }
 
 pub async fn validate_account(
+    config: &Config,
     rpc_client: &RpcClient,
     account_pubkey: &Pubkey,
     expected_account_type: Option<AccountType>,
 ) -> Result<(), KoraError> {
-    let account = CacheUtil::get_account(rpc_client, account_pubkey, false).await?;
+    let account = CacheUtil::get_account(config, rpc_client, account_pubkey, false).await?;
 
     if let Some(expected_type) = expected_account_type {
         expected_type.validate_account_type(&account, account_pubkey)?;
@@ -156,7 +157,7 @@ mod tests {
             create_mock_token_account, AccountMockBuilder,
         },
         common::{MintAccountMockBuilder, TokenAccountMockBuilder},
-        config_mock::ConfigMockBuilder,
+        config_mock::{mock_state::get_config, ConfigMockBuilder},
         rpc_mock::{create_mock_rpc_client_account_not_found, create_mock_rpc_client_with_account},
     };
 
@@ -365,7 +366,9 @@ mod tests {
         let rpc_client = create_mock_rpc_client_with_account(&mint_account);
         let account_pubkey = Pubkey::new_unique();
 
-        let result = validate_account(&rpc_client, &account_pubkey, Some(AccountType::Mint)).await;
+        let config = get_config().unwrap();
+        let result =
+            validate_account(&config, &rpc_client, &account_pubkey, Some(AccountType::Mint)).await;
         assert!(result.is_ok());
     }
 
@@ -377,7 +380,8 @@ mod tests {
         let rpc_client = create_mock_rpc_client_with_account(&account);
         let account_pubkey = Pubkey::new_unique();
 
-        let result = validate_account(&rpc_client, &account_pubkey, None).await;
+        let config = get_config().unwrap();
+        let result = validate_account(&config, &rpc_client, &account_pubkey, None).await;
         assert!(result.is_ok());
     }
 
@@ -388,8 +392,10 @@ mod tests {
         let rpc_client = create_mock_rpc_client_account_not_found();
         let account_pubkey = Pubkey::new_unique();
 
+        let config = get_config().unwrap();
         let result =
-            validate_account(&rpc_client, &account_pubkey, Some(AccountType::System)).await;
+            validate_account(&config, &rpc_client, &account_pubkey, Some(AccountType::System))
+                .await;
         assert!(result.is_err());
         let error_msg = result.unwrap_err().to_string();
         assert!(error_msg.contains("Account") && error_msg.contains("not found"));
@@ -403,8 +409,10 @@ mod tests {
         let rpc_client = create_mock_rpc_client_with_account(&account);
         let account_pubkey = Pubkey::new_unique();
 
+        let config = get_config().unwrap();
         let result =
-            validate_account(&rpc_client, &account_pubkey, Some(AccountType::System)).await;
+            validate_account(&config, &rpc_client, &account_pubkey, Some(AccountType::System))
+                .await;
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("is not owned by"));
     }

--- a/crates/lib/src/validator/config_validator.rs
+++ b/crates/lib/src/validator/config_validator.rs
@@ -478,9 +478,13 @@ impl ConfigValidator {
             // Validate allowed programs - should be executable
             for program_str in &config.validation.allowed_programs {
                 if let Ok(program_pubkey) = Pubkey::from_str(program_str) {
-                    if let Err(e) =
-                        validate_account(rpc_client, &program_pubkey, Some(AccountType::Program))
-                            .await
+                    if let Err(e) = validate_account(
+                        config,
+                        rpc_client,
+                        &program_pubkey,
+                        Some(AccountType::Program),
+                    )
+                    .await
                     {
                         errors.push(format!("Program {program_str} validation failed: {e}"));
                     }
@@ -491,7 +495,8 @@ impl ConfigValidator {
             for token_str in &config.validation.allowed_tokens {
                 if let Ok(token_pubkey) = Pubkey::from_str(token_str) {
                     if let Err(e) =
-                        validate_account(rpc_client, &token_pubkey, Some(AccountType::Mint)).await
+                        validate_account(config, rpc_client, &token_pubkey, Some(AccountType::Mint))
+                            .await
                     {
                         errors.push(format!("Token {token_str} validation failed: {e}"));
                     }
@@ -502,7 +507,8 @@ impl ConfigValidator {
             for token_str in &config.validation.allowed_spl_paid_tokens {
                 if let Ok(token_pubkey) = Pubkey::from_str(token_str) {
                     if let Err(e) =
-                        validate_account(rpc_client, &token_pubkey, Some(AccountType::Mint)).await
+                        validate_account(config, rpc_client, &token_pubkey, Some(AccountType::Mint))
+                            .await
                     {
                         errors.push(format!("SPL paid token {token_str} validation failed: {e}"));
                     }
@@ -520,7 +526,7 @@ impl ConfigValidator {
             // Validate missing ATAs for payment address
             if let Some(payment_address) = &config.kora.payment_address {
                 if let Ok(payment_address) = Pubkey::from_str(payment_address) {
-                    match find_missing_atas(rpc_client, &payment_address).await {
+                    match find_missing_atas(config, rpc_client, &payment_address).await {
                         Ok(atas_to_create) => {
                             if !atas_to_create.is_empty() {
                                 errors.push(format!(


### PR DESCRIPTION
Work done by @lgalabru

Commits of https://github.com/solana-foundation/kora/pull/247 but rebased on main / newer version

(From https://github.com/txtx/kora/tree/fix/limit-singletons-access)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Refactor code to pass `config` as a parameter to functions, improving modularity and reducing global state dependency.
> 
>   - **Behavior**:
>     - Refactor to pass `config` as a parameter to functions instead of accessing it globally.
>     - Affects functions like `validate_transaction`, `check_transaction_usage_limit`, and `validate_with_result`.
>   - **Files**:
>     - `transaction/versioned_transaction.rs`: Updates `VersionedTransactionResolved` methods to accept `config`.
>     - `usage_limit/usage_tracker.rs`: Modifies `check_transaction_usage_limit` to require `config`.
>     - `validator/config_validator.rs`: Changes `validate_with_result` to use `config` parameter.
>   - **Misc**:
>     - Improves modularity and testability by reducing global state dependency.
>     - Updates tests to accommodate the new function signatures.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=solana-foundation%2Fkora&utm_source=github&utm_medium=referral)<sup> for b6d780fb0cdda3031e497a9a73d12e6eca6f02fd. You can [customize](https://app.ellipsis.dev/solana-foundation/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

## 📊 Unit Test Coverage
![Coverage](https://img.shields.io/badge/coverage-81.0%25-green)

**Unit Test Coverage: 81.0%**

[View Detailed Coverage Report](https://github.com/solana-foundation/kora/actions/runs/19650962529)