### PR TITLE
ci: automate rust release & tag

### DIFF
--- a/.github/workflows/rust-publish.yml
+++ b/.github/workflows/rust-publish.yml
@@ -2,6 +2,17 @@ name: Publish Rust Crates
 
 on:
   workflow_dispatch:
+    inputs:
+      publish-to-crates-io:
+        description: 'Publish to crates.io registry'
+        required: true
+        default: true
+        type: boolean
+      create-github-release:
+        description: 'Create GitHub release'
+        required: true
+        default: true
+        type: boolean
 
 permissions:
   contents: write
@@ -35,24 +46,82 @@ jobs:
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "📦 Kora v$VERSION"
 
-      - name: Create git tags
+      - name: Create and push git tags
         run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
           git tag "v${{ steps.version.outputs.version }}"
           git tag "kora-lib-v${{ steps.version.outputs.version }}"
           git tag "kora-cli-v${{ steps.version.outputs.version }}"
           git push origin --tags
 
       - name: Publish kora-lib to crates.io
-        run: cargo publish -p kora-lib --locked
+        if: ${{ github.event.inputs.publish-to-crates-io == 'true' }}
+        run: |
+          echo "📦 Publishing kora-lib@${{ steps.version.outputs.version }} to crates.io..."
+          cargo publish -p kora-lib --locked
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.KORA_CLI_REGISTRY_TOKEN }}
 
       - name: Wait for kora-lib to be available on crates.io
+        if: ${{ github.event.inputs.publish-to-crates-io == 'true' }}
         run: |
           echo "Waiting 30 seconds for crates.io to index kora-lib..."
           sleep 30
 
       - name: Publish kora-cli to crates.io
-        run: cargo publish -p kora-cli --locked
+        if: ${{ github.event.inputs.publish-to-crates-io == 'true' }}
+        run: |
+          echo "📦 Publishing kora-cli@${{ steps.version.outputs.version }} to crates.io..."
+          cargo publish -p kora-cli --locked
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.KORA_CLI_REGISTRY_TOKEN }}
+
+      - name: Create GitHub Release
+        if: ${{ github.event.inputs.create-github-release == 'true' }}
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const tagName = `v${{ steps.version.outputs.version }}`;
+            const releaseName = `Kora v${{ steps.version.outputs.version }}`;
+
+            await github.rest.repos.createRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              tag_name: tagName,
+              name: releaseName,
+              body: `Release of Kora v${{ steps.version.outputs.version }}\n\n**Crates:**\n- kora-lib v${{ steps.version.outputs.version }}\n- kora-cli v${{ steps.version.outputs.version }}`,
+              draft: false,
+              prerelease: false,
+            });
+
+            console.log(`✅ Created release: ${releaseName}`);
+
+      - name: Publish summary
+        run: |
+          echo "## 🎉 Kora Crates Published" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Version**: \`${{ steps.version.outputs.version }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "**Crates**:" >> $GITHUB_STEP_SUMMARY
+          echo "- \`kora-lib\`" >> $GITHUB_STEP_SUMMARY
+          echo "- \`kora-cli\`" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Tags**:" >> $GITHUB_STEP_SUMMARY
+          echo "- \`v${{ steps.version.outputs.version }}\` (generic)" >> $GITHUB_STEP_SUMMARY
+          echo "- \`kora-lib-v${{ steps.version.outputs.version }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "- \`kora-cli-v${{ steps.version.outputs.version }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          if [ "${{ github.event.inputs.publish-to-crates-io }}" == "true" ]; then
+            echo "✅ Published to crates.io:" >> $GITHUB_STEP_SUMMARY
+            echo "- https://crates.io/crates/kora-lib/${{ steps.version.outputs.version }}" >> $GITHUB_STEP_SUMMARY
+            echo "- https://crates.io/crates/kora-cli/${{ steps.version.outputs.version }}" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "⏭️ Skipped crates.io publish (dry run)" >> $GITHUB_STEP_SUMMARY
+          fi
+          echo "" >> $GITHUB_STEP_SUMMARY
+          if [ "${{ github.event.inputs.create-github-release }}" == "true" ]; then
+            echo "✅ GitHub release created: https://github.com/${{ github.repository }}/releases/tag/v${{ steps.version.outputs.version }}" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "⏭️ Skipped GitHub release creation" >> $GITHUB_STEP_SUMMARY
+          fi


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Automates Rust release process with options to publish to crates.io and create GitHub releases, controlled by workflow inputs.
> 
>   - **Workflow Inputs**:
>     - Adds `publish-to-crates-io` and `create-github-release` inputs to control publishing and release creation.
>   - **Git Tags**:
>     - Automates creation and pushing of git tags for `kora-lib` and `kora-cli`.
>   - **Publishing**:
>     - Conditional publishing of `kora-lib` and `kora-cli` to crates.io based on `publish-to-crates-io` input.
>     - Waits 30 seconds for crates.io indexing after publishing `kora-lib`.
>   - **GitHub Release**:
>     - Conditional creation of GitHub release based on `create-github-release` input using `actions/github-script@v7`.
>   - **Summary**:
>     - Adds a summary step to log publishing and release actions, including URLs to crates.io and GitHub releases.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=solana-foundation%2Fkora&utm_source=github&utm_medium=referral)<sup> for 6b63f90805a9e4109738ca1592b3665b9c49255a. You can [customize](https://app.ellipsis.dev/solana-foundation/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->