### PR TITLE
chore: update jup testing bounds

### DIFF
--- a/tests/external/jupiter_integration.rs
+++ b/tests/external/jupiter_integration.rs
@@ -20,7 +20,7 @@ async fn test_jupiter_integration_usdc() {
                 token_price.price
             );
             assert!(
-                token_price.price < dec!(0.01),
+                token_price.price < dec!(0.1),
                 "USDC price too high: {} SOL",
                 token_price.price
             );


### PR DESCRIPTION
increase testing bounds to account for price fluctuation. primary purpose of the test is to ensure integration is working and we're not getting gibberish response data, so expanding bounds quite a bit shoud be safe and helps protect tests against more volatility

closes PRO-840

## 📊 Unit Test Coverage
![Coverage](https://img.shields.io/badge/coverage-80.8%25-green)

**Unit Test Coverage: 80.8%**

[View Detailed Coverage Report](https://github.com/solana-foundation/kora/actions/runs/21836033604)