### PR TITLE
feat: structured numeric RPC error codes

### DIFF
--- a/crates/lib/src/error.rs
+++ b/crates/lib/src/error.rs
@@ -124,30 +124,121 @@ impl_kora_error_from!(Box<dyn StdError> => InternalServerError);
 impl_kora_error_from!(Box<dyn StdError + Send + Sync> => InternalServerError);
 impl_kora_error_from!(ProgramError => InvalidTransaction);
 
-impl From<KoraError> for RpcError {
-    fn from(err: KoraError) -> Self {
-        match err {
-            KoraError::AccountNotFound(_)
-            | KoraError::InvalidTransaction(_)
-            | KoraError::ValidationError(_)
-            | KoraError::UnsupportedFeeToken(_)
-            | KoraError::InsufficientFunds(_) => invalid_request(err),
+/// Stable numeric error codes for RPC responses following JSON-RPC 2.0 spec (-32000 to -32099 for server errors).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(into = "i32")]
+pub enum KoraErrorCode {
+    // Validation errors (-32000 to -32019)
+    InvalidTransaction = -32000,
+    ValidationError = -32001,
+    UnsupportedFeeToken = -32002,
+    InsufficientFunds = -32003,
+    InvalidRequest = -32004,
+    FeeEstimationFailed = -32005,
+    TransactionExecutionFailed = -32006,
 
-            KoraError::InternalServerError(_) | KoraError::SerializationError(_) => {
-                internal_server_error(err)
-            }
+    // Signing errors (-32020 to -32029)
+    SigningError = -32020,
 
-            _ => invalid_request(err),
-        }
+    // Auth / Rate limiting (-32030 to -32039)
+    RateLimitExceeded = -32030,
+    UsageLimitExceeded = -32031,
+    Unauthorized = -32032,
+
+    // Token / Swap (-32040 to -32049)
+    SwapError = -32040,
+    TokenOperationError = -32041,
+
+    // Account errors (-32050 to -32059)
+    AccountNotFound = -32050,
+
+    // External services (-32060 to -32069)
+    JitoError = -32060,
+    RecaptchaError = -32061,
+
+    // Internal errors (-32090 to -32099)
+    InternalServerError = -32090,
+    ConfigError = -32091,
+    SerializationError = -32092,
+    RpcError = -32093,
+}
+
+impl From<KoraErrorCode> for i32 {
+    fn from(code: KoraErrorCode) -> Self {
+        code as i32
     }
 }
 
-pub fn invalid_request(e: KoraError) -> RpcError {
-    RpcError::Call(CallError::from_std_error(e))
+impl KoraError {
+    pub fn error_code(&self) -> KoraErrorCode {
+        match self {
+            KoraError::InvalidTransaction(_) => KoraErrorCode::InvalidTransaction,
+            KoraError::ValidationError(_) => KoraErrorCode::ValidationError,
+            KoraError::UnsupportedFeeToken(_) => KoraErrorCode::UnsupportedFeeToken,
+            KoraError::InsufficientFunds(_) => KoraErrorCode::InsufficientFunds,
+            KoraError::InvalidRequest(_) => KoraErrorCode::InvalidRequest,
+            KoraError::FeeEstimationFailed(_) => KoraErrorCode::FeeEstimationFailed,
+            KoraError::TransactionExecutionFailed(_) => KoraErrorCode::TransactionExecutionFailed,
+            KoraError::SigningError(_) => KoraErrorCode::SigningError,
+            KoraError::RateLimitExceeded => KoraErrorCode::RateLimitExceeded,
+            KoraError::UsageLimitExceeded(_) => KoraErrorCode::UsageLimitExceeded,
+            KoraError::Unauthorized(_) => KoraErrorCode::Unauthorized,
+            KoraError::SwapError(_) => KoraErrorCode::SwapError,
+            KoraError::TokenOperationError(_) => KoraErrorCode::TokenOperationError,
+            KoraError::AccountNotFound(_) => KoraErrorCode::AccountNotFound,
+            KoraError::JitoError(_) => KoraErrorCode::JitoError,
+            KoraError::RecaptchaError(_) => KoraErrorCode::RecaptchaError,
+            KoraError::InternalServerError(_) => KoraErrorCode::InternalServerError,
+            KoraError::ConfigError(_) => KoraErrorCode::ConfigError,
+            KoraError::SerializationError(_) => KoraErrorCode::SerializationError,
+            KoraError::RpcError(_) => KoraErrorCode::RpcError,
+        }
+    }
+
+    /// Returns a structured data object for the RPC error response.
+    pub fn to_json_error_data(&self) -> serde_json::Value {
+        let error_type = match self {
+            KoraError::AccountNotFound(_) => "AccountNotFound",
+            KoraError::RpcError(_) => "RpcError",
+            KoraError::SigningError(_) => "SigningError",
+            KoraError::InvalidTransaction(_) => "InvalidTransaction",
+            KoraError::TransactionExecutionFailed(_) => "TransactionExecutionFailed",
+            KoraError::FeeEstimationFailed(_) => "FeeEstimationFailed",
+            KoraError::UnsupportedFeeToken(_) => "UnsupportedFeeToken",
+            KoraError::InsufficientFunds(_) => "InsufficientFunds",
+            KoraError::InternalServerError(_) => "InternalServerError",
+            KoraError::ValidationError(_) => "ValidationError",
+            KoraError::SerializationError(_) => "SerializationError",
+            KoraError::SwapError(_) => "SwapError",
+            KoraError::TokenOperationError(_) => "TokenOperationError",
+            KoraError::InvalidRequest(_) => "InvalidRequest",
+            KoraError::Unauthorized(_) => "Unauthorized",
+            KoraError::RateLimitExceeded => "RateLimitExceeded",
+            KoraError::UsageLimitExceeded(_) => "UsageLimitExceeded",
+            KoraError::ConfigError(_) => "ConfigError",
+            KoraError::JitoError(_) => "JitoError",
+            KoraError::RecaptchaError(_) => "RecaptchaError",
+        };
+
+        serde_json::json!({
+            "error_type": error_type,
+            "message": self.to_string(),
+        })
+    }
 }
 
-pub fn internal_server_error(e: KoraError) -> RpcError {
-    RpcError::Call(CallError::from_std_error(e))
+impl From<KoraError> for RpcError {
+    fn from(err: KoraError) -> Self {
+        let code = err.error_code();
+        let message = err.to_string();
+        let data = err.to_json_error_data();
+
+        RpcError::Call(CallError::Custom(jsonrpsee::types::error::ErrorObject::owned(
+            code as i32,
+            message,
+            Some(data),
+        )))
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -338,66 +429,96 @@ mod tests {
     }
 
     #[test]
-    fn test_kora_error_to_rpc_error_invalid_request() {
+    fn test_kora_error_to_rpc_error_codes() {
         let test_cases = vec![
-            KoraError::AccountNotFound("test".to_string()),
-            KoraError::InvalidTransaction("test".to_string()),
-            KoraError::ValidationError("test".to_string()),
-            KoraError::UnsupportedFeeToken("test".to_string()),
-            KoraError::InsufficientFunds("test".to_string()),
+            (KoraError::InvalidTransaction("test".to_string()), -32000),
+            (KoraError::ValidationError("test".to_string()), -32001),
+            (KoraError::UnsupportedFeeToken("test".to_string()), -32002),
+            (KoraError::InsufficientFunds("test".to_string()), -32003),
+            (KoraError::InvalidRequest("test".to_string()), -32004),
+            (KoraError::FeeEstimationFailed("test".to_string()), -32005),
+            (KoraError::TransactionExecutionFailed("test".to_string()), -32006),
+            (KoraError::SigningError("test".to_string()), -32020),
+            (KoraError::RateLimitExceeded, -32030),
+            (KoraError::UsageLimitExceeded("test".to_string()), -32031),
+            (KoraError::Unauthorized("test".to_string()), -32032),
+            (KoraError::SwapError("test".to_string()), -32040),
+            (KoraError::TokenOperationError("test".to_string()), -32041),
+            (KoraError::AccountNotFound("test".to_string()), -32050),
+            (KoraError::JitoError("test".to_string()), -32060),
+            (KoraError::RecaptchaError("test".to_string()), -32061),
+            (KoraError::InternalServerError("test".to_string()), -32090),
+            (KoraError::ConfigError("test".to_string()), -32091),
+            (KoraError::SerializationError("test".to_string()), -32092),
+            (KoraError::RpcError("test".to_string()), -32093),
         ];
 
-        for kora_error in test_cases {
+        for (kora_error, expected_code) in test_cases {
             let rpc_error: RpcError = kora_error.into();
-            assert!(matches!(rpc_error, RpcError::Call(_)));
+            if let RpcError::Call(CallError::Custom(err_obj)) = rpc_error {
+                assert_eq!(err_obj.code(), expected_code);
+            } else {
+                panic!("Expected RpcError::Call(CallError::Custom), got {:?}", rpc_error);
+            }
         }
     }
 
     #[test]
-    fn test_kora_error_to_rpc_error_internal_server() {
-        let test_cases = vec![
-            KoraError::InternalServerError("test".to_string()),
-            KoraError::SerializationError("test".to_string()),
-        ];
+    fn test_rpc_error_structure() {
+        let error = KoraError::AccountNotFound("test_acc".to_string());
+        let rpc_error: RpcError = error.into();
 
-        for kora_error in test_cases {
-            let rpc_error: RpcError = kora_error.into();
-            assert!(matches!(rpc_error, RpcError::Call(_)));
+        if let RpcError::Call(CallError::Custom(err_obj)) = rpc_error {
+            assert_eq!(err_obj.code(), -32050);
+            assert_eq!(err_obj.message(), "Account test_acc not found");
+
+            let data = err_obj.data().unwrap();
+            let json_data: serde_json::Value = serde_json::from_str(data.get()).unwrap();
+
+            assert_eq!(json_data["error_type"], "AccountNotFound");
+            assert_eq!(json_data["message"], "Account test_acc not found");
+        } else {
+            panic!("Expected RpcError::Call(CallError::Custom)");
         }
     }
 
     #[test]
-    fn test_kora_error_to_rpc_error_default_case() {
-        let other_errors = vec![
-            KoraError::RpcError("test".to_string()),
-            KoraError::SigningError("test".to_string()),
-            KoraError::TransactionExecutionFailed("test".to_string()),
-            KoraError::FeeEstimationFailed("test".to_string()),
-            KoraError::SwapError("test".to_string()),
-            KoraError::TokenOperationError("test".to_string()),
-            KoraError::InvalidRequest("test".to_string()),
-            KoraError::Unauthorized("test".to_string()),
+    fn test_all_variants_have_unique_codes() {
+        use std::collections::HashSet;
+        let variants = vec![
+            KoraError::AccountNotFound("".into()),
+            KoraError::RpcError("".into()),
+            KoraError::SigningError("".into()),
+            KoraError::InvalidTransaction("".into()),
+            KoraError::TransactionExecutionFailed("".into()),
+            KoraError::FeeEstimationFailed("".into()),
+            KoraError::UnsupportedFeeToken("".into()),
+            KoraError::InsufficientFunds("".into()),
+            KoraError::InternalServerError("".into()),
+            KoraError::ValidationError("".into()),
+            KoraError::SerializationError("".into()),
+            KoraError::SwapError("".into()),
+            KoraError::TokenOperationError("".into()),
+            KoraError::InvalidRequest("".into()),
+            KoraError::Unauthorized("".into()),
             KoraError::RateLimitExceeded,
+            KoraError::UsageLimitExceeded("".into()),
+            KoraError::ConfigError("".into()),
+            KoraError::JitoError("".into()),
+            KoraError::RecaptchaError("".into()),
         ];
 
-        for kora_error in other_errors {
-            let rpc_error: RpcError = kora_error.into();
-            assert!(matches!(rpc_error, RpcError::Call(_)));
+        let mut codes = HashSet::new();
+        for variant in variants {
+            let code = variant.error_code() as i32;
+            assert!(
+                codes.insert(code),
+                "Duplicate error code {} found for variant {:?}",
+                code,
+                variant
+            );
+            assert!((-32099..=-32000).contains(&code), "Code {} out of range", code);
         }
-    }
-
-    #[test]
-    fn test_invalid_request_function() {
-        let error = KoraError::ValidationError("invalid input".to_string());
-        let rpc_error = invalid_request(error);
-        assert!(matches!(rpc_error, RpcError::Call(_)));
-    }
-
-    #[test]
-    fn test_internal_server_error_function() {
-        let error = KoraError::InternalServerError("server panic".to_string());
-        let rpc_error = internal_server_error(error);
-        assert!(matches!(rpc_error, RpcError::Call(_)));
     }
 
     #[test]

--- a/crates/lib/src/error.rs
+++ b/crates/lib/src/error.rs
@@ -125,8 +125,7 @@ impl_kora_error_from!(Box<dyn StdError + Send + Sync> => InternalServerError);
 impl_kora_error_from!(ProgramError => InvalidTransaction);
 
 /// Stable numeric error codes for RPC responses following JSON-RPC 2.0 spec (-32000 to -32099 for server errors).
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(into = "i32")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum KoraErrorCode {
     // Validation errors (-32000 to -32019)
     InvalidTransaction = -32000,
@@ -163,12 +162,6 @@ pub enum KoraErrorCode {
     RpcError = -32093,
 }
 
-impl From<KoraErrorCode> for i32 {
-    fn from(code: KoraErrorCode) -> Self {
-        code as i32
-    }
-}
-
 impl KoraError {
     pub fn error_code(&self) -> KoraErrorCode {
         match self {
@@ -195,34 +188,11 @@ impl KoraError {
         }
     }
 
-    /// Returns a structured data object for the RPC error response.
     pub fn to_json_error_data(&self) -> serde_json::Value {
-        let error_type = match self {
-            KoraError::AccountNotFound(_) => "AccountNotFound",
-            KoraError::RpcError(_) => "RpcError",
-            KoraError::SigningError(_) => "SigningError",
-            KoraError::InvalidTransaction(_) => "InvalidTransaction",
-            KoraError::TransactionExecutionFailed(_) => "TransactionExecutionFailed",
-            KoraError::FeeEstimationFailed(_) => "FeeEstimationFailed",
-            KoraError::UnsupportedFeeToken(_) => "UnsupportedFeeToken",
-            KoraError::InsufficientFunds(_) => "InsufficientFunds",
-            KoraError::InternalServerError(_) => "InternalServerError",
-            KoraError::ValidationError(_) => "ValidationError",
-            KoraError::SerializationError(_) => "SerializationError",
-            KoraError::SwapError(_) => "SwapError",
-            KoraError::TokenOperationError(_) => "TokenOperationError",
-            KoraError::InvalidRequest(_) => "InvalidRequest",
-            KoraError::Unauthorized(_) => "Unauthorized",
-            KoraError::RateLimitExceeded => "RateLimitExceeded",
-            KoraError::UsageLimitExceeded(_) => "UsageLimitExceeded",
-            KoraError::ConfigError(_) => "ConfigError",
-            KoraError::JitoError(_) => "JitoError",
-            KoraError::RecaptchaError(_) => "RecaptchaError",
-        };
+        let error_type = format!("{:?}", self.error_code());
 
         serde_json::json!({
             "error_type": error_type,
-            "message": self.to_string(),
         })
     }
 }
@@ -294,7 +264,7 @@ impl From<BundleError> for KoraError {
 mod tests {
     use super::*;
     use solana_program::program_error::ProgramError;
-    use std::error::Error as StdError;
+    use std::{collections::HashSet, error::Error as StdError};
 
     #[test]
     fn test_kora_response_ok() {
@@ -476,7 +446,6 @@ mod tests {
             let json_data: serde_json::Value = serde_json::from_str(data.get()).unwrap();
 
             assert_eq!(json_data["error_type"], "AccountNotFound");
-            assert_eq!(json_data["message"], "Account test_acc not found");
         } else {
             panic!("Expected RpcError::Call(CallError::Custom)");
         }
@@ -484,7 +453,6 @@ mod tests {
 
     #[test]
     fn test_all_variants_have_unique_codes() {
-        use std::collections::HashSet;
         let variants = vec![
             KoraError::AccountNotFound("".into()),
             KoraError::RpcError("".into()),

--- a/sdks/ts/src/client.ts
+++ b/sdks/ts/src/client.ts
@@ -1,6 +1,7 @@
 import { Address, assertIsAddress, Instruction, isTransactionSigner } from '@solana/kit';
 import { findAssociatedTokenPda, getTransferInstruction, TOKEN_PROGRAM_ADDRESS } from '@solana-program/token';
 import crypto from 'crypto';
+import { KoraError } from './error.js';
 
 import {
     AuthenticationHeaders,
@@ -111,8 +112,8 @@ export class KoraClient {
         const json = (await response.json()) as { error?: RpcError; result: T };
 
         if (json.error) {
-            const error = json.error;
-            throw new Error(`RPC Error ${error.code}: ${error.message}`);
+            const { code, message, data } = json.error;
+            throw new KoraError(code, message, data);
         }
 
         return json.result;

--- a/sdks/ts/src/error.ts
+++ b/sdks/ts/src/error.ts
@@ -1,0 +1,70 @@
+/**
+ * Stable numeric error codes for RPC responses following JSON-RPC 2.0 spec (-32000 to -32099 for server errors).
+ */
+export enum KoraErrorCode {
+    // Validation errors (-32000 to -32019)
+    InvalidTransaction = -32000,
+    ValidationError = -32001,
+    UnsupportedFeeToken = -32002,
+    InsufficientFunds = -32003,
+    InvalidRequest = -32004,
+    FeeEstimationFailed = -32005,
+    TransactionExecutionFailed = -32006,
+
+    // Signing errors (-32020 to -32029)
+    SigningError = -32020,
+
+    // Auth / Rate limiting (-32030 to -32039)
+    RateLimitExceeded = -32030,
+    UsageLimitExceeded = -32031,
+    Unauthorized = -32032,
+
+    // Token / Swap (-32040 to -32049)
+    SwapError = -32040,
+    TokenOperationError = -32041,
+
+    // Account errors (-32050 to -32059)
+    AccountNotFound = -32050,
+
+    // External services (-32060 to -32069)
+    JitoError = -32060,
+    RecaptchaError = -32061,
+
+    // Internal errors (-32090 to -32099)
+    InternalServerError = -32090,
+    ConfigError = -32091,
+    SerializationError = -32092,
+    RpcError = -32093,
+}
+
+/**
+ * Structured data returned in the JSON-RPC error object's `data` field.
+ */
+export interface KoraErrorData {
+    error_type: string;
+    message: string;
+}
+
+/**
+ * Represents a structured error returned by the Kora paymaster service.
+ */
+export class KoraError extends Error {
+    /** The stable numeric error code */
+    public readonly code: number;
+    /** Optional structured data about the error */
+    public readonly data?: KoraErrorData;
+
+    constructor(code?: number, message?: string, data?: KoraErrorData) {
+        const finalCode = code ?? -32603;
+        const finalMessage = message ?? 'Unknown error';
+        super(`Kora Error ${finalCode}: ${finalMessage}`);
+        this.name = 'KoraError';
+        this.code = finalCode;
+        this.data = data;
+
+        // Ensure proper stack trace in environments that support Error.captureStackTrace
+        if (Error.captureStackTrace) {
+            Error.captureStackTrace(this, KoraError);
+        }
+    }
+}

--- a/sdks/ts/src/error.ts
+++ b/sdks/ts/src/error.ts
@@ -42,7 +42,6 @@ export enum KoraErrorCode {
  */
 export interface KoraErrorData {
     error_type: string;
-    message: string;
 }
 
 /**
@@ -50,7 +49,7 @@ export interface KoraErrorData {
  */
 export class KoraError extends Error {
     /** The stable numeric error code */
-    public readonly code: number;
+    public readonly code: KoraErrorCode;
     /** Optional structured data about the error */
     public readonly data?: KoraErrorData;
 
@@ -59,7 +58,7 @@ export class KoraError extends Error {
         const finalMessage = message ?? 'Unknown error';
         super(`Kora Error ${finalCode}: ${finalMessage}`);
         this.name = 'KoraError';
-        this.code = finalCode;
+        this.code = finalCode as KoraErrorCode;
         this.data = data;
 
         // Ensure proper stack trace in environments that support Error.captureStackTrace

--- a/sdks/ts/src/index.ts
+++ b/sdks/ts/src/index.ts
@@ -1,3 +1,4 @@
+export * from './error.js';
 export * from './types/index.js';
 export { KoraClient } from './client.js';
 export { createKitKoraClient, kora, type KoraKitClient } from './kit/index.js';

--- a/sdks/ts/src/types/index.ts
+++ b/sdks/ts/src/types/index.ts
@@ -459,6 +459,11 @@ export interface FeePayerPolicy {
 export interface RpcError {
     /** Error code */
     code: number;
+    /** Optional structured data about the error */
+    data?: {
+        error_type: string;
+        message: string;
+    };
     /** Human-readable error message */
     message: string;
 }

--- a/sdks/ts/src/types/index.ts
+++ b/sdks/ts/src/types/index.ts
@@ -462,7 +462,6 @@ export interface RpcError {
     /** Optional structured data about the error */
     data?: {
         error_type: string;
-        message: string;
     };
     /** Human-readable error message */
     message: string;

--- a/sdks/ts/test/kit-client.test.ts
+++ b/sdks/ts/test/kit-client.test.ts
@@ -96,7 +96,7 @@ describe('createKitKoraClient', () => {
                     feeToken: MOCK_FEE_TOKEN,
                     feePayerWallet: MOCK_WALLET,
                 }),
-            ).rejects.toThrow('RPC Error -32000: Server error');
+            ).rejects.toThrow('Kora Error -32000: Server error');
         });
 
         it('should expose kora namespace for raw RPC access', async () => {

--- a/sdks/ts/test/plugin.test.ts
+++ b/sdks/ts/test/plugin.test.ts
@@ -502,7 +502,7 @@ describe('Kora Kit Plugin', () => {
         it('should propagate RPC errors', async () => {
             mockErrorResponse({ code: -32601, message: 'Method not found' });
 
-            await expect(kora.getConfig()).rejects.toThrow('RPC Error -32601: Method not found');
+            await expect(kora.getConfig()).rejects.toThrow('Kora Error -32601: Method not found');
         });
 
         it('should propagate network errors', async () => {

--- a/sdks/ts/test/unit.test.ts
+++ b/sdks/ts/test/unit.test.ts
@@ -12,6 +12,7 @@ import {
 } from '@solana/kit';
 
 import { KoraClient } from '../src/client.js';
+import { KoraError } from '../src/error.js';
 import {
     Config,
     EstimateTransactionFeeRequest,
@@ -113,7 +114,7 @@ describe('KoraClient Unit Tests', () => {
         it('should handle RPC error responses', async () => {
             const mockError = { code: -32601, message: 'Method not found' };
             mockErrorResponse(mockError);
-            await expect(client.getConfig()).rejects.toThrow('RPC Error -32601: Method not found');
+            await expect(client.getConfig()).rejects.toThrow('Kora Error -32601: Method not found');
         });
 
         it('should handle network errors', async () => {
@@ -337,7 +338,7 @@ describe('KoraClient Unit Tests', () => {
             };
             const mockError = { code: -32000, message: 'Bundle validation failed' };
             mockErrorResponse(mockError);
-            await expect(client.signBundle(request)).rejects.toThrow('RPC Error -32000: Bundle validation failed');
+            await expect(client.signBundle(request)).rejects.toThrow('Kora Error -32000: Bundle validation failed');
         });
     });
 
@@ -366,7 +367,9 @@ describe('KoraClient Unit Tests', () => {
             };
             const mockError = { code: -32000, message: 'Jito submission failed' };
             mockErrorResponse(mockError);
-            await expect(client.signAndSendBundle(request)).rejects.toThrow('RPC Error -32000: Jito submission failed');
+            await expect(client.signAndSendBundle(request)).rejects.toThrow(
+                'Kora Error -32000: Jito submission failed',
+            );
         });
     });
 
@@ -573,7 +576,7 @@ describe('KoraClient Unit Tests', () => {
             });
 
             await expect(client.getPaymentInstruction(validRequest)).rejects.toThrow(
-                'RPC Error -32602: Invalid transaction',
+                'Kora Error -32602: Invalid transaction',
             );
         });
 
@@ -707,12 +710,45 @@ describe('KoraClient Unit Tests', () => {
         it('should handle responses with an error object', async () => {
             const mockError = { code: -32602, message: 'Invalid params' };
             mockErrorResponse(mockError);
-            await expect(client.getConfig()).rejects.toThrow('RPC Error -32602: Invalid params');
+            await expect(client.getConfig()).rejects.toThrow('Kora Error -32602: Invalid params');
         });
 
-        it('should handle empty error object', async () => {
+        it('should handle empty error object gracefully', async () => {
             mockErrorResponse({});
-            await expect(client.getConfig()).rejects.toThrow('RPC Error undefined: undefined');
+            try {
+                await client.getConfig();
+                throw new Error('Should have thrown KoraError');
+            } catch (e: any) {
+                expect(e).toBeInstanceOf(KoraError);
+                expect(e.code).toBe(-32603);
+                expect(e.message).toBe('Kora Error -32603: Unknown error');
+                expect(e.data).toBeUndefined();
+            }
+        });
+
+        it('should populate KoraError properties (code and data)', async () => {
+            const mockError = {
+                code: -32050,
+                data: {
+                    error_type: 'AccountNotFound',
+                    message: 'Account not found message',
+                },
+                message: 'Account not found message',
+            };
+            mockErrorResponse(mockError);
+
+            try {
+                await client.getConfig();
+                throw new Error('Should have thrown KoraError');
+            } catch (e: any) {
+                expect(e).toBeInstanceOf(KoraError);
+                expect(e.code).toBe(-32050);
+                expect(e.data).toEqual({
+                    error_type: 'AccountNotFound',
+                    message: 'Account not found message',
+                });
+                expect(e.message).toBe('Kora Error -32050: Account not found message');
+            }
         });
     });
 

--- a/sdks/ts/test/unit.test.ts
+++ b/sdks/ts/test/unit.test.ts
@@ -731,7 +731,6 @@ describe('KoraClient Unit Tests', () => {
                 code: -32050,
                 data: {
                     error_type: 'AccountNotFound',
-                    message: 'Account not found message',
                 },
                 message: 'Account not found message',
             };
@@ -745,7 +744,6 @@ describe('KoraClient Unit Tests', () => {
                 expect(e.code).toBe(-32050);
                 expect(e.data).toEqual({
                     error_type: 'AccountNotFound',
-                    message: 'Account not found message',
                 });
                 expect(e.message).toBe('Kora Error -32050: Account not found message');
             }


### PR DESCRIPTION
Replaces string-based error parsing with stable numeric codes (-32000 to -32099).

- Added `KoraErrorCode` enum in Rust and TS
- Added `KoraError` class in TS SDK clients can now use `instanceof KoraError` and switch on `error.code`

Breaking: RPC errors now return specific -320xx codes instead of generic -32603/-32600