### PR TITLE
hotfix: (PRO-639) Fix big transaction causing error when using v0 tra…

### DIFF
--- a/crates/lib/src/fee/fee.rs
+++ b/crates/lib/src/fee/fee.rs
@@ -15,7 +15,6 @@ use crate::{
         ParsedSystemInstructionType, VersionedTransactionResolved,
     },
 };
-use solana_message::Message;
 
 #[cfg(not(test))]
 use {crate::cache::CacheUtil, crate::state::get_config};
@@ -498,21 +497,7 @@ impl TransactionFeeUtil {
                 // Legacy transactions don't have lookup tables, use as-is
                 rpc_client.get_fee_for_message(message).await
             }
-            VersionedMessage::V0(v0_message) => {
-                // Create a legacy message with resolved account keys to avoid lookup table index issues
-                // This is a workaround for https://github.com/anza-xyz/agave/pull/7719
-
-                let resolved_message = Message::new_with_compiled_instructions(
-                    v0_message.header.num_required_signatures,
-                    v0_message.header.num_readonly_signed_accounts,
-                    v0_message.header.num_readonly_unsigned_accounts,
-                    resolved_transaction.all_account_keys.clone(),
-                    v0_message.recent_blockhash,
-                    v0_message.instructions.clone(),
-                );
-
-                rpc_client.get_fee_for_message(&resolved_message).await
-            }
+            VersionedMessage::V0(v0_message) => rpc_client.get_fee_for_message(v0_message).await,
         }
         .map_err(|e| KoraError::RpcError(e.to_string()))
     }


### PR DESCRIPTION
…nsaction

- Used to have an issue with agave validator that would not properly serialized, this seems to be resolved, so we can now use the function directly, which fixes transaction too big error when trying to manually serialize it
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes transaction too big error by directly using `v0_message` in `get_estimate_fee_resolved()` in `fee.rs`, removing a workaround for Agave validator serialization issue.
> 
>   - **Behavior**:
>     - Fixes transaction too big error by directly using `v0_message` in `get_estimate_fee_resolved()` in `fee.rs`.
>     - Removes workaround for Agave validator serialization issue.
>   - **Code Simplification**:
>     - Removes creation of legacy message for `VersionedMessage::V0` in `get_estimate_fee_resolved()`.
>   - **Imports**:
>     - Removes unused import of `Message` from `solana_message`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=solana-foundation%2Fkora&utm_source=github&utm_medium=referral)<sup> for b805a493764abbc4544bb2e073999ad30c9b3fc3. You can [customize](https://app.ellipsis.dev/solana-foundation/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

## 📊 Unit Test Coverage
![Coverage](https://img.shields.io/badge/coverage-80.7%25-green)

**Unit Test Coverage: 80.7%**

[View Detailed Coverage Report](https://github.com/solana-foundation/kora/actions/runs/20925453717)