### PR TITLE
fix: remove unused import in cli args

### DIFF
--- a/crates/cli/src/args.rs
+++ b/crates/cli/src/args.rs
@@ -1,4 +1,4 @@
-use clap::{command, Parser};
+use clap::Parser;
 
 /// Global arguments used by all subcommands
 #[derive(Debug, Parser)]


### PR DESCRIPTION
## Summary
- Remove unused `command` import from `clap` in `crates/cli/src/args.rs`
- Eliminates `unused_imports` clippy warning

## Test plan
- [x] `cargo clippy --workspace` produces zero warnings
- [x] `cargo check --workspace` compiles successfully
- [x] `cargo fmt --all` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## 📊 Unit Test Coverage
![Coverage](https://img.shields.io/badge/coverage-80.8%25-green)

**Unit Test Coverage: 80.8%**

[View Detailed Coverage Report](https://github.com/solana-foundation/kora/actions/runs/21929797590)