### PR TITLE
release: 2.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.0.2 - 2026-01-12
+
+
+### Hotfix
+
+- (PRO-639) Fix big transaction causing error when using v0 transaction (#297)
+
 ## 2.0.1 - 2025-11-24
 
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2619,7 +2619,7 @@ dependencies = [
 
 [[package]]
 name = "kora-cli"
-version = "2.0.1"
+version = "2.0.2"
 dependencies = [
  "clap",
  "dotenv",
@@ -2636,7 +2636,7 @@ dependencies = [
 
 [[package]]
 name = "kora-lib"
-version = "2.0.1"
+version = "2.0.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6874,7 +6874,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "tests"
-version = "2.0.1"
+version = "2.0.2"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ all = { level = "deny", priority = -1 }
 module_inception = { level = "allow", priority = 0 }
 
 [workspace.package]
-version = "2.0.1"
+version = "2.0.2"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/solana-foundation/kora"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kora-cli"
-version = "2.0.1"
+version = "2.0.2"
 edition = "2021"
 description = "CLI for Kora gasless relayer"
 license = "MIT"
@@ -14,7 +14,7 @@ path = "src/main.rs"
 docs = ["kora-lib/docs", "dep:utoipa"]
 
 [dependencies]
-kora-lib = { path = "../lib", version = "2.0.1" }
+kora-lib = { path = "../lib", version = "2.0.2" }
 clap = { workspace = true }
 tokio = { workspace = true }
 env_logger = { workspace = true }

--- a/crates/lib/Cargo.toml
+++ b/crates/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kora-lib"
-version = "2.0.1"
+version = "2.0.2"
 edition = "2021"
 license = "MIT"
 description = "Core library for Kora gasless relayer"


### PR DESCRIPTION
- Hotfix for get fee for message for v0 transactions with lookup tables
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Hotfix release 2.0.2 fixes error with big transactions using v0 transaction and lookup tables, with version updates across Cargo files.
> 
>   - **Hotfix**:
>     - Fixes error with big transactions using v0 transaction and lookup tables.
>   - **Version Updates**:
>     - Bumps version to `2.0.2` in `Cargo.toml`, `crates/cli/Cargo.toml`, and `crates/lib/Cargo.toml`.
>     - Updates `Cargo.lock` to reflect new version `2.0.2`.
>   - **Documentation**:
>     - Adds entry for version `2.0.2` in `CHANGELOG.md` detailing the hotfix.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=solana-foundation%2Fkora&utm_source=github&utm_medium=referral)<sup> for 638f3b4a26741798ce2931be52e9c9c006ca84f6. You can [customize](https://app.ellipsis.dev/solana-foundation/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

## 📊 Unit Test Coverage
![Coverage](https://img.shields.io/badge/coverage-80.7%25-green)

**Unit Test Coverage: 80.7%**

[View Detailed Coverage Report](https://github.com/solana-foundation/kora/actions/runs/20928182383)