### PR TITLE
chore: beta release v2.2.0-beta.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,27 @@
+## 2.2.0-beta.5 - 2026-02-03
+
+
+### Cherry-pick
+
+- Hotfix example packages and Jupiter v3 API migration (#326)
+
+
+### Features
+
+- add Claude skill for automated full release workflow (#328)
+
+## ts-sdk-v0.2.0-beta.4 - 2026-01-29
+
+
+### Documentation
+
+- update sdk readme for release (#314)
+
+
+### Features
+
+- add reCAPTCHA support to TypeScript client (#317)
+
 ## 2.2.0-beta.4 - 2026-01-29
 
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3084,7 +3084,7 @@ dependencies = [
 
 [[package]]
 name = "kora-cli"
-version = "2.2.0-beta.4"
+version = "2.2.0-beta.5"
 dependencies = [
  "clap",
  "dotenv",
@@ -3101,7 +3101,7 @@ dependencies = [
 
 [[package]]
 name = "kora-lib"
-version = "2.2.0-beta.4"
+version = "2.2.0-beta.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -7455,7 +7455,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "tests"
-version = "2.2.0-beta.4"
+version = "2.2.0-beta.5"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,13 +13,13 @@ all = { level = "deny", priority = -1 }
 module_inception = { level = "allow", priority = 0 }
 
 [workspace.package]
-version = "2.2.0-beta.4"
+version = "2.2.0-beta.5"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/solana-foundation/kora"
 
 [workspace.dependencies]
-kora-lib = { path = "crates/lib", version = "2.2.0-beta.4" }
+kora-lib = { path = "crates/lib", version = "2.2.0-beta.5" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 anyhow = "1.0.95"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kora-cli"
-version = "2.2.0-beta.4"
+version = "2.2.0-beta.5"
 edition = "2021"
 description = "CLI for Kora gasless relayer"
 license = "MIT"

--- a/crates/lib/Cargo.toml
+++ b/crates/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kora-lib"
-version = "2.2.0-beta.4"
+version = "2.2.0-beta.5"
 edition = "2021"
 license = "MIT"
 description = "Core library for Kora gasless relayer"

--- a/sdks/ts/package.json
+++ b/sdks/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@solana/kora",
-  "version": "0.2.0-beta.4",
+  "version": "0.2.0-beta.5",
   "description": "TypeScript SDK for Kora RPC",
   "main": "dist/src/index.js",
   "type": "module",


### PR DESCRIPTION
## Release Summary

### Rust Crates
- **Version**: v2.2.0-beta.5
- Updates `kora-lib` and `kora-cli` versions
- CHANGELOG generated from commits since last release

### TypeScript SDK
- **Version**: v0.2.0-beta.5
- Updates `sdks/ts/package.json`

## Post-Merge Steps

### Rust Crates
After merging, trigger the **Publish Rust Crates** workflow to:
- Create git tags (v2.2.0-beta.5, kora-lib-v2.2.0-beta.5, kora-cli-v2.2.0-beta.5)
- Publish to crates.io with beta tag

### TypeScript SDK
Trigger the **Publish TypeScript SDK (Manual)** workflow to publish to npm with beta tag.

## 📊 Unit Test Coverage
![Coverage](https://img.shields.io/badge/coverage-81.8%25-green)

**Unit Test Coverage: 81.8%**

[View Detailed Coverage Report](https://github.com/solana-foundation/kora/actions/runs/21633349645)