### PR TITLE
feat: Add getVersion RPC method

### DIFF
--- a/crates/lib/src/config.rs
+++ b/crates/lib/src/config.rs
@@ -324,6 +324,7 @@ pub struct EnabledMethods {
     pub transfer_transaction: bool,
     pub get_blockhash: bool,
     pub get_config: bool,
+    pub get_version: bool,
 }
 
 impl EnabledMethods {
@@ -338,6 +339,7 @@ impl EnabledMethods {
             self.transfer_transaction,
             self.get_blockhash,
             self.get_config,
+            self.get_version,
         ]
         .into_iter()
     }
@@ -372,13 +374,16 @@ impl EnabledMethods {
         if self.get_config {
             methods.push("getConfig".to_string());
         }
+        if self.get_version {
+            methods.push("getVersion".to_string());
+        }
         methods
     }
 }
 
 impl IntoIterator for &EnabledMethods {
     type Item = bool;
-    type IntoIter = std::array::IntoIter<bool, 9>;
+    type IntoIter = std::array::IntoIter<bool, 10>;
 
     fn into_iter(self) -> Self::IntoIter {
         [
@@ -391,6 +396,7 @@ impl IntoIterator for &EnabledMethods {
             self.transfer_transaction,
             self.get_blockhash,
             self.get_config,
+            self.get_version,
         ]
         .into_iter()
     }
@@ -408,6 +414,7 @@ impl Default for EnabledMethods {
             transfer_transaction: true,
             get_blockhash: true,
             get_config: true,
+            get_version: true,
         }
     }
 }
@@ -604,6 +611,7 @@ mod tests {
                 ("get_blockhash", true),
                 ("get_config", true),
                 ("get_payer_signer", true),
+                ("get_version", true),
             ])
             .build_config()
             .unwrap();

--- a/crates/lib/src/rpc_server/method/get_version.rs
+++ b/crates/lib/src/rpc_server/method/get_version.rs
@@ -1,0 +1,27 @@
+use crate::KoraError;
+use serde::Serialize;
+use utoipa::ToSchema;
+
+#[derive(Debug, Clone, Serialize, ToSchema)]
+pub struct GetVersionResponse {
+    pub version: String,
+}
+
+pub async fn get_version() -> Result<GetVersionResponse, KoraError> {
+    Ok(GetVersionResponse { version: env!("CARGO_PKG_VERSION").to_string() })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_get_version_success() {
+        let result = get_version().await;
+        assert!(result.is_ok());
+        let response = result.unwrap();
+        assert!(!response.version.is_empty());
+        // Version should match Cargo.toml version
+        assert_eq!(response.version, env!("CARGO_PKG_VERSION"));
+    }
+}

--- a/crates/lib/src/rpc_server/method/mod.rs
+++ b/crates/lib/src/rpc_server/method/mod.rs
@@ -3,6 +3,7 @@ pub mod get_blockhash;
 pub mod get_config;
 pub mod get_payer_signer;
 pub mod get_supported_tokens;
+pub mod get_version;
 pub mod sign_and_send_transaction;
 pub mod sign_transaction;
 pub mod transfer_transaction;

--- a/crates/lib/src/rpc_server/openapi/docs.rs
+++ b/crates/lib/src/rpc_server/openapi/docs.rs
@@ -18,6 +18,7 @@ use crate::rpc_server::{
         get_config::GetConfigResponse,
         get_payer_signer::GetPayerSignerResponse,
         get_supported_tokens::GetSupportedTokensResponse,
+        get_version::GetVersionResponse,
         sign_and_send_transaction::{
             SignAndSendTransactionRequest, SignAndSendTransactionResponse,
         },
@@ -51,6 +52,7 @@ const JSON_CONTENT_TYPE: &str = "application/json";
         GetConfigResponse,
         GetPayerSignerResponse,
         GetSupportedTokensResponse,
+        GetVersionResponse,
         SignAndSendTransactionRequest,
         SignAndSendTransactionResponse,
         SignTransactionRequest,

--- a/crates/lib/src/rpc_server/rpc.rs
+++ b/crates/lib/src/rpc_server/rpc.rs
@@ -17,6 +17,7 @@ use crate::rpc_server::method::{
     get_config::{get_config, GetConfigResponse},
     get_payer_signer::{get_payer_signer, GetPayerSignerResponse},
     get_supported_tokens::{get_supported_tokens, GetSupportedTokensResponse},
+    get_version::{get_version, GetVersionResponse},
     sign_and_send_transaction::{
         sign_and_send_transaction, SignAndSendTransactionRequest, SignAndSendTransactionResponse,
     },
@@ -121,6 +122,13 @@ impl KoraRpc {
         result
     }
 
+    pub async fn get_version(&self) -> Result<GetVersionResponse, KoraError> {
+        info!("Get version request received");
+        let result = get_version().await;
+        info!("Get version response: {result:?}");
+        result
+    }
+
     #[cfg(feature = "docs")]
     pub fn build_docs_spec() -> Vec<OpenApiSpec> {
         vec![
@@ -164,6 +172,11 @@ impl KoraRpc {
                 request: Some(TransferTransactionRequest::schema().1),
                 response: TransferTransactionResponse::schema().1,
             },
+            OpenApiSpec {
+                name: "getVersion".to_string(),
+                request: None,
+                response: GetVersionResponse::schema().1,
+            },
         ]
     }
 }
@@ -191,6 +204,17 @@ mod tests {
         // Test liveness endpoint
         let result = kora_rpc.liveness().await;
         assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_get_version() {
+        let kora_rpc = create_test_kora_rpc();
+
+        let result = kora_rpc.get_version().await;
+        assert!(result.is_ok());
+        let response = result.unwrap();
+        assert!(!response.version.is_empty());
+        assert_eq!(response.version, env!("CARGO_PKG_VERSION"));
     }
 
     #[tokio::test]

--- a/crates/lib/src/rpc_server/server.rs
+++ b/crates/lib/src/rpc_server/server.rs
@@ -197,6 +197,7 @@ fn build_rpc_module(rpc: KoraRpc) -> Result<RpcModule<KoraRpc>, anyhow::Error> {
         get_blockhash
     );
     register_method_if_enabled!(module, enabled_methods, get_config, "getConfig", get_config);
+    register_method_if_enabled!(module, enabled_methods, get_version, "getVersion", get_version);
 
     Ok(module)
 }
@@ -259,7 +260,7 @@ mod tests {
         // Verify that the module has the expected methods
         let module = result.unwrap();
         let method_names: Vec<&str> = module.method_names().collect();
-        assert_eq!(method_names.len(), 9);
+        assert_eq!(method_names.len(), 10);
         assert!(method_names.contains(&"liveness"));
         assert!(method_names.contains(&"estimateTransactionFee"));
         assert!(method_names.contains(&"getSupportedTokens"));
@@ -269,6 +270,7 @@ mod tests {
         assert!(method_names.contains(&"transferTransaction"));
         assert!(method_names.contains(&"getBlockhash"));
         assert!(method_names.contains(&"getConfig"));
+        assert!(method_names.contains(&"getVersion"));
     }
 
     #[test]
@@ -283,6 +285,7 @@ mod tests {
             transfer_transaction: false,
             get_blockhash: false,
             get_config: false,
+            get_version: false,
             liveness: false,
         };
 
@@ -314,6 +317,7 @@ mod tests {
             sign_and_send_transaction: false,
             transfer_transaction: false,
             get_blockhash: false,
+            get_version: false,
         };
 
         let kora_config = KoraConfigBuilder::new().with_enabled_methods(enabled_methods).build();

--- a/crates/lib/src/validator/config_validator.rs
+++ b/crates/lib/src/validator/config_validator.rs
@@ -746,6 +746,7 @@ mod tests {
                     get_blockhash: false,
                     get_config: false,
                     get_payer_signer: false,
+                    get_version: false,
                 },
                 auth: AuthConfig::default(),
                 payment_address: None,

--- a/examples/deploy/kora.toml
+++ b/examples/deploy/kora.toml
@@ -90,6 +90,7 @@ transfer_transaction = true
 get_blockhash = true
 get_config = true
 get_payer_signer = true
+get_version = true
 
 [validation.price]
 type = "margin" # free / margin / fixed

--- a/examples/getting-started/demo/server/kora.toml
+++ b/examples/getting-started/demo/server/kora.toml
@@ -18,6 +18,7 @@ transfer_transaction = true
 get_blockhash = true
 get_config = true
 get_payer_signer = true
+get_version = true
 
 [validation]
 max_allowed_lamports = 2500000

--- a/examples/x402/demo/kora/kora.toml
+++ b/examples/x402/demo/kora/kora.toml
@@ -21,6 +21,7 @@ transfer_transaction = false
 get_blockhash = true
 get_config = true
 get_payer_signer = true
+get_version = true
 
 [validation]
 max_allowed_lamports = 1000000

--- a/kora.toml
+++ b/kora.toml
@@ -21,6 +21,7 @@ transfer_transaction = true
 get_blockhash = true
 get_config = true
 get_payer_signer = true
+get_version = true
 
 [validation]
 max_allowed_lamports = 1000000

--- a/sdks/ts/src/client.ts
+++ b/sdks/ts/src/client.ts
@@ -5,6 +5,7 @@ import {
     EstimateTransactionFeeResponse,
     GetBlockhashResponse,
     GetSupportedTokensResponse,
+    GetVersionResponse,
     SignAndSendTransactionRequest,
     SignAndSendTransactionResponse,
     SignTransactionRequest,
@@ -146,6 +147,21 @@ export class KoraClient {
      */
     async getBlockhash(): Promise<GetBlockhashResponse> {
         return this.rpcRequest<GetBlockhashResponse, undefined>('getBlockhash', undefined);
+    }
+
+    /**
+     * Gets the version of the Kora server.
+     * @returns Object containing the server version
+     * @throws {Error} When the RPC call fails
+     *
+     * @example
+     * ```typescript
+     * const { version } = await client.getVersion();
+     * console.log('Server version:', version);
+     * ```
+     */
+    async getVersion(): Promise<GetVersionResponse> {
+        return this.rpcRequest<GetVersionResponse, undefined>('getVersion', undefined);
     }
 
     /**

--- a/sdks/ts/src/types/index.ts
+++ b/sdks/ts/src/types/index.ts
@@ -127,6 +127,14 @@ export interface GetBlockhashResponse {
 }
 
 /**
+ * Response containing the server version.
+ */
+export interface GetVersionResponse {
+    /** Server version string */
+    version: string;
+}
+
+/**
  * Response containing supported token mint addresses.
  */
 export interface GetSupportedTokensResponse {
@@ -254,6 +262,8 @@ export interface EnabledMethods {
     get_blockhash: boolean;
     /** Whether the get_config method is enabled */
     get_config: boolean;
+    /** Whether the get_version method is enabled */
+    get_version: boolean;
 }
 
 /**

--- a/sdks/ts/test/integration.test.ts
+++ b/sdks/ts/test/integration.test.ts
@@ -110,6 +110,7 @@ describe(`KoraClient Integration Tests (${AUTH_ENABLED ? 'with auth' : 'without 
             expect(config.enabled_methods.transfer_transaction).toBeDefined();
             expect(config.enabled_methods.get_blockhash).toBeDefined();
             expect(config.enabled_methods.get_config).toBeDefined();
+            expect(config.enabled_methods.get_version).toBeDefined();
         });
 
         it('should get payer signer', async () => {
@@ -131,6 +132,15 @@ describe(`KoraClient Integration Tests (${AUTH_ENABLED ? 'with auth' : 'without 
             expect(typeof blockhash).toBe('string');
             expect(blockhash.length).toBeGreaterThanOrEqual(43);
             expect(blockhash.length).toBeLessThanOrEqual(44); // Base58 encoded hash length
+        });
+
+        it('should get version', async () => {
+            const { version } = await client.getVersion();
+            expect(version).toBeDefined();
+            expect(typeof version).toBe('string');
+            expect(version.length).toBeGreaterThan(0);
+            // Version should follow semver format (e.g., "2.1.0" or "2.1.0-beta.0")
+            expect(version).toMatch(/^\d+\.\d+\.\d+/);
         });
     });
 

--- a/sdks/ts/test/unit.test.ts
+++ b/sdks/ts/test/unit.test.ts
@@ -5,6 +5,7 @@ import {
     GetBlockhashResponse,
     GetSupportedTokensResponse,
     GetPayerSignerResponse,
+    GetVersionResponse,
     SignTransactionRequest,
     SignTransactionResponse,
     SignAndSendTransactionRequest,
@@ -173,6 +174,7 @@ describe('KoraClient Unit Tests', () => {
                     transfer_transaction: true,
                     get_blockhash: true,
                     get_config: true,
+                    get_version: true,
                 },
             };
 
@@ -187,6 +189,16 @@ describe('KoraClient Unit Tests', () => {
             };
 
             await testSuccessfulRpcMethod('getBlockhash', () => client.getBlockhash(), mockResponse);
+        });
+    });
+
+    describe('getVersion', () => {
+        it('should return server version', async () => {
+            const mockResponse: GetVersionResponse = {
+                version: '2.1.0-beta.0',
+            };
+
+            await testSuccessfulRpcMethod('getVersion', () => client.getVersion(), mockResponse);
         });
     });
 
@@ -426,6 +438,7 @@ describe('KoraClient Unit Tests', () => {
                 transfer_transaction: true,
                 get_blockhash: true,
                 get_config: true,
+                get_version: true,
             },
         };
 

--- a/tests/src/common/fixtures/auth-test.toml
+++ b/tests/src/common/fixtures/auth-test.toml
@@ -22,6 +22,7 @@ transfer_transaction = true
 get_blockhash = true
 get_config = true
 get_payer_signer = true
+get_version = true
 
 [validation]
 max_allowed_lamports = 1000000

--- a/tests/src/common/fixtures/fee-payer-policy-test.toml
+++ b/tests/src/common/fixtures/fee-payer-policy-test.toml
@@ -20,6 +20,7 @@ transfer_transaction = true
 get_blockhash = true
 get_config = true
 get_payer_signer = true
+get_version = true
 
 [validation]
 max_allowed_lamports = 1000000

--- a/tests/src/common/fixtures/kora-free-test.toml
+++ b/tests/src/common/fixtures/kora-free-test.toml
@@ -20,6 +20,7 @@ transfer_transaction = true
 get_blockhash = true
 get_config = true
 get_payer_signer = true
+get_version = true
 
 [validation]
 max_allowed_lamports = 1000000

--- a/tests/src/common/fixtures/kora-test.toml
+++ b/tests/src/common/fixtures/kora-test.toml
@@ -20,6 +20,7 @@ transfer_transaction = true
 get_blockhash = true
 get_config = true
 get_payer_signer = true
+get_version = true
 
 [validation]
 max_allowed_lamports = 1000000

--- a/tests/src/common/fixtures/paymaster-address-test.toml
+++ b/tests/src/common/fixtures/paymaster-address-test.toml
@@ -19,6 +19,7 @@ transfer_transaction = true
 get_blockhash = true
 get_config = true
 get_payer_signer = true
+get_version = true
 
 [validation]
 max_allowed_lamports = 1000000


### PR DESCRIPTION
Introduces a new getVersion RPC method to retrieve the server version.
Updates sdk, configuration, fixtures, and tests to support enabling/disabling the new method.

closes PRO-607

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `getVersion` RPC method to retrieve server version, update configurations, and add tests.
> 
>   - **Behavior**:
>     - Adds `getVersion` RPC method in `get_version.rs` to return server version using `CARGO_PKG_VERSION`.
>     - Updates `KoraRpc` in `rpc.rs` to include `get_version()` method.
>     - Registers `getVersion` method in `server.rs` using `register_method_if_enabled!` macro.
>   - **Configuration**:
>     - Adds `get_version` to `EnabledMethods` in `config.rs` and updates default configurations in various `kora.toml` files.
>   - **SDK**:
>     - Adds `getVersion()` method to `KoraClient` in `client.ts`.
>     - Defines `GetVersionResponse` in `types/index.ts`.
>   - **Testing**:
>     - Adds unit and integration tests for `getVersion` in `unit.test.ts` and `integration.test.ts`.
>     - Updates test fixtures to include `get_version` in enabled methods.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=solana-foundation%2Fkora&utm_source=github&utm_medium=referral)<sup> for 9fe4a5f3e2f5925d487481afc11739a1839f08a1. You can [customize](https://app.ellipsis.dev/solana-foundation/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

## 📊 Unit Test Coverage
![Coverage](https://img.shields.io/badge/coverage-80.7%25-green)

**Unit Test Coverage: 80.7%**

[View Detailed Coverage Report](https://github.com/solana-foundation/kora/actions/runs/20734690211)