### PR TITLE
fix(ci): grant pull-request write for fork live marker comment

### DIFF
--- a/.github/workflows/fork-external-live-manual.yml
+++ b/.github/workflows/fork-external-live-manual.yml
@@ -12,7 +12,7 @@ permissions:
   actions: write
   contents: read
   issues: write
-  pull-requests: read
+  pull-requests: write
 
 jobs:
   external-live:


### PR DESCRIPTION
## Summary
- grant `pull-requests: write` in `.github/workflows/fork-external-live-manual.yml`
- keep all other workflow behavior unchanged

## Why
Manual fork live test runs failed at PR comment creation with:
`Resource not accessible by integration`

The API response required:
- `issues=write`
- `pull_requests=write`

This change adds the missing pull-request write permission.