### PR TITLE
feat: add transactions_to_sign parameter to bundle endpoints

### DIFF
--- a/crates/lib/src/bundle/helper.rs
+++ b/crates/lib/src/bundle/helper.rs
@@ -13,7 +13,7 @@ use crate::{
 use solana_client::nonblocking::rpc_client::RpcClient;
 use solana_commitment_config::CommitmentConfig;
 use solana_sdk::{instruction::Instruction, pubkey::Pubkey};
-use std::sync::Arc;
+use std::{collections::HashMap, sync::Arc};
 
 pub struct BundleProcessor {
     pub resolved_transactions: Vec<VersionedTransactionResolved>,
@@ -24,53 +24,47 @@ pub struct BundleProcessor {
 
 impl BundleProcessor {
     /// Extract transactions at specified indices for processing.
-    /// Returns (filtered_transactions, indices_used).
-    /// If `transactions_to_sign` is None, returns all transactions with all indices.
+    /// Returns (filtered_transactions, index_to_position_map).
+    /// If `sign_only_indices` is None, returns all transactions with all indices.
     pub fn extract_transactions_to_process(
         transactions: &[String],
-        transactions_to_sign: Option<&[usize]>,
-    ) -> Result<(Vec<String>, Vec<usize>), KoraError> {
-        let indices: &[usize];
-        let default_indices: Vec<usize>;
+        sign_only_indices: Option<Vec<usize>>,
+    ) -> Result<(Vec<String>, HashMap<usize, usize>), KoraError> {
+        let indices = sign_only_indices.unwrap_or_else(|| (0..transactions.len()).collect());
 
-        match transactions_to_sign {
-            Some(idx_list) => indices = idx_list,
-            None => {
-                default_indices = (0..transactions.len()).collect();
-                indices = &default_indices;
+        // Build map and filtered list (duplicates silently ignored)
+        let mut index_to_position: HashMap<usize, usize> = HashMap::with_capacity(indices.len());
+        let mut filtered: Vec<String> = Vec::with_capacity(indices.len());
+
+        for idx in indices {
+            if index_to_position.contains_key(&idx) {
+                continue; // skip duplicate
             }
-        };
+            let tx = transactions.get(idx).ok_or_else(|| {
+                KoraError::ValidationError(format!(
+                    "sign_only_indices index {} out of bounds (bundle has {} transactions)",
+                    idx,
+                    transactions.len()
+                ))
+            })?;
+            index_to_position.insert(idx, filtered.len());
+            filtered.push(tx.clone());
+        }
 
-        let filtered: Vec<String> = indices
-            .iter()
-            .map(|&idx| {
-                transactions.get(idx).cloned().ok_or_else(|| {
-                    KoraError::ValidationError(format!(
-                        "transactions_to_sign index {} out of bounds (bundle has {} transactions)",
-                        idx,
-                        transactions.len()
-                    ))
-                })
-            })
-            .collect::<Result<Vec<_>, _>>()?;
-
-        Ok((filtered, indices.to_vec()))
+        Ok((filtered, index_to_position))
     }
 
     /// Merge signed transactions back into the original list, preserving order.
-    /// Transactions at indices in `signed_indices` are replaced with corresponding signed versions.
+    /// `index_to_position` maps original transaction index -> position in signed_transactions vec.
     pub fn merge_signed_transactions(
         original_transactions: &[String],
         signed_transactions: Vec<String>,
-        signed_indices: &[usize],
+        index_to_position: &std::collections::HashMap<usize, usize>,
     ) -> Vec<String> {
-        let mut signed_iter = signed_transactions.into_iter();
-        let signed_set: std::collections::HashSet<usize> = signed_indices.iter().copied().collect();
-
         (0..original_transactions.len())
             .map(|idx| {
-                if signed_set.contains(&idx) {
-                    signed_iter.next().unwrap()
+                if let Some(&position) = index_to_position.get(&idx) {
+                    signed_transactions[position].clone()
                 } else {
                     original_transactions[idx].clone()
                 }
@@ -324,25 +318,30 @@ mod tests {
     #[test]
     fn test_extract_transactions_none_returns_all() {
         let txs = vec!["tx0".to_string(), "tx1".to_string(), "tx2".to_string()];
-        let (result, indices) =
+        let (result, index_to_position) =
             BundleProcessor::extract_transactions_to_process(&txs, None).unwrap();
         assert_eq!(result, txs);
-        assert_eq!(indices, vec![0, 1, 2]);
+        assert_eq!(index_to_position.len(), 3);
+        assert_eq!(index_to_position.get(&0), Some(&0));
+        assert_eq!(index_to_position.get(&1), Some(&1));
+        assert_eq!(index_to_position.get(&2), Some(&2));
     }
 
     #[test]
     fn test_extract_transactions_specific_indices() {
         let txs = vec!["tx0".to_string(), "tx1".to_string(), "tx2".to_string()];
-        let (result, indices) =
-            BundleProcessor::extract_transactions_to_process(&txs, Some(&[0, 2])).unwrap();
+        let (result, index_to_position) =
+            BundleProcessor::extract_transactions_to_process(&txs, Some(vec![0, 2])).unwrap();
         assert_eq!(result, vec!["tx0".to_string(), "tx2".to_string()]);
-        assert_eq!(indices, vec![0, 2]);
+        assert_eq!(index_to_position.len(), 2);
+        assert_eq!(index_to_position.get(&0), Some(&0));
+        assert_eq!(index_to_position.get(&2), Some(&1));
     }
 
     #[test]
     fn test_extract_transactions_out_of_bounds() {
         let txs = vec!["tx0".to_string(), "tx1".to_string()];
-        let result = BundleProcessor::extract_transactions_to_process(&txs, Some(&[0, 5]));
+        let result = BundleProcessor::extract_transactions_to_process(&txs, Some(vec![0, 5]));
         assert!(result.is_err());
         let err = result.unwrap_err();
         assert!(matches!(err, KoraError::ValidationError(_)));
@@ -351,10 +350,22 @@ mod tests {
     #[test]
     fn test_extract_transactions_empty_indices() {
         let txs = vec!["tx0".to_string(), "tx1".to_string()];
-        let (result, indices) =
-            BundleProcessor::extract_transactions_to_process(&txs, Some(&[])).unwrap();
+        let (result, index_to_position) =
+            BundleProcessor::extract_transactions_to_process(&txs, Some(vec![])).unwrap();
         assert!(result.is_empty());
-        assert!(indices.is_empty());
+        assert!(index_to_position.is_empty());
+    }
+
+    #[test]
+    fn test_extract_transactions_duplicate_indices_silently_skipped() {
+        let txs = vec!["tx0".to_string(), "tx1".to_string()];
+        let (result, index_to_position) =
+            BundleProcessor::extract_transactions_to_process(&txs, Some(vec![0, 0, 1])).unwrap();
+        // Duplicates are silently skipped, only unique indices processed
+        assert_eq!(result, vec!["tx0".to_string(), "tx1".to_string()]);
+        assert_eq!(index_to_position.len(), 2);
+        assert_eq!(index_to_position.get(&0), Some(&0)); // tx0 at position 0 in filtered
+        assert_eq!(index_to_position.get(&1), Some(&1)); // tx1 at position 1 in filtered
     }
 
     #[test]
@@ -362,9 +373,12 @@ mod tests {
         let original =
             vec!["tx0".to_string(), "tx1".to_string(), "tx2".to_string(), "tx3".to_string()];
         let signed = vec!["signed_tx0".to_string(), "signed_tx2".to_string()];
-        let indices = vec![0, 2];
+        // index 0 -> position 0, index 2 -> position 1
+        let index_to_position =
+            std::collections::HashMap::from([(0_usize, 0_usize), (2_usize, 1_usize)]);
 
-        let result = BundleProcessor::merge_signed_transactions(&original, signed, &indices);
+        let result =
+            BundleProcessor::merge_signed_transactions(&original, signed, &index_to_position);
 
         assert_eq!(
             result,
@@ -381,9 +395,35 @@ mod tests {
     fn test_merge_signed_transactions_all_signed() {
         let original = vec!["tx0".to_string(), "tx1".to_string()];
         let signed = vec!["signed_tx0".to_string(), "signed_tx1".to_string()];
-        let indices = vec![0, 1];
+        let index_to_position =
+            std::collections::HashMap::from([(0_usize, 0_usize), (1_usize, 1_usize)]);
 
-        let result = BundleProcessor::merge_signed_transactions(&original, signed, &indices);
+        let result =
+            BundleProcessor::merge_signed_transactions(&original, signed, &index_to_position);
         assert_eq!(result, vec!["signed_tx0".to_string(), "signed_tx1".to_string()]);
+    }
+
+    #[test]
+    fn test_merge_signed_transactions_descending_indices() {
+        let original =
+            vec!["tx0".to_string(), "tx1".to_string(), "tx2".to_string(), "tx3".to_string()];
+        // indices [2, 0] means: signed[0] = tx2, signed[1] = tx0
+        let signed = vec!["signed_tx2".to_string(), "signed_tx0".to_string()];
+        // index 2 -> position 0, index 0 -> position 1
+        let index_to_position =
+            std::collections::HashMap::from([(2_usize, 0_usize), (0_usize, 1_usize)]);
+
+        let result =
+            BundleProcessor::merge_signed_transactions(&original, signed, &index_to_position);
+
+        assert_eq!(
+            result,
+            vec![
+                "signed_tx0".to_string(),
+                "tx1".to_string(),
+                "signed_tx2".to_string(),
+                "tx3".to_string(),
+            ]
+        );
     }
 }

--- a/crates/lib/src/rpc_server/method/estimate_bundle_fee.rs
+++ b/crates/lib/src/rpc_server/method/estimate_bundle_fee.rs
@@ -30,6 +30,9 @@ pub struct EstimateBundleFeeRequest {
     /// Whether to verify signatures during simulation (defaults to false)
     #[serde(default = "default_sig_verify")]
     pub sig_verify: bool,
+    /// Optional indices of transactions to estimate fees for (defaults to all if not specified)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sign_only_indices: Option<Vec<usize>>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
@@ -52,14 +55,22 @@ pub async fn estimate_bundle_fee(
         return Err(BundleError::Jito(JitoError::NotEnabled).into());
     }
 
+    // Validate bundle size on ALL transactions first
     BundleValidator::validate_jito_bundle_size(&request.transactions)?;
+
+    // Extract only the transactions we need to process
+    let (transactions_to_process, _index_to_position) =
+        BundleProcessor::extract_transactions_to_process(
+            &request.transactions,
+            request.sign_only_indices,
+        )?;
 
     let signer = get_request_signer_with_signer_key(request.signer_key.as_deref())?;
     let fee_payer = signer.pubkey();
     let payment_destination = config.kora.get_payment_address(&fee_payer)?;
 
     let processor = BundleProcessor::process_bundle(
-        &request.transactions,
+        &transactions_to_process,
         fee_payer,
         &payment_destination,
         config,
@@ -108,6 +119,7 @@ mod tests {
             fee_token: None,
             signer_key: None,
             sig_verify: true,
+            sign_only_indices: None,
         };
 
         let result = estimate_bundle_fee(&rpc_client, request).await;
@@ -129,6 +141,7 @@ mod tests {
             fee_token: None,
             signer_key: None,
             sig_verify: true,
+            sign_only_indices: None,
         };
 
         let result = estimate_bundle_fee(&rpc_client, request).await;
@@ -153,6 +166,7 @@ mod tests {
             fee_token: None,
             signer_key: None,
             sig_verify: true,
+            sign_only_indices: None,
         };
 
         let result = estimate_bundle_fee(&rpc_client, request).await;
@@ -177,6 +191,7 @@ mod tests {
             fee_token: None,
             signer_key: Some("invalid_pubkey".to_string()),
             sig_verify: true,
+            sign_only_indices: None,
         };
 
         let result = estimate_bundle_fee(&rpc_client, request).await;
@@ -206,6 +221,7 @@ mod tests {
             fee_token: None,
             signer_key: None,
             sig_verify: true,
+            sign_only_indices: None,
         };
 
         let result = estimate_bundle_fee(&rpc_client, request).await;
@@ -235,6 +251,7 @@ mod tests {
             fee_token: None,
             signer_key: None,
             sig_verify: true,
+            sign_only_indices: None,
         };
 
         let result = estimate_bundle_fee(&rpc_client, request).await;

--- a/crates/lib/src/rpc_server/method/sign_bundle.rs
+++ b/crates/lib/src/rpc_server/method/sign_bundle.rs
@@ -31,7 +31,7 @@ pub struct SignBundleRequest {
     pub sig_verify: bool,
     /// Optional indices of transactions to sign (defaults to all if not specified)
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub transactions_to_sign: Option<Vec<usize>>,
+    pub sign_only_indices: Option<Vec<usize>>,
 }
 
 #[derive(Debug, Serialize, ToSchema)]
@@ -56,10 +56,10 @@ pub async fn sign_bundle(
     BundleValidator::validate_jito_bundle_size(&request.transactions)?;
 
     // Extract only the transactions we need to process
-    let (transactions_to_process, signed_indices) =
+    let (transactions_to_process, index_to_position) =
         BundleProcessor::extract_transactions_to_process(
             &request.transactions,
-            request.transactions_to_sign.as_deref(),
+            request.sign_only_indices,
         )?;
 
     let signer = get_request_signer_with_signer_key(request.signer_key.as_deref())?;
@@ -88,7 +88,7 @@ pub async fn sign_bundle(
     let signed_transactions = BundleProcessor::merge_signed_transactions(
         &request.transactions,
         encoded_signed,
-        &signed_indices,
+        &index_to_position,
     );
 
     Ok(SignBundleResponse { signed_transactions, signer_pubkey: fee_payer.to_string() })
@@ -120,7 +120,7 @@ mod tests {
             transactions: vec![],
             signer_key: None,
             sig_verify: true,
-            transactions_to_sign: None,
+            sign_only_indices: None,
         };
 
         let result = sign_bundle(&rpc_client, request).await;
@@ -141,7 +141,7 @@ mod tests {
             transactions: vec!["some_tx".to_string()],
             signer_key: None,
             sig_verify: true,
-            transactions_to_sign: None,
+            sign_only_indices: None,
         };
 
         let result = sign_bundle(&rpc_client, request).await;
@@ -165,7 +165,7 @@ mod tests {
             transactions: vec!["tx".to_string(); 6],
             signer_key: None,
             sig_verify: true,
-            transactions_to_sign: None,
+            sign_only_indices: None,
         };
 
         let result = sign_bundle(&rpc_client, request).await;
@@ -189,7 +189,7 @@ mod tests {
             transactions: vec!["some_tx".to_string()],
             signer_key: Some("invalid_pubkey".to_string()),
             sig_verify: true,
-            transactions_to_sign: None,
+            sign_only_indices: None,
         };
 
         let result = sign_bundle(&rpc_client, request).await;
@@ -237,7 +237,7 @@ mod tests {
             transactions,
             signer_key: Some(signer_pubkey.to_string()),
             sig_verify: true,
-            transactions_to_sign: None,
+            sign_only_indices: None,
         };
 
         let result = sign_bundle(&rpc_client, request).await;
@@ -281,7 +281,7 @@ mod tests {
             transactions: vec![encoded_tx],
             signer_key: Some(signer_pubkey.to_string()),
             sig_verify: true,
-            transactions_to_sign: None,
+            sign_only_indices: None,
         };
 
         let result = sign_bundle(&rpc_client, request).await;
@@ -314,22 +314,22 @@ mod tests {
         assert_eq!(request.transactions.len(), 2);
         assert_eq!(request.signer_key, Some("11111111111111111111111111111111".to_string()));
         assert!(!request.sig_verify);
-        assert!(request.transactions_to_sign.is_none());
+        assert!(request.sign_only_indices.is_none());
     }
 
     #[tokio::test]
-    async fn test_sign_bundle_request_deserialization_with_transactions_to_sign() {
+    async fn test_sign_bundle_request_deserialization_with_sign_only_indices() {
         let json = r#"{
             "transactions": ["tx1", "tx2", "tx3"],
             "signer_key": "11111111111111111111111111111111",
             "sig_verify": false,
-            "transactions_to_sign": [0, 2]
+            "sign_only_indices": [0, 2]
         }"#;
         let request: SignBundleRequest = serde_json::from_str(json).unwrap();
 
         assert_eq!(request.transactions.len(), 3);
         assert_eq!(request.signer_key, Some("11111111111111111111111111111111".to_string()));
         assert!(!request.sig_verify);
-        assert_eq!(request.transactions_to_sign, Some(vec![0, 2]));
+        assert_eq!(request.sign_only_indices, Some(vec![0, 2]));
     }
 }

--- a/sdks/ts/src/client.ts
+++ b/sdks/ts/src/client.ts
@@ -281,6 +281,7 @@ export class KoraClient {
      * @param request.transactions - Array of base64-encoded transactions to sign
      * @param request.signer_key - Optional signer address for the transactions
      * @param request.sig_verify - Optional signature verification (defaults to false)
+     * @param request.sign_only_indices - Optional indices of transactions to sign (defaults to all)
      * @returns Array of signed transactions and signer public key
      * @throws {Error} When the RPC call fails or validation fails
      *
@@ -303,6 +304,7 @@ export class KoraClient {
      * @param request.transactions - Array of base64-encoded transactions to sign and send
      * @param request.signer_key - Optional signer address for the transactions
      * @param request.sig_verify - Optional signature verification (defaults to false)
+     * @param request.sign_only_indices - Optional indices of transactions to sign (defaults to all)
      * @returns Array of signed transactions, signer public key, and Jito bundle UUID
      * @throws {Error} When the RPC call fails, validation fails, or Jito submission fails
      *

--- a/sdks/ts/src/types/index.ts
+++ b/sdks/ts/src/types/index.ts
@@ -55,6 +55,8 @@ export interface SignBundleRequest {
     signer_key?: string;
     /** Optional signer verification during transaction simulation (defaults to false) */
     sig_verify?: boolean;
+    /** Optional indices of transactions to sign (defaults to all if not specified) */
+    sign_only_indices?: number[];
 }
 
 /**
@@ -67,6 +69,8 @@ export interface SignAndSendBundleRequest {
     signer_key?: string;
     /** Optional signer verification during transaction simulation (defaults to false) */
     sig_verify?: boolean;
+    /** Optional indices of transactions to sign (defaults to all if not specified) */
+    sign_only_indices?: number[];
 }
 
 /**
@@ -95,6 +99,8 @@ export interface EstimateBundleFeeRequest {
     signer_key?: string;
     /** Optional signer verification during transaction simulation (defaults to false) */
     sig_verify?: boolean;
+    /** Optional indices of transactions to estimate fees for (defaults to all if not specified) */
+    sign_only_indices?: number[];
 }
 
 /**

--- a/tests/rpc/bundles.rs
+++ b/tests/rpc/bundles.rs
@@ -667,13 +667,13 @@ async fn test_sign_bundle_insufficient_payment_error() {
 }
 
 // **************************************************************************************
-// Partial signing tests (transactions_to_sign parameter)
+// Partial signing tests (sign_only_indices parameter)
 // **************************************************************************************
 
-/// Test processing only specific transactions in a bundle using transactions_to_sign parameter
+/// Test processing only specific transactions in a bundle using sign_only_indices parameter
 /// Response should contain ALL transactions in original order, with only specified ones signed.
 #[tokio::test]
-async fn test_sign_bundle_with_transactions_to_sign_filter() {
+async fn test_sign_bundle_with_sign_only_indices_filter() {
     let ctx = TestContext::new().await.expect("Failed to create test context");
 
     let fee_payer = FeePayerTestHelper::get_fee_payer_pubkey();
@@ -702,13 +702,13 @@ async fn test_sign_bundle_with_transactions_to_sign_filter() {
     }
 
     // Process only transactions at indices 0 and 2
-    // Pass transactions_to_sign as positional params: [transactions, signer_key, sig_verify, transactions_to_sign]
-    let transactions_to_sign: Vec<usize> = vec![0, 2];
+    // Pass sign_only_indices as positional params: [transactions, signer_key, sig_verify, sign_only_indices]
+    let sign_only_indices: Vec<usize> = vec![0, 2];
     let original_tx1 = transactions[1].clone();
     let response: serde_json::Value = ctx
         .rpc_call(
             "signBundle",
-            rpc_params![transactions, Option::<String>::None, false, transactions_to_sign],
+            rpc_params![transactions, Option::<String>::None, false, sign_only_indices],
         )
         .await
         .expect("Failed to sign bundle");
@@ -734,9 +734,9 @@ async fn test_sign_bundle_with_transactions_to_sign_filter() {
     );
 }
 
-/// Test that out-of-bounds transactions_to_sign index fails validation
+/// Test that out-of-bounds sign_only_indices index fails validation
 #[tokio::test]
-async fn test_sign_bundle_out_of_bounds_transactions_to_sign_fails() {
+async fn test_sign_bundle_out_of_bounds_sign_only_indices_fails() {
     let ctx = TestContext::new().await.expect("Failed to create test context");
 
     let fee_payer = FeePayerTestHelper::get_fee_payer_pubkey();
@@ -760,13 +760,13 @@ async fn test_sign_bundle_out_of_bounds_transactions_to_sign_fails() {
         .expect("Failed to create transaction");
 
     // Bundle has 1 transaction, try to sign index 5
-    // Pass transactions_to_sign as positional params: [transactions, signer_key, sig_verify, transactions_to_sign]
+    // Pass sign_only_indices as positional params: [transactions, signer_key, sig_verify, sign_only_indices]
     let transactions = vec![tx];
-    let transactions_to_sign: Vec<usize> = vec![5];
+    let sign_only_indices: Vec<usize> = vec![5];
     let result: Result<serde_json::Value, _> = ctx
         .rpc_call(
             "signBundle",
-            rpc_params![transactions, Option::<String>::None, false, transactions_to_sign],
+            rpc_params![transactions, Option::<String>::None, false, sign_only_indices],
         )
         .await;
 


### PR DESCRIPTION
## Summary
- Add optional `transactions_to_sign` parameter to `signBundle` and `signAndSendBundle` endpoints
- Enable partial bundle signing where clients can specify which transactions Kora should sign
- Implement validation for out-of-bounds transaction indices
- Fix bundle integration test parameter format to use positional params correctly

## Test Plan
All 20 bundle integration tests passing:
- Partial signing tests verify correct transaction selection and merging
- Out-of-bounds validation test confirms proper error handling
- Existing bundle tests confirm backward compatibility (all transactions signed by default)

Run tests with:
```bash
just test-integration --filter regular
```

Closes PRO-743


## 📊 Unit Test Coverage
![Coverage](https://img.shields.io/badge/coverage-82.1%25-green)

**Unit Test Coverage: 82.1%**

[View Detailed Coverage Report](https://github.com/solana-foundation/kora/actions/runs/21215391828)