### PR TITLE
ci: exempt release-tagged PRs from stale bot

### DIFF
--- a/.github/workflows/stale-prs.yml
+++ b/.github/workflows/stale-prs.yml
@@ -22,5 +22,5 @@ jobs:
             It will be closed in 5 days if there is no further activity.
           close-pr-message: 'Closed due to inactivity.'
           stale-pr-label: 'stale'
-          exempt-pr-labels: 'pinned,work-in-progress'
+          exempt-pr-labels: 'pinned,work-in-progress,release'
           operations-per-run: 100


### PR DESCRIPTION
## Summary
- Add `release` to `exempt-pr-labels` in stale PR cleanup workflow
- Prevents automatic closure of PRs tagged with `release` label

## Changes
- Updated `.github/workflows/stale-prs.yml` to include `release` in exempt labels list alongside `pinned` and `work-in-progress`

## Test Plan
- [x] Verify workflow YAML syntax is valid
- [x] Confirm release-labeled PRs are skipped after workflow runs

## Context
Release PRs should not be automatically closed due to inactivity, as they may remain open for extended periods during beta/RC phases.

## 📊 Unit Test Coverage
![Coverage](https://img.shields.io/badge/coverage-80.8%25-green)

**Unit Test Coverage: 80.8%**

[View Detailed Coverage Report](https://github.com/solana-foundation/kora/actions/runs/22223728233)