### PR TITLE
fix(ci): grant pull-request write for fork live marker comment

### DIFF
--- a/.github/workflows/fork-external-live-manual.yml
+++ b/.github/workflows/fork-external-live-manual.yml
@@ -12,7 +12,7 @@ permissions:
   actions: write
   contents: read
   issues: write
-  pull-requests: read
+  pull-requests: write
 
 jobs:
   external-live:


### PR DESCRIPTION
## Summary
- set `pull-requests: write` in `.github/workflows/fork-external-live-manual.yml`
- keep all other workflow behavior unchanged

## Why
Manual fork external live test runs failed when posting the approval marker comment with:
`Resource not accessible by integration`

GitHub response indicated the endpoint requires both:
- `issues=write`
- `pull_requests=write`

This change adds the missing pull-request write permission.

## 📊 Unit Test Coverage
![Coverage](https://img.shields.io/badge/coverage-81.0%25-green)

**Unit Test Coverage: 81.0%**

[View Detailed Coverage Report](https://github.com/solana-foundation/kora/actions/runs/22410371917)