### PR TITLE
fix(sdk): move runtime dependencies to peerDependencies and add contributing guide

### DIFF
--- a/sdks/ts/package.json
+++ b/sdks/ts/package.json
@@ -42,11 +42,15 @@
   ],
   "author": "",
   "license": "MIT",
+  "peerDependencies": {
+    "@solana-program/token": "^0.5.1",
+    "@solana/kit": ">=2.3.0"
+  },
   "devDependencies": {
-    "@solana-program/compute-budget": "^0.8.0",
-    "@solana-program/system": "^0.7.0",
     "@solana-program/token": "^0.5.1",
     "@solana/kit": "^2.3.0",
+    "@solana-program/compute-budget": "^0.8.0",
+    "@solana-program/system": "^0.7.0",
     "@solana/prettier-config-solana": "^0.0.5",
     "@types/jest": "^29.5.12",
     "@types/node": "^20.17.27",

--- a/sdks/ts/src/client.ts
+++ b/sdks/ts/src/client.ts
@@ -1,4 +1,3 @@
-// TODO Make sure to change necessary deps from devdeps to deps
 import { assertIsAddress, createNoopSigner, Instruction } from '@solana/kit';
 import {
     Config,


### PR DESCRIPTION
## Summary

Fixes dependency configuration by moving runtime dependencies to `peerDependencies` 

## Changes

- Move `@solana/kit` and `@solana-program/token` to `peerDependencies`
- Update `@solana/kit` version range from `^2.3.0` to `>=2.3.0` for better flexibility
- Keep packages in `devDependencies` for development/testing
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Move runtime dependencies to `peerDependencies` and update version range in `package.json`, plus minor cleanup in `client.ts`.
> 
>   - **Dependencies**:
>     - Move `@solana/kit` and `@solana-program/token` to `peerDependencies` in `package.json`.
>     - Update `@solana/kit` version range from `^2.3.0` to `>=2.3.0` in `package.json`.
>     - Keep `@solana/kit` and `@solana-program/token` in `devDependencies` for development/testing in `package.json`.
>   - **Misc**:
>     - Remove TODO comment in `client.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=solana-foundation%2Fkora&utm_source=github&utm_medium=referral)<sup> for c16ae2e0f4d7bc04f7858b50df99d9ff8a8bdfc6. You can [customize](https://app.ellipsis.dev/solana-foundation/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->