### PR TITLE
fix(bundle): validate signed txs with sequential simulation

### DIFF
--- a/crates/lib/src/bundle/helper.rs
+++ b/crates/lib/src/bundle/helper.rs
@@ -1,8 +1,5 @@
 use crate::{
-    bundle::{
-        BundleError, JitoBundleClient, JitoBundleSimulationConfig, JitoBundleSimulationResult,
-        JitoError,
-    },
+    bundle::{BundleError, JitoError},
     config::Config,
     constant::ESTIMATED_LAMPORTS_FOR_PAYMENT_INSTRUCTION,
     fee::fee::{FeeConfigUtil, TransactionFeeUtil},
@@ -89,23 +86,6 @@ impl BundleProcessor {
                 }
             })
             .collect()
-    }
-
-    pub async fn simulate_bundle(
-        encoded_txs: &[String],
-        config: &Config,
-    ) -> Result<JitoBundleSimulationResult, KoraError> {
-        let jito_client = JitoBundleClient::new(&config.kora.bundle.jito);
-        Ok(jito_client.simulate_bundle(encoded_txs).await?)
-    }
-
-    pub async fn simulate_bundle_with_config(
-        encoded_txs: &[String],
-        simulation_config: JitoBundleSimulationConfig,
-        config: &Config,
-    ) -> Result<JitoBundleSimulationResult, KoraError> {
-        let jito_client = JitoBundleClient::new(&config.kora.bundle.jito);
-        Ok(jito_client.simulate_bundle_with_config(encoded_txs, simulation_config).await?)
     }
 
     #[allow(clippy::too_many_arguments)]

--- a/crates/lib/src/bundle/helper.rs
+++ b/crates/lib/src/bundle/helper.rs
@@ -254,16 +254,6 @@ impl BundleProcessor {
         self.sign_all_internal(signer, fee_payer, rpc_client, config, will_send, true).await
     }
 
-    pub async fn sign_all_for_simulation(
-        self,
-        signer: &Arc<solana_keychain::Signer>,
-        fee_payer: &Pubkey,
-        rpc_client: &RpcClient,
-        config: &Config,
-    ) -> Result<Vec<VersionedTransactionResolved>, KoraError> {
-        self.sign_all_internal(signer, fee_payer, rpc_client, config, false, false).await
-    }
-
     async fn sign_all_internal(
         mut self,
         signer: &Arc<solana_keychain::Signer>,

--- a/crates/lib/src/bundle/helper.rs
+++ b/crates/lib/src/bundle/helper.rs
@@ -1,5 +1,8 @@
 use crate::{
-    bundle::{BundleError, JitoError},
+    bundle::{
+        BundleError, JitoBundleClient, JitoBundleSimulationConfig, JitoBundleSimulationResult,
+        JitoError,
+    },
     config::Config,
     constant::ESTIMATED_LAMPORTS_FOR_PAYMENT_INSTRUCTION,
     fee::fee::{FeeConfigUtil, TransactionFeeUtil},
@@ -86,6 +89,23 @@ impl BundleProcessor {
                 }
             })
             .collect()
+    }
+
+    pub async fn simulate_bundle(
+        encoded_txs: &[String],
+        config: &Config,
+    ) -> Result<JitoBundleSimulationResult, KoraError> {
+        let jito_client = JitoBundleClient::new(&config.kora.bundle.jito);
+        Ok(jito_client.simulate_bundle(encoded_txs).await?)
+    }
+
+    pub async fn simulate_bundle_with_config(
+        encoded_txs: &[String],
+        simulation_config: JitoBundleSimulationConfig,
+        config: &Config,
+    ) -> Result<JitoBundleSimulationResult, KoraError> {
+        let jito_client = JitoBundleClient::new(&config.kora.bundle.jito);
+        Ok(jito_client.simulate_bundle_with_config(encoded_txs, simulation_config).await?)
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -224,14 +244,38 @@ impl BundleProcessor {
     }
 
     pub async fn sign_all(
-        mut self,
+        self,
         signer: &Arc<solana_keychain::Signer>,
         fee_payer: &Pubkey,
         rpc_client: &RpcClient,
         config: &Config,
         will_send: bool,
     ) -> Result<Vec<VersionedTransactionResolved>, KoraError> {
-        self.validate_payment()?;
+        self.sign_all_internal(signer, fee_payer, rpc_client, config, will_send, true).await
+    }
+
+    pub async fn sign_all_for_simulation(
+        self,
+        signer: &Arc<solana_keychain::Signer>,
+        fee_payer: &Pubkey,
+        rpc_client: &RpcClient,
+        config: &Config,
+    ) -> Result<Vec<VersionedTransactionResolved>, KoraError> {
+        self.sign_all_internal(signer, fee_payer, rpc_client, config, false, false).await
+    }
+
+    async fn sign_all_internal(
+        mut self,
+        signer: &Arc<solana_keychain::Signer>,
+        fee_payer: &Pubkey,
+        rpc_client: &RpcClient,
+        config: &Config,
+        will_send: bool,
+        validate_payment: bool,
+    ) -> Result<Vec<VersionedTransactionResolved>, KoraError> {
+        if validate_payment {
+            self.validate_payment()?;
+        }
 
         let mut blockhash = None;
         let tx_count = self.resolved_transactions.len();

--- a/crates/lib/src/bundle/jito/client.rs
+++ b/crates/lib/src/bundle/jito/client.rs
@@ -228,6 +228,7 @@ impl JitoBundleClient {
 
 pub struct JitoClient {
     block_engine_url: String,
+    simulate_bundle_url: String,
     client: Client,
 }
 
@@ -252,7 +253,14 @@ struct JsonRpcError {
 
 impl JitoClient {
     pub fn new(config: &JitoConfig) -> Self {
-        Self { block_engine_url: config.block_engine_url.clone(), client: Client::new() }
+        Self {
+            block_engine_url: config.block_engine_url.clone(),
+            simulate_bundle_url: config
+                .simulate_bundle_url
+                .clone()
+                .unwrap_or_else(|| config.block_engine_url.clone()),
+            client: Client::new(),
+        }
     }
 
     fn block_engine_base_url(&self) -> &str {
@@ -358,9 +366,9 @@ impl JitoClient {
             })?);
         }
 
-        let raw_result: Value = self
-            .send_request(self.block_engine_base_url(), "simulateBundle", Value::Array(params))
-            .await?;
+        let simulate_url = self.simulate_bundle_url.trim_end_matches('/');
+        let raw_result: Value =
+            self.send_request(simulate_url, "simulateBundle", Value::Array(params)).await?;
         let parsed_result = JitoBundleSimulationResult::from_rpc_result(raw_result)?;
 
         if let Some((failed_idx, failed_result)) = parsed_result.first_failure() {
@@ -526,7 +534,8 @@ mod tests {
             .with_body(r#"{"jsonrpc":"2.0","id":1,"result":"bundle-uuid-12345"}"#)
             .create();
 
-        let config = JitoConfig { block_engine_url: server.url() };
+        let config =
+            JitoConfig { block_engine_url: server.url(), simulate_bundle_url: Some(server.url()) };
         let client = JitoClient::new(&config);
 
         let tx = create_mock_encoded_transaction();
@@ -547,7 +556,8 @@ mod tests {
             .with_body("Internal Server Error")
             .create();
 
-        let config = JitoConfig { block_engine_url: server.url() };
+        let config =
+            JitoConfig { block_engine_url: server.url(), simulate_bundle_url: Some(server.url()) };
         let client = JitoClient::new(&config);
 
         let tx = create_mock_encoded_transaction();
@@ -568,7 +578,8 @@ mod tests {
             .with_body(r#"{"jsonrpc":"2.0","id":1,"error":{"message":"Bundle rejected"}}"#)
             .create();
 
-        let config = JitoConfig { block_engine_url: server.url() };
+        let config =
+            JitoConfig { block_engine_url: server.url(), simulate_bundle_url: Some(server.url()) };
         let client = JitoClient::new(&config);
 
         let tx = create_mock_encoded_transaction();
@@ -590,7 +601,8 @@ mod tests {
             .with_body(r#"{"jsonrpc":"2.0","id":1,"result":{"value":[{"bundle_id":"uuid1","status":"Landed"}]}}"#)
             .create();
 
-        let config = JitoConfig { block_engine_url: server.url() };
+        let config =
+            JitoConfig { block_engine_url: server.url(), simulate_bundle_url: Some(server.url()) };
         let client = JitoClient::new(&config);
 
         let result = client.get_bundle_statuses(vec!["uuid1".to_string()]).await;
@@ -616,7 +628,8 @@ mod tests {
             )
             .create();
 
-        let config = JitoConfig { block_engine_url: server.url() };
+        let config =
+            JitoConfig { block_engine_url: server.url(), simulate_bundle_url: Some(server.url()) };
         let client = JitoClient::new(&config);
 
         let result = client.simulate_bundle(&["encoded-tx".to_string()]).await;
@@ -646,7 +659,8 @@ mod tests {
             )
             .create();
 
-        let config = JitoConfig { block_engine_url: server.url() };
+        let config =
+            JitoConfig { block_engine_url: server.url(), simulate_bundle_url: Some(server.url()) };
         let client = JitoClient::new(&config);
 
         let result = client.simulate_bundle(&["encoded-tx".to_string()]).await;
@@ -673,7 +687,8 @@ mod tests {
             )
             .create();
 
-        let config = JitoConfig { block_engine_url: server.url() };
+        let config =
+            JitoConfig { block_engine_url: server.url(), simulate_bundle_url: Some(server.url()) };
         let client = JitoClient::new(&config);
 
         let result = client.simulate_bundle(&[create_mock_encoded_transaction()]).await;
@@ -698,7 +713,8 @@ mod tests {
             )
             .create();
 
-        let config = JitoConfig { block_engine_url: server.url() };
+        let config =
+            JitoConfig { block_engine_url: server.url(), simulate_bundle_url: Some(server.url()) };
         let client = JitoClient::new(&config);
 
         let result = client.simulate_bundle(&[create_mock_encoded_transaction()]).await;
@@ -732,7 +748,8 @@ mod tests {
             )
             .create();
 
-        let config = JitoConfig { block_engine_url: server.url() };
+        let config =
+            JitoConfig { block_engine_url: server.url(), simulate_bundle_url: Some(server.url()) };
         let client = JitoClient::new(&config);
 
         let simulation_config = JitoBundleSimulationConfig {
@@ -768,7 +785,8 @@ mod tests {
             .with_body(r#"{"jsonrpc":"2.0","id":1,"result":12345}"#)
             .create();
 
-        let config = JitoConfig { block_engine_url: server.url() };
+        let config =
+            JitoConfig { block_engine_url: server.url(), simulate_bundle_url: Some(server.url()) };
         let client = JitoClient::new(&config);
 
         let tx = create_mock_encoded_transaction();
@@ -789,7 +807,8 @@ mod tests {
             .with_body(r#"{"jsonrpc":"2.0","id":1}"#)
             .create();
 
-        let config = JitoConfig { block_engine_url: server.url() };
+        let config =
+            JitoConfig { block_engine_url: server.url(), simulate_bundle_url: Some(server.url()) };
         let client = JitoClient::new(&config);
 
         let tx = create_mock_encoded_transaction();
@@ -810,7 +829,8 @@ mod tests {
             .with_body(r#"{"jsonrpc":"2.0","id":1,"result":"multi-tx-bundle-uuid"}"#)
             .create();
 
-        let config = JitoConfig { block_engine_url: server.url() };
+        let config =
+            JitoConfig { block_engine_url: server.url(), simulate_bundle_url: Some(server.url()) };
         let client = JitoClient::new(&config);
 
         let txs = vec![
@@ -836,7 +856,8 @@ mod tests {
             .with_body(r#"not valid json"#)
             .create();
 
-        let config = JitoConfig { block_engine_url: server.url() };
+        let config =
+            JitoConfig { block_engine_url: server.url(), simulate_bundle_url: Some(server.url()) };
         let client = JitoClient::new(&config);
 
         let tx = create_mock_encoded_transaction();
@@ -860,7 +881,8 @@ mod tests {
             .with_body(r#"{"jsonrpc":"2.0","id":1,"result":{"value":[]}}"#)
             .create();
 
-        let config = JitoConfig { block_engine_url: server.url() };
+        let config =
+            JitoConfig { block_engine_url: server.url(), simulate_bundle_url: Some(server.url()) };
         let client = JitoClient::new(&config);
 
         let result = client.get_bundle_statuses(vec![]).await;
@@ -883,7 +905,8 @@ mod tests {
             .with_body(r#"{"jsonrpc":"2.0","id":1,"result":{"value":[{"bundle_id":"uuid1","status":"Landed"},{"bundle_id":"uuid2","status":"Pending"}]}}"#)
             .create();
 
-        let config = JitoConfig { block_engine_url: server.url() };
+        let config =
+            JitoConfig { block_engine_url: server.url(), simulate_bundle_url: Some(server.url()) };
         let client = JitoClient::new(&config);
 
         let result = client
@@ -899,7 +922,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_jito_bundle_client_dispatches_to_mock() {
-        let config = JitoConfig { block_engine_url: JITO_MOCK_BLOCK_ENGINE_URL.to_string() };
+        let config = JitoConfig {
+            block_engine_url: JITO_MOCK_BLOCK_ENGINE_URL.to_string(),
+            simulate_bundle_url: Some(JITO_MOCK_BLOCK_ENGINE_URL.to_string()),
+        };
         let client = JitoBundleClient::new(&config);
 
         assert!(matches!(client, JitoBundleClient::Mock(_)));
@@ -914,7 +940,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_jito_bundle_client_dispatches_to_real() {
-        let config = JitoConfig { block_engine_url: "https://example.com".to_string() };
+        let config = JitoConfig {
+            block_engine_url: "https://example.com".to_string(),
+            simulate_bundle_url: None,
+        };
         let client = JitoBundleClient::new(&config);
 
         assert!(matches!(client, JitoBundleClient::Live(_)));
@@ -922,7 +951,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_mock_client_get_bundle_statuses() {
-        let config = JitoConfig { block_engine_url: JITO_MOCK_BLOCK_ENGINE_URL.to_string() };
+        let config = JitoConfig {
+            block_engine_url: JITO_MOCK_BLOCK_ENGINE_URL.to_string(),
+            simulate_bundle_url: Some(JITO_MOCK_BLOCK_ENGINE_URL.to_string()),
+        };
         let client = JitoBundleClient::new(&config);
 
         let result = client.get_bundle_statuses(vec!["test-uuid".to_string()]).await;
@@ -935,7 +967,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_mock_client_simulate_bundle() {
-        let config = JitoConfig { block_engine_url: JITO_MOCK_BLOCK_ENGINE_URL.to_string() };
+        let config = JitoConfig {
+            block_engine_url: JITO_MOCK_BLOCK_ENGINE_URL.to_string(),
+            simulate_bundle_url: Some(JITO_MOCK_BLOCK_ENGINE_URL.to_string()),
+        };
         let client = JitoBundleClient::new(&config);
 
         let result = client.simulate_bundle(&[create_mock_encoded_transaction()]).await;

--- a/crates/lib/src/bundle/jito/client.rs
+++ b/crates/lib/src/bundle/jito/client.rs
@@ -66,17 +66,28 @@ impl JitoBundleSimulationResult {
     fn parse_transaction_result(
         value: Value,
     ) -> Result<JitoBundleSimulationTransactionResult, JitoError> {
-        let logs = value
-            .get("logs")
-            .and_then(Value::as_array)
-            .map(|entries| {
-                entries
-                    .iter()
-                    .filter_map(Value::as_str)
-                    .map(ToString::to_string)
-                    .collect::<Vec<String>>()
-            })
-            .unwrap_or_default();
+        let logs = match value.get("logs") {
+            Some(Value::Array(entries)) => entries
+                .iter()
+                .map(|entry| {
+                    entry.as_str().map(ToString::to_string).ok_or_else(|| {
+                        JitoError::ApiError(
+                            "Invalid log entry in simulateBundle response".to_string(),
+                        )
+                    })
+                })
+                .collect::<Result<Vec<_>, _>>()?,
+            None | Some(Value::Null) => {
+                return Err(JitoError::ApiError(
+                    "Missing logs in simulateBundle response".to_string(),
+                ))
+            }
+            _ => {
+                return Err(JitoError::ApiError(
+                    "Invalid logs in simulateBundle response".to_string(),
+                ))
+            }
+        };
 
         let pre_execution_accounts = match value.get("preExecutionAccounts") {
             None | Some(Value::Null) => None,
@@ -364,13 +375,11 @@ impl JitoClient {
             return Err(BundleError::ValidationError(message));
         }
 
-        if parsed_result.transaction_results.is_empty() {
-            if let Some(summary) = &parsed_result.summary {
-                if JitoBundleSimulationResult::summary_failed(summary) {
-                    return Err(BundleError::ValidationError(format!(
-                        "Bundle simulation failed: {summary}",
-                    )));
-                }
+        if let Some(summary) = &parsed_result.summary {
+            if JitoBundleSimulationResult::summary_failed(summary) {
+                return Err(BundleError::ValidationError(format!(
+                    "Bundle simulation failed: {summary}",
+                )));
             }
         }
 

--- a/crates/lib/src/bundle/jito/client.rs
+++ b/crates/lib/src/bundle/jito/client.rs
@@ -200,16 +200,6 @@ impl JitoBundleClient {
         }
     }
 
-    pub async fn simulate_bundle(
-        &self,
-        encoded_transactions: &[String],
-    ) -> Result<JitoBundleSimulationResult, BundleError> {
-        match self {
-            Self::Live(client) => client.simulate_bundle(encoded_transactions).await,
-            Self::Mock(client) => client.simulate_bundle(encoded_transactions).await,
-        }
-    }
-
     pub async fn simulate_bundle_with_config(
         &self,
         encoded_transactions: &[String],
@@ -335,36 +325,18 @@ impl JitoClient {
         Ok(self.send_request(&url, "getBundleStatuses", params).await?)
     }
 
-    pub async fn simulate_bundle(
-        &self,
-        encoded_transactions: &[String],
-    ) -> Result<JitoBundleSimulationResult, BundleError> {
-        self.simulate_bundle_with_optional_config(encoded_transactions, None).await
-    }
-
     pub async fn simulate_bundle_with_config(
         &self,
         encoded_transactions: &[String],
         simulation_config: JitoBundleSimulationConfig,
     ) -> Result<JitoBundleSimulationResult, BundleError> {
-        self.simulate_bundle_with_optional_config(encoded_transactions, Some(simulation_config))
-            .await
-    }
-
-    async fn simulate_bundle_with_optional_config(
-        &self,
-        encoded_transactions: &[String],
-        simulation_config: Option<JitoBundleSimulationConfig>,
-    ) -> Result<JitoBundleSimulationResult, BundleError> {
         let mut params = vec![json!({ "encodedTransactions": encoded_transactions })];
-        if let Some(config) = simulation_config {
-            params.push(serde_json::to_value(config).map_err(|e| {
-                JitoError::ApiError(format!(
-                    "Failed to serialize simulateBundle config: {}",
-                    sanitize_error!(e)
-                ))
-            })?);
-        }
+        params.push(serde_json::to_value(simulation_config).map_err(|e| {
+            JitoError::ApiError(format!(
+                "Failed to serialize simulateBundle config: {}",
+                sanitize_error!(e)
+            ))
+        })?);
 
         let simulate_url = self.simulate_bundle_url.trim_end_matches('/');
         let raw_result: Value =
@@ -425,17 +397,6 @@ impl JitoMockClient {
             })
             .collect();
         Ok(json!({ "value": mock_statuses }))
-    }
-
-    pub async fn simulate_bundle(
-        &self,
-        _encoded_transactions: &[String],
-    ) -> Result<JitoBundleSimulationResult, BundleError> {
-        self.simulate_bundle_with_config(
-            _encoded_transactions,
-            JitoBundleSimulationConfig::default(),
-        )
-        .await
     }
 
     pub async fn simulate_bundle_with_config(
@@ -632,7 +593,12 @@ mod tests {
             JitoConfig { block_engine_url: server.url(), simulate_bundle_url: Some(server.url()) };
         let client = JitoClient::new(&config);
 
-        let result = client.simulate_bundle(&["encoded-tx".to_string()]).await;
+        let result = client
+            .simulate_bundle_with_config(
+                &["encoded-tx".to_string()],
+                JitoBundleSimulationConfig::default(),
+            )
+            .await;
         mock.assert();
         assert!(result.is_ok());
         let simulation = result.unwrap();
@@ -663,7 +629,12 @@ mod tests {
             JitoConfig { block_engine_url: server.url(), simulate_bundle_url: Some(server.url()) };
         let client = JitoClient::new(&config);
 
-        let result = client.simulate_bundle(&["encoded-tx".to_string()]).await;
+        let result = client
+            .simulate_bundle_with_config(
+                &["encoded-tx".to_string()],
+                JitoBundleSimulationConfig::default(),
+            )
+            .await;
         mock.assert();
         assert!(result.is_ok());
         let simulation = result.unwrap();
@@ -691,7 +662,12 @@ mod tests {
             JitoConfig { block_engine_url: server.url(), simulate_bundle_url: Some(server.url()) };
         let client = JitoClient::new(&config);
 
-        let result = client.simulate_bundle(&[create_mock_encoded_transaction()]).await;
+        let result = client
+            .simulate_bundle_with_config(
+                &[create_mock_encoded_transaction()],
+                JitoBundleSimulationConfig::default(),
+            )
+            .await;
         mock.assert();
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
@@ -717,7 +693,12 @@ mod tests {
             JitoConfig { block_engine_url: server.url(), simulate_bundle_url: Some(server.url()) };
         let client = JitoClient::new(&config);
 
-        let result = client.simulate_bundle(&[create_mock_encoded_transaction()]).await;
+        let result = client
+            .simulate_bundle_with_config(
+                &[create_mock_encoded_transaction()],
+                JitoBundleSimulationConfig::default(),
+            )
+            .await;
         mock.assert();
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
@@ -973,7 +954,12 @@ mod tests {
         };
         let client = JitoBundleClient::new(&config);
 
-        let result = client.simulate_bundle(&[create_mock_encoded_transaction()]).await;
+        let result = client
+            .simulate_bundle_with_config(
+                &[create_mock_encoded_transaction()],
+                JitoBundleSimulationConfig::default(),
+            )
+            .await;
 
         assert!(result.is_ok());
         let simulation = result.unwrap();

--- a/crates/lib/src/bundle/jito/client.rs
+++ b/crates/lib/src/bundle/jito/client.rs
@@ -140,7 +140,7 @@ impl JitoBundleSimulationResult {
 
             let mut parsed = Self::parse_transaction_result(value)?;
             parsed.context = context.clone();
-            return Ok(Self { context, summary: None, transaction_results: vec![parsed] });
+            return Ok(Self { context, summary, transaction_results: vec![parsed] });
         }
 
         if result.get("err").is_some()
@@ -162,7 +162,7 @@ impl JitoBundleSimulationResult {
         match summary {
             Value::String(status) => !status.eq_ignore_ascii_case("succeeded"),
             Value::Object(map) => map.contains_key("failed") || map.contains_key("error"),
-            _ => false,
+            _ => true,
         }
     }
 
@@ -491,7 +491,7 @@ impl JitoMockClient {
 
                 JitoBundleSimulationTransactionResult {
                     err: None,
-                    logs: vec![],
+                    logs: vec!["Program 11111111111111111111111111111111 invoke [1]".to_string()],
                     context: json!({ "slot": 12345678, "apiVersion": "mock" }),
                     pre_execution_accounts: pre_accounts,
                     post_execution_accounts: post_accounts,

--- a/crates/lib/src/bundle/jito/client.rs
+++ b/crates/lib/src/bundle/jito/client.rs
@@ -6,12 +6,158 @@ use crate::{
     sanitize_error,
 };
 use reqwest::Client;
-use serde::{Deserialize, Serialize};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use serde_json::{json, Value};
 
 pub enum JitoBundleClient {
     Live(JitoClient),
     Mock(JitoMockClient),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct JitoBundleAccountConfig {
+    pub addresses: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub encoding: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+pub struct JitoBundleSimulationConfig {
+    #[serde(
+        rename = "preExecutionAccountsConfigs",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub pre_execution_accounts_configs: Option<Vec<Option<JitoBundleAccountConfig>>>,
+    #[serde(
+        rename = "postExecutionAccountsConfigs",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub post_execution_accounts_configs: Option<Vec<Option<JitoBundleAccountConfig>>>,
+    #[serde(rename = "transactionEncoding", default, skip_serializing_if = "Option::is_none")]
+    pub transaction_encoding: Option<String>,
+    #[serde(rename = "skipSigVerify", default, skip_serializing_if = "Option::is_none")]
+    pub skip_sig_verify: Option<bool>,
+    #[serde(rename = "replaceRecentBlockhash", default, skip_serializing_if = "Option::is_none")]
+    pub replace_recent_blockhash: Option<bool>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct JitoBundleSimulationTransactionResult {
+    pub err: Option<Value>,
+    #[serde(default)]
+    pub logs: Vec<String>,
+    pub context: Value,
+    pub pre_execution_accounts: Option<Vec<Value>>,
+    pub post_execution_accounts: Option<Vec<Value>>,
+    pub units_consumed: Option<u64>,
+    pub return_data: Option<Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct JitoBundleSimulationResult {
+    pub context: Value,
+    pub summary: Option<Value>,
+    pub transaction_results: Vec<JitoBundleSimulationTransactionResult>,
+}
+
+impl JitoBundleSimulationResult {
+    fn parse_transaction_result(
+        value: Value,
+    ) -> Result<JitoBundleSimulationTransactionResult, JitoError> {
+        let logs = value
+            .get("logs")
+            .and_then(Value::as_array)
+            .map(|entries| {
+                entries
+                    .iter()
+                    .filter_map(Value::as_str)
+                    .map(ToString::to_string)
+                    .collect::<Vec<String>>()
+            })
+            .unwrap_or_default();
+
+        let pre_execution_accounts = match value.get("preExecutionAccounts") {
+            None | Some(Value::Null) => None,
+            Some(Value::Array(accounts)) => Some(accounts.clone()),
+            _ => {
+                return Err(JitoError::ApiError(
+                    "Invalid preExecutionAccounts in simulateBundle response".to_string(),
+                ))
+            }
+        };
+
+        let post_execution_accounts = match value.get("postExecutionAccounts") {
+            None | Some(Value::Null) => None,
+            Some(Value::Array(accounts)) => Some(accounts.clone()),
+            _ => {
+                return Err(JitoError::ApiError(
+                    "Invalid postExecutionAccounts in simulateBundle response".to_string(),
+                ))
+            }
+        };
+
+        Ok(JitoBundleSimulationTransactionResult {
+            err: value.get("err").filter(|err| !err.is_null()).cloned(),
+            logs,
+            context: Value::Null,
+            pre_execution_accounts,
+            post_execution_accounts,
+            units_consumed: value.get("unitsConsumed").and_then(Value::as_u64),
+            return_data: value.get("returnData").filter(|data| !data.is_null()).cloned(),
+        })
+    }
+
+    fn from_rpc_result(result: Value) -> Result<Self, JitoError> {
+        let context = result.get("context").cloned().unwrap_or(Value::Null);
+
+        if let Some(value) = result.get("value").cloned() {
+            let summary = value.get("summary").cloned();
+
+            if let Some(transaction_results) =
+                value.get("transactionResults").and_then(Value::as_array)
+            {
+                let mut parsed_results = Vec::with_capacity(transaction_results.len());
+                for tx_result in transaction_results {
+                    let mut parsed = Self::parse_transaction_result(tx_result.clone())?;
+                    parsed.context = context.clone();
+                    parsed_results.push(parsed);
+                }
+                return Ok(Self { context, summary, transaction_results: parsed_results });
+            }
+
+            let mut parsed = Self::parse_transaction_result(value)?;
+            parsed.context = context.clone();
+            return Ok(Self { context, summary: None, transaction_results: vec![parsed] });
+        }
+
+        if result.get("err").is_some()
+            || result.get("logs").is_some()
+            || result.get("preExecutionAccounts").is_some()
+            || result.get("postExecutionAccounts").is_some()
+        {
+            let mut parsed = Self::parse_transaction_result(result)?;
+            parsed.context = context.clone();
+            return Ok(Self { context, summary: None, transaction_results: vec![parsed] });
+        }
+
+        Err(JitoError::ApiError(
+            "Invalid simulateBundle response: missing `value` or transaction fields".to_string(),
+        ))
+    }
+
+    fn summary_failed(summary: &Value) -> bool {
+        match summary {
+            Value::String(status) => !status.eq_ignore_ascii_case("succeeded"),
+            Value::Object(map) => map.contains_key("failed") || map.contains_key("error"),
+            _ => false,
+        }
+    }
+
+    fn first_failure(&self) -> Option<(usize, &JitoBundleSimulationTransactionResult)> {
+        self.transaction_results.iter().enumerate().find(|(_, tx_result)| tx_result.err.is_some())
+    }
 }
 
 impl JitoBundleClient {
@@ -40,6 +186,31 @@ impl JitoBundleClient {
         match self {
             Self::Live(client) => client.get_bundle_statuses(bundle_uuids).await,
             Self::Mock(client) => client.get_bundle_statuses(bundle_uuids).await,
+        }
+    }
+
+    pub async fn simulate_bundle(
+        &self,
+        encoded_transactions: &[String],
+    ) -> Result<JitoBundleSimulationResult, BundleError> {
+        match self {
+            Self::Live(client) => client.simulate_bundle(encoded_transactions).await,
+            Self::Mock(client) => client.simulate_bundle(encoded_transactions).await,
+        }
+    }
+
+    pub async fn simulate_bundle_with_config(
+        &self,
+        encoded_transactions: &[String],
+        simulation_config: JitoBundleSimulationConfig,
+    ) -> Result<JitoBundleSimulationResult, BundleError> {
+        match self {
+            Self::Live(client) => {
+                client.simulate_bundle_with_config(encoded_transactions, simulation_config).await
+            }
+            Self::Mock(client) => {
+                client.simulate_bundle_with_config(encoded_transactions, simulation_config).await
+            }
         }
     }
 }
@@ -73,9 +244,20 @@ impl JitoClient {
         Self { block_engine_url: config.block_engine_url.clone(), client: Client::new() }
     }
 
-    async fn send_request(&self, method: &str, params: Value) -> Result<Value, JitoError> {
-        let url = format!("{}/api/v1/bundles", self.block_engine_url);
+    fn block_engine_base_url(&self) -> &str {
+        self.block_engine_url.trim_end_matches('/')
+    }
 
+    fn bundle_api_url(&self) -> String {
+        format!("{}/api/v1/bundles", self.block_engine_base_url())
+    }
+
+    async fn send_request<T: DeserializeOwned>(
+        &self,
+        url: &str,
+        method: &str,
+        params: Value,
+    ) -> Result<T, JitoError> {
         let request = JsonRpcRequest {
             jsonrpc: "2.0".to_string(),
             id: 1,
@@ -85,7 +267,7 @@ impl JitoClient {
 
         let response = self
             .client
-            .post(&url)
+            .post(url)
             .header("Content-Type", "application/json")
             .json(&request)
             .send()
@@ -107,9 +289,13 @@ impl JitoClient {
             return Err(JitoError::ApiError(error.message));
         }
 
-        rpc_response
+        let result = rpc_response
             .result
-            .ok_or_else(|| JitoError::ApiError("Empty response from Jito".to_string()))
+            .ok_or_else(|| JitoError::ApiError("Empty response from Jito".to_string()))?;
+
+        serde_json::from_value(result).map_err(|e| {
+            JitoError::ApiError(format!("Failed to parse {method} result: {}", sanitize_error!(e)))
+        })
     }
 
     pub async fn send_bundle(
@@ -117,11 +303,8 @@ impl JitoClient {
         encoded_transactions: &[String],
     ) -> Result<String, BundleError> {
         let params = json!([encoded_transactions, {"encoding": "base64"}]);
-        let result = self.send_request("sendBundle", params).await?;
-
-        result.as_str().map(|s| s.to_string()).ok_or_else(|| {
-            JitoError::ApiError("Invalid bundle UUID in response".to_string()).into()
-        })
+        let url = self.bundle_api_url();
+        Ok(self.send_request(&url, "sendBundle", params).await?)
     }
 
     pub async fn get_bundle_statuses(
@@ -129,7 +312,69 @@ impl JitoClient {
         bundle_uuids: Vec<String>,
     ) -> Result<Value, BundleError> {
         let params = json!([bundle_uuids]);
-        Ok(self.send_request("getBundleStatuses", params).await?)
+        let url = self.bundle_api_url();
+        Ok(self.send_request(&url, "getBundleStatuses", params).await?)
+    }
+
+    pub async fn simulate_bundle(
+        &self,
+        encoded_transactions: &[String],
+    ) -> Result<JitoBundleSimulationResult, BundleError> {
+        self.simulate_bundle_with_optional_config(encoded_transactions, None).await
+    }
+
+    pub async fn simulate_bundle_with_config(
+        &self,
+        encoded_transactions: &[String],
+        simulation_config: JitoBundleSimulationConfig,
+    ) -> Result<JitoBundleSimulationResult, BundleError> {
+        self.simulate_bundle_with_optional_config(encoded_transactions, Some(simulation_config))
+            .await
+    }
+
+    async fn simulate_bundle_with_optional_config(
+        &self,
+        encoded_transactions: &[String],
+        simulation_config: Option<JitoBundleSimulationConfig>,
+    ) -> Result<JitoBundleSimulationResult, BundleError> {
+        let mut params = vec![json!({ "encodedTransactions": encoded_transactions })];
+        if let Some(config) = simulation_config {
+            params.push(serde_json::to_value(config).map_err(|e| {
+                JitoError::ApiError(format!(
+                    "Failed to serialize simulateBundle config: {}",
+                    sanitize_error!(e)
+                ))
+            })?);
+        }
+
+        let raw_result: Value = self
+            .send_request(self.block_engine_base_url(), "simulateBundle", Value::Array(params))
+            .await?;
+        let parsed_result = JitoBundleSimulationResult::from_rpc_result(raw_result)?;
+
+        if let Some((failed_idx, failed_result)) = parsed_result.first_failure() {
+            let mut message = format!(
+                "Bundle simulation failed at transaction index {}: {}",
+                failed_idx,
+                failed_result.err.as_ref().unwrap_or(&Value::Null)
+            );
+            if !failed_result.logs.is_empty() {
+                message.push_str(&format!(". Logs: {}", failed_result.logs.join(" | ")));
+            }
+            return Err(BundleError::ValidationError(message));
+        }
+
+        if parsed_result.transaction_results.is_empty() {
+            if let Some(summary) = &parsed_result.summary {
+                if JitoBundleSimulationResult::summary_failed(summary) {
+                    return Err(BundleError::ValidationError(format!(
+                        "Bundle simulation failed: {summary}",
+                    )));
+                }
+            }
+        }
+
+        Ok(parsed_result)
     }
 }
 
@@ -163,6 +408,87 @@ impl JitoMockClient {
             })
             .collect();
         Ok(json!({ "value": mock_statuses }))
+    }
+
+    pub async fn simulate_bundle(
+        &self,
+        _encoded_transactions: &[String],
+    ) -> Result<JitoBundleSimulationResult, BundleError> {
+        self.simulate_bundle_with_config(
+            _encoded_transactions,
+            JitoBundleSimulationConfig::default(),
+        )
+        .await
+    }
+
+    pub async fn simulate_bundle_with_config(
+        &self,
+        encoded_transactions: &[String],
+        simulation_config: JitoBundleSimulationConfig,
+    ) -> Result<JitoBundleSimulationResult, BundleError> {
+        let transaction_results = encoded_transactions
+            .iter()
+            .enumerate()
+            .map(|(idx, _)| {
+                let pre_accounts = simulation_config
+                    .pre_execution_accounts_configs
+                    .as_ref()
+                    .and_then(|configs| configs.get(idx))
+                    .and_then(|entry| entry.as_ref())
+                    .map(|entry| {
+                        entry
+                            .addresses
+                            .iter()
+                            .map(|_| {
+                                json!({
+                                    "lamports": 1_000_000_000_u64,
+                                    "owner": "11111111111111111111111111111111",
+                                    "data": ["", "base64"],
+                                    "executable": false,
+                                    "rentEpoch": 0_u64
+                                })
+                            })
+                            .collect::<Vec<Value>>()
+                    });
+
+                let post_accounts = simulation_config
+                    .post_execution_accounts_configs
+                    .as_ref()
+                    .and_then(|configs| configs.get(idx))
+                    .and_then(|entry| entry.as_ref())
+                    .map(|entry| {
+                        entry
+                            .addresses
+                            .iter()
+                            .map(|_| {
+                                json!({
+                                    "lamports": 1_000_000_000_u64,
+                                    "owner": "11111111111111111111111111111111",
+                                    "data": ["", "base64"],
+                                    "executable": false,
+                                    "rentEpoch": 0_u64
+                                })
+                            })
+                            .collect::<Vec<Value>>()
+                    });
+
+                JitoBundleSimulationTransactionResult {
+                    err: None,
+                    logs: vec![],
+                    context: json!({ "slot": 12345678, "apiVersion": "mock" }),
+                    pre_execution_accounts: pre_accounts,
+                    post_execution_accounts: post_accounts,
+                    units_consumed: Some(0),
+                    return_data: None,
+                }
+            })
+            .collect::<Vec<JitoBundleSimulationTransactionResult>>();
+
+        Ok(JitoBundleSimulationResult {
+            context: json!({ "slot": 12345678, "apiVersion": "mock" }),
+            summary: Some(json!("succeeded")),
+            transaction_results,
+        })
     }
 }
 
@@ -259,6 +585,165 @@ mod tests {
         let client = JitoClient::new(&config);
 
         let result = client.get_bundle_statuses(vec!["uuid1".to_string()]).await;
+        mock.assert();
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_simulate_bundle_success() {
+        let mut server = Server::new_async().await;
+
+        let mock = server
+            .mock("POST", "/")
+            .match_header("content-type", "application/json")
+            .match_body(Matcher::PartialJson(json!({
+                "method": "simulateBundle",
+                "params": [{ "encodedTransactions": ["encoded-tx"] }]
+            })))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"{"jsonrpc":"2.0","id":1,"result":{"context":{"slot":123,"apiVersion":"1.18.0"},"err":null,"logs":["ok"],"unitsConsumed":42}}"#,
+            )
+            .create();
+
+        let config = JitoConfig { block_engine_url: server.url() };
+        let client = JitoClient::new(&config);
+
+        let result = client.simulate_bundle(&["encoded-tx".to_string()]).await;
+        mock.assert();
+        assert!(result.is_ok());
+        let simulation = result.unwrap();
+        assert_eq!(simulation.transaction_results.len(), 1);
+        assert_eq!(simulation.transaction_results[0].logs, vec!["ok".to_string()]);
+        assert_eq!(simulation.transaction_results[0].units_consumed, Some(42));
+    }
+
+    #[tokio::test]
+    async fn test_simulate_bundle_success_with_transaction_results_shape() {
+        let mut server = Server::new_async().await;
+
+        let mock = server
+            .mock("POST", "/")
+            .match_header("content-type", "application/json")
+            .match_body(Matcher::PartialJson(json!({
+                "method": "simulateBundle",
+                "params": [{ "encodedTransactions": ["encoded-tx"] }]
+            })))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"{"jsonrpc":"2.0","id":1,"result":{"context":{"slot":456,"apiVersion":"2.3.0"},"value":{"summary":"succeeded","transactionResults":[{"err":null,"logs":["ok-v2"],"unitsConsumed":84}]}}}"#,
+            )
+            .create();
+
+        let config = JitoConfig { block_engine_url: server.url() };
+        let client = JitoClient::new(&config);
+
+        let result = client.simulate_bundle(&["encoded-tx".to_string()]).await;
+        mock.assert();
+        assert!(result.is_ok());
+        let simulation = result.unwrap();
+        assert_eq!(simulation.summary, Some(json!("succeeded")));
+        assert_eq!(simulation.transaction_results.len(), 1);
+        assert_eq!(simulation.transaction_results[0].logs, vec!["ok-v2".to_string()]);
+        assert_eq!(simulation.transaction_results[0].units_consumed, Some(84));
+    }
+
+    #[tokio::test]
+    async fn test_simulate_bundle_execution_failure() {
+        let mut server = Server::new_async().await;
+
+        let mock = server
+            .mock("POST", "/")
+            .match_body(Matcher::PartialJson(json!({"method": "simulateBundle"})))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"{"jsonrpc":"2.0","id":1,"result":{"context":{"slot":123},"err":"custom program error","logs":["failed log"]}}"#,
+            )
+            .create();
+
+        let config = JitoConfig { block_engine_url: server.url() };
+        let client = JitoClient::new(&config);
+
+        let result = client.simulate_bundle(&[create_mock_encoded_transaction()]).await;
+        mock.assert();
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("Bundle simulation failed"));
+        assert!(err.contains("failed log"));
+    }
+
+    #[tokio::test]
+    async fn test_simulate_bundle_summary_failure_without_transaction_results() {
+        let mut server = Server::new_async().await;
+
+        let mock = server
+            .mock("POST", "/")
+            .match_body(Matcher::PartialJson(json!({"method": "simulateBundle"})))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"{"jsonrpc":"2.0","id":1,"result":{"context":{"slot":123},"value":{"summary":{"failed":{"error":"custom error"}},"transactionResults":[]}}}"#,
+            )
+            .create();
+
+        let config = JitoConfig { block_engine_url: server.url() };
+        let client = JitoClient::new(&config);
+
+        let result = client.simulate_bundle(&[create_mock_encoded_transaction()]).await;
+        mock.assert();
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("Bundle simulation failed"));
+    }
+
+    #[tokio::test]
+    async fn test_simulate_bundle_with_config_includes_second_param() {
+        let mut server = Server::new_async().await;
+
+        let mock = server
+            .mock("POST", "/")
+            .match_header("content-type", "application/json")
+            .match_body(Matcher::PartialJson(json!({
+                "method": "simulateBundle",
+                "params": [
+                    {"encodedTransactions": ["encoded-tx"]},
+                    {
+                        "preExecutionAccountsConfigs": [{"addresses": ["11111111111111111111111111111111"]}],
+                        "postExecutionAccountsConfigs": [{"addresses": ["11111111111111111111111111111111"]}]
+                    }
+                ]
+            })))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"{"jsonrpc":"2.0","id":1,"result":{"context":{"slot":123},"err":null,"logs":[]}}"#,
+            )
+            .create();
+
+        let config = JitoConfig { block_engine_url: server.url() };
+        let client = JitoClient::new(&config);
+
+        let simulation_config = JitoBundleSimulationConfig {
+            pre_execution_accounts_configs: Some(vec![Some(JitoBundleAccountConfig {
+                addresses: vec!["11111111111111111111111111111111".to_string()],
+                encoding: None,
+            })]),
+            post_execution_accounts_configs: Some(vec![Some(JitoBundleAccountConfig {
+                addresses: vec!["11111111111111111111111111111111".to_string()],
+                encoding: None,
+            })]),
+            transaction_encoding: None,
+            skip_sig_verify: None,
+            replace_recent_blockhash: None,
+        };
+
+        let result = client
+            .simulate_bundle_with_config(&["encoded-tx".to_string()], simulation_config)
+            .await;
+
         mock.assert();
         assert!(result.is_ok());
     }
@@ -437,5 +922,20 @@ mod tests {
         let statuses = result.unwrap();
         assert!(statuses["value"].is_array());
         assert_eq!(statuses["value"][0]["status"], "Landed");
+    }
+
+    #[tokio::test]
+    async fn test_mock_client_simulate_bundle() {
+        let config = JitoConfig { block_engine_url: JITO_MOCK_BLOCK_ENGINE_URL.to_string() };
+        let client = JitoBundleClient::new(&config);
+
+        let result = client.simulate_bundle(&[create_mock_encoded_transaction()]).await;
+
+        assert!(result.is_ok());
+        let simulation = result.unwrap();
+        assert_eq!(simulation.summary, Some(json!("succeeded")));
+        assert_eq!(simulation.transaction_results.len(), 1);
+        assert!(simulation.transaction_results[0].err.is_none());
+        assert_eq!(simulation.context["apiVersion"], "mock");
     }
 }

--- a/crates/lib/src/bundle/jito/config.rs
+++ b/crates/lib/src/bundle/jito/config.rs
@@ -6,9 +6,14 @@ use crate::bundle::jito::constant::JITO_DEFAULT_BLOCK_ENGINE_URL;
 /// Jito-specific configuration
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct JitoConfig {
-    /// Jito block engine URL
+    /// Jito block engine URL for sendBundle / getBundleStatuses
     #[serde(default = "default_jito_block_engine_url")]
     pub block_engine_url: String,
+    /// RPC URL that supports the simulateBundle method (e.g. a Jito-Solana RPC node
+    /// or a provider like Helius / QuickNode with Jito add-on).
+    /// Required when bundle support is enabled.
+    #[serde(default)]
+    pub simulate_bundle_url: Option<String>,
 }
 
 fn default_jito_block_engine_url() -> String {
@@ -17,7 +22,10 @@ fn default_jito_block_engine_url() -> String {
 
 impl Default for JitoConfig {
     fn default() -> Self {
-        Self { block_engine_url: JITO_DEFAULT_BLOCK_ENGINE_URL.to_string() }
+        Self {
+            block_engine_url: JITO_DEFAULT_BLOCK_ENGINE_URL.to_string(),
+            simulate_bundle_url: None,
+        }
     }
 }
 

--- a/crates/lib/src/bundle/jito/mod.rs
+++ b/crates/lib/src/bundle/jito/mod.rs
@@ -4,6 +4,9 @@ mod error;
 
 pub mod constant;
 
-pub use client::{JitoBundleClient, JitoClient, JitoMockClient};
+pub use client::{
+    JitoBundleAccountConfig, JitoBundleClient, JitoBundleSimulationConfig,
+    JitoBundleSimulationResult, JitoBundleSimulationTransactionResult, JitoClient, JitoMockClient,
+};
 pub use config::JitoConfig;
 pub use error::JitoError;

--- a/crates/lib/src/config.rs
+++ b/crates/lib/src/config.rs
@@ -962,9 +962,11 @@ rate_limit = 1
 
     #[test]
     fn test_token2022_extension_blocking_without_initialize_uses_raw_extension_names() {
-        let mut token_2022 = Token2022Config::default();
-        token_2022.blocked_mint_extensions = vec!["transfer_fee_config".to_string()];
-        token_2022.blocked_account_extensions = vec!["memo_transfer".to_string()];
+        let token_2022 = Token2022Config {
+            blocked_mint_extensions: vec!["transfer_fee_config".to_string()],
+            blocked_account_extensions: vec!["memo_transfer".to_string()],
+            ..Token2022Config::default()
+        };
 
         assert!(token_2022.is_mint_extension_blocked(ExtensionType::TransferFeeConfig));
         assert!(token_2022.is_account_extension_blocked(ExtensionType::MemoTransfer));

--- a/crates/lib/src/config.rs
+++ b/crates/lib/src/config.rs
@@ -1067,7 +1067,7 @@ allow_create = true
         assert_eq!(config.kora.cache.url, Some("http://localhost:6379".to_string()));
         assert!(config.kora.cache.enabled);
 
-        assert_eq!(config.kora.enabled_methods.transfer_transaction, true);
-        assert_eq!(config.kora.enabled_methods.sign_transaction, false);
+        assert!(config.kora.enabled_methods.transfer_transaction);
+        assert!(!config.kora.enabled_methods.sign_transaction);
     }
 }

--- a/crates/lib/src/rpc_server/method/estimate_bundle_fee.rs
+++ b/crates/lib/src/rpc_server/method/estimate_bundle_fee.rs
@@ -124,12 +124,19 @@ mod tests {
     use super::*;
     use crate::{
         config::TransactionPluginType,
+        fee::price::{PriceConfig, PriceModel},
         tests::{
             common::{setup_or_get_test_signer, setup_or_get_test_usage_limiter, RpcMockBuilder},
             config_mock::{mock_state::setup_config_mock, ConfigMockBuilder},
             transaction_mock::create_mock_encoded_transaction,
         },
+        transaction::TransactionUtil,
     };
+    use mockito::{Matcher, Server};
+    use serde_json::json;
+    use solana_message::{Message, VersionedMessage};
+    use solana_sdk::pubkey::Pubkey;
+    use solana_system_interface::instruction::transfer;
 
     #[tokio::test]
     async fn test_estimate_bundle_fee_empty_bundle() {
@@ -342,5 +349,60 @@ mod tests {
 
         let result = estimate_bundle_fee(&rpc_client, request).await;
         assert!(result.is_ok(), "estimateBundleFee should skip transaction plugins");
+    }
+
+    #[tokio::test]
+    async fn test_estimate_bundle_fee_rejects_sequential_outflow_violation() {
+        let mut server = Server::new_async().await;
+        let simulate_mock = server
+            .mock("POST", "/")
+            .match_header("content-type", "application/json")
+            .match_body(Matcher::PartialJson(json!({"method": "simulateBundle"})))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"{"jsonrpc":"2.0","id":1,"result":{"context":{"slot":123},"value":{"summary":"succeeded","transactionResults":[{"err":null,"logs":["Program 11111111111111111111111111111111 invoke [1]"],"preExecutionAccounts":[{"lamports":2500000,"owner":"11111111111111111111111111111111","data":["","base64"],"executable":false,"rentEpoch":0}],"postExecutionAccounts":[{"lamports":1000000,"owner":"11111111111111111111111111111111","data":["","base64"],"executable":false,"rentEpoch":0}]}]}}}"#,
+            )
+            .create();
+
+        let mut config = ConfigMockBuilder::new()
+            .with_bundle_enabled(true)
+            .with_usage_limit_enabled(false)
+            .with_max_allowed_lamports(1_000_000)
+            .build();
+        config.validation.price = PriceConfig { model: PriceModel::Free };
+        config.kora.bundle.jito.block_engine_url = server.url();
+        let _m = setup_config_mock(config);
+        let _ = setup_or_get_test_usage_limiter().await;
+
+        let signer_pubkey = setup_or_get_test_signer();
+        let rpc_client = Arc::new(
+            RpcMockBuilder::new()
+                .with_fee_estimate(5000)
+                .with_blockhash()
+                .with_simulation()
+                .build(),
+        );
+
+        let ix = transfer(&Pubkey::new_unique(), &Pubkey::new_unique(), 1_000_000_000);
+        let message = VersionedMessage::Legacy(Message::new(&[ix], Some(&signer_pubkey)));
+        let transaction = TransactionUtil::new_unsigned_versioned_transaction(message);
+        let encoded_tx = TransactionUtil::encode_versioned_transaction(&transaction).unwrap();
+
+        let request = EstimateBundleFeeRequest {
+            transactions: vec![encoded_tx],
+            fee_token: None,
+            signer_key: Some(signer_pubkey.to_string()),
+            sig_verify: false,
+            sign_only_indices: None,
+        };
+
+        let result = estimate_bundle_fee(&rpc_client, request).await;
+
+        simulate_mock.assert();
+        assert!(result.is_err(), "Expected sequential outflow validation error");
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("Total transfer amount"), "Unexpected error: {err}");
+        assert!(err.contains("exceeds maximum allowed"), "Unexpected error: {err}");
     }
 }

--- a/crates/lib/src/rpc_server/method/estimate_bundle_fee.rs
+++ b/crates/lib/src/rpc_server/method/estimate_bundle_fee.rs
@@ -98,7 +98,7 @@ pub async fn estimate_bundle_fee(
         &transactions,
         &signed_indices,
         &fee_payer,
-        !sig_verify,
+        true,
     )
     .await?;
 
@@ -372,6 +372,7 @@ mod tests {
             .build();
         config.validation.price = PriceConfig { model: PriceModel::Free };
         config.kora.bundle.jito.block_engine_url = server.url();
+        config.kora.bundle.jito.simulate_bundle_url = Some(server.url());
         let _m = setup_config_mock(config);
         let _ = setup_or_get_test_usage_limiter().await;
 

--- a/crates/lib/src/rpc_server/method/estimate_bundle_fee.rs
+++ b/crates/lib/src/rpc_server/method/estimate_bundle_fee.rs
@@ -49,6 +49,13 @@ pub async fn estimate_bundle_fee(
     rpc_client: &Arc<RpcClient>,
     request: EstimateBundleFeeRequest,
 ) -> Result<EstimateBundleFeeResponse, KoraError> {
+    let EstimateBundleFeeRequest {
+        transactions,
+        fee_token,
+        signer_key,
+        sig_verify,
+        sign_only_indices,
+    } = request;
     let config = &get_config()?;
 
     if !config.kora.bundle.enabled {
@@ -56,20 +63,17 @@ pub async fn estimate_bundle_fee(
     }
 
     // Validate bundle size on ALL transactions first
-    BundleValidator::validate_jito_bundle_size(&request.transactions)?;
+    BundleValidator::validate_jito_bundle_size(&transactions)?;
 
     // Extract only the transactions we need to process
     let (transactions_to_process, _index_to_position) =
-        BundleProcessor::extract_transactions_to_process(
-            &request.transactions,
-            request.sign_only_indices,
-        )?;
+        BundleProcessor::extract_transactions_to_process(&transactions, sign_only_indices.clone())?;
 
-    let signer = get_request_signer_with_signer_key(request.signer_key.as_deref())?;
+    let signer = get_request_signer_with_signer_key(signer_key.as_deref())?;
     let fee_payer = signer.pubkey();
     let payment_destination = config.kora.get_payment_address(&fee_payer)?;
 
-    let sig_verify = request.sig_verify || config.kora.force_sig_verify;
+    let sig_verify = sig_verify || config.kora.force_sig_verify;
     let processor = BundleProcessor::process_bundle(
         &transactions_to_process,
         fee_payer,
@@ -84,10 +88,24 @@ pub async fn estimate_bundle_fee(
 
     let fee_in_lamports = processor.total_required_lamports;
 
+    let signed_indices = BundleValidator::signed_indices_for_bundle(
+        transactions.len(),
+        sign_only_indices.as_deref(),
+    );
+    BundleValidator::simulate_and_validate_sequential_bundle(
+        rpc_client,
+        config,
+        &transactions,
+        &signed_indices,
+        &fee_payer,
+        !sig_verify,
+    )
+    .await?;
+
     // Calculate fee in token if requested
     let fee_in_token = FeeConfigUtil::calculate_fee_in_token(
         fee_in_lamports,
-        request.fee_token.as_deref(),
+        fee_token.as_deref(),
         rpc_client,
         config,
     )

--- a/crates/lib/src/rpc_server/method/sign_and_send_bundle.rs
+++ b/crates/lib/src/rpc_server/method/sign_and_send_bundle.rs
@@ -52,6 +52,13 @@ pub async fn sign_and_send_bundle(
     rpc_client: &Arc<RpcClient>,
     request: SignAndSendBundleRequest,
 ) -> Result<SignAndSendBundleResponse, KoraError> {
+    let SignAndSendBundleRequest {
+        transactions,
+        signer_key,
+        sig_verify,
+        user_id,
+        sign_only_indices,
+    } = request;
     let config = &get_config()?;
 
     if !config.kora.bundle.enabled {
@@ -59,20 +66,17 @@ pub async fn sign_and_send_bundle(
     }
 
     // Validate bundle size on ALL transactions first
-    BundleValidator::validate_jito_bundle_size(&request.transactions)?;
+    BundleValidator::validate_jito_bundle_size(&transactions)?;
 
     // Extract only the transactions we need to process
     let (transactions_to_process, index_to_position) =
-        BundleProcessor::extract_transactions_to_process(
-            &request.transactions,
-            request.sign_only_indices,
-        )?;
+        BundleProcessor::extract_transactions_to_process(&transactions, sign_only_indices.clone())?;
 
-    let signer = get_request_signer_with_signer_key(request.signer_key.as_deref())?;
+    let signer = get_request_signer_with_signer_key(signer_key.as_deref())?;
     let fee_payer = signer.pubkey();
     let payment_destination = config.kora.get_payment_address(&fee_payer)?;
 
-    let sig_verify = request.sig_verify || config.kora.force_sig_verify;
+    let sig_verify = sig_verify || config.kora.force_sig_verify;
     let processor = BundleProcessor::process_bundle(
         &transactions_to_process,
         fee_payer,
@@ -81,7 +85,7 @@ pub async fn sign_and_send_bundle(
         rpc_client,
         sig_verify,
         Some(PluginExecutionContext::SignAndSendBundle),
-        BundleProcessingMode::CheckUsage(request.user_id.as_deref()),
+        BundleProcessingMode::CheckUsage(user_id.as_deref()),
     )
     .await?;
 
@@ -95,10 +99,24 @@ pub async fn sign_and_send_bundle(
 
     // Merge signed transactions back into original positions
     let signed_transactions = BundleProcessor::merge_signed_transactions(
-        &request.transactions,
+        &transactions,
         encoded_signed,
         &index_to_position,
     );
+
+    let signed_indices = BundleValidator::signed_indices_for_bundle(
+        transactions.len(),
+        sign_only_indices.as_deref(),
+    );
+    BundleValidator::simulate_and_validate_sequential_bundle(
+        rpc_client,
+        config,
+        &signed_transactions,
+        &signed_indices,
+        &fee_payer,
+        !sig_verify,
+    )
+    .await?;
 
     // Send the full merged bundle to Jito for atomic execution.
     let jito_client = JitoBundleClient::new(&config.kora.bundle.jito);
@@ -225,6 +243,16 @@ mod tests {
     #[tokio::test]
     async fn test_sign_and_send_bundle_sends_full_bundle_when_sign_only_indices_set() {
         let mut server = Server::new_async().await;
+        let simulate_mock = server
+            .mock("POST", "/")
+            .match_header("content-type", "application/json")
+            .match_body(Matcher::PartialJson(json!({"method": "simulateBundle"})))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"{"jsonrpc":"2.0","id":1,"result":{"context":{"slot":123},"value":{"summary":"succeeded","transactionResults":[{"err":null,"logs":[]},{"err":null,"logs":[],"preExecutionAccounts":[{"lamports":1000000000,"owner":"11111111111111111111111111111111","data":["","base64"],"executable":false,"rentEpoch":0}],"postExecutionAccounts":[{"lamports":1000000000,"owner":"11111111111111111111111111111111","data":["","base64"],"executable":false,"rentEpoch":0}]},{"err":null,"logs":[]}]}}}"#,
+            )
+            .create();
         let mock = server
             .mock("POST", "/api/v1/bundles")
             .match_header("content-type", "application/json")
@@ -243,7 +271,9 @@ mod tests {
         let mut config = ConfigMockBuilder::new()
             .with_bundle_enabled(true)
             .with_usage_limit_enabled(false)
+            .with_max_allowed_lamports(1_000_000)
             .build();
+        assert_eq!(config.validation.max_allowed_lamports, 1_000_000);
         config.validation.price = PriceConfig { model: PriceModel::Free };
         config.kora.bundle.jito.block_engine_url = server.url();
         let _m = setup_config_mock(config);
@@ -258,14 +288,26 @@ mod tests {
                 .build(),
         );
 
-        let transactions: Vec<String> = (0..3)
-            .map(|_| {
-                let ix = transfer(&Pubkey::new_unique(), &Pubkey::new_unique(), 1000000000);
-                let message = VersionedMessage::Legacy(Message::new(&[ix], Some(&signer_pubkey)));
-                let transaction = TransactionUtil::new_unsigned_versioned_transaction(message);
-                TransactionUtil::encode_versioned_transaction(&transaction).unwrap()
-            })
-            .collect();
+        // Build non-signed transactions (indices 0 and 2) with unique accounts
+        // that don't overlap with the signed transaction (index 1).
+        let make_non_signed_tx = || {
+            let payer = Pubkey::new_unique();
+            let ix = transfer(&payer, &Pubkey::new_unique(), 1000000000);
+            let message = VersionedMessage::Legacy(Message::new(&[ix], Some(&payer)));
+            let transaction = TransactionUtil::new_unsigned_versioned_transaction(message);
+            TransactionUtil::encode_versioned_transaction(&transaction).unwrap()
+        };
+
+        // Signed transaction (index 1) uses the signer_pubkey as fee payer
+        let signed_ix = transfer(&Pubkey::new_unique(), &Pubkey::new_unique(), 1000000000);
+        let signed_message =
+            VersionedMessage::Legacy(Message::new(&[signed_ix], Some(&signer_pubkey)));
+        let signed_transaction =
+            TransactionUtil::new_unsigned_versioned_transaction(signed_message);
+        let signed_encoded =
+            TransactionUtil::encode_versioned_transaction(&signed_transaction).unwrap();
+
+        let transactions = vec![make_non_signed_tx(), signed_encoded, make_non_signed_tx()];
 
         let request = SignAndSendBundleRequest {
             transactions,
@@ -282,10 +324,78 @@ mod tests {
             "Expected full bundle to be sent to Jito, got error: {:?}",
             result.as_ref().err()
         );
+        simulate_mock.assert();
         mock.assert();
         let response = result.unwrap();
         assert_eq!(response.bundle_uuid, "bundle-uuid-full-3");
         assert_eq!(response.signed_transactions.len(), 3);
+    }
+
+    #[tokio::test]
+    async fn test_sign_and_send_bundle_rejects_sequential_outflow_violation() {
+        let mut server = Server::new_async().await;
+        let simulate_mock = server
+            .mock("POST", "/")
+            .match_header("content-type", "application/json")
+            .match_body(Matcher::PartialJson(json!({"method": "simulateBundle"})))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"{"jsonrpc":"2.0","id":1,"result":{"context":{"slot":123},"value":{"summary":"succeeded","transactionResults":[{"err":null,"logs":[]},{"err":null,"logs":["Program 11111111111111111111111111111111 invoke [1]"],"preExecutionAccounts":[{"lamports":2500000,"owner":"11111111111111111111111111111111","data":["","base64"],"executable":false,"rentEpoch":0}],"postExecutionAccounts":[{"lamports":1000000,"owner":"11111111111111111111111111111111","data":["","base64"],"executable":false,"rentEpoch":0}]},{"err":null,"logs":[]}]}}}"#,
+            )
+            .create();
+
+        let mut config = ConfigMockBuilder::new()
+            .with_bundle_enabled(true)
+            .with_usage_limit_enabled(false)
+            .with_max_allowed_lamports(1_000_000)
+            .build();
+        config.validation.price = PriceConfig { model: PriceModel::Free };
+        config.kora.bundle.jito.block_engine_url = server.url();
+        let _m = setup_config_mock(config);
+        let _ = setup_or_get_test_usage_limiter().await;
+
+        let signer_pubkey = setup_or_get_test_signer();
+        let rpc_client = Arc::new(
+            RpcMockBuilder::new()
+                .with_fee_estimate(5000)
+                .with_blockhash()
+                .with_simulation()
+                .build(),
+        );
+
+        let make_non_signed_tx = || {
+            let payer = Pubkey::new_unique();
+            let ix = transfer(&payer, &Pubkey::new_unique(), 1_000_000_000);
+            let message = VersionedMessage::Legacy(Message::new(&[ix], Some(&payer)));
+            let transaction = TransactionUtil::new_unsigned_versioned_transaction(message);
+            TransactionUtil::encode_versioned_transaction(&transaction).unwrap()
+        };
+
+        let signed_ix = transfer(&Pubkey::new_unique(), &Pubkey::new_unique(), 1_000_000_000);
+        let signed_message =
+            VersionedMessage::Legacy(Message::new(&[signed_ix], Some(&signer_pubkey)));
+        let signed_transaction =
+            TransactionUtil::new_unsigned_versioned_transaction(signed_message);
+        let signed_encoded =
+            TransactionUtil::encode_versioned_transaction(&signed_transaction).unwrap();
+
+        let transactions = vec![make_non_signed_tx(), signed_encoded, make_non_signed_tx()];
+        let request = SignAndSendBundleRequest {
+            transactions,
+            signer_key: Some(signer_pubkey.to_string()),
+            sig_verify: true,
+            user_id: None,
+            sign_only_indices: Some(vec![1]),
+        };
+
+        let result = sign_and_send_bundle(&rpc_client, request).await;
+
+        simulate_mock.assert();
+        assert!(result.is_err(), "Expected sequential outflow validation error");
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("Total transfer amount"), "Unexpected error: {err}");
+        assert!(err.contains("exceeds maximum allowed"), "Unexpected error: {err}");
     }
 
     #[tokio::test]

--- a/crates/lib/src/rpc_server/method/sign_and_send_bundle.rs
+++ b/crates/lib/src/rpc_server/method/sign_and_send_bundle.rs
@@ -276,6 +276,7 @@ mod tests {
         assert_eq!(config.validation.max_allowed_lamports, 1_000_000);
         config.validation.price = PriceConfig { model: PriceModel::Free };
         config.kora.bundle.jito.block_engine_url = server.url();
+        config.kora.bundle.jito.simulate_bundle_url = Some(server.url());
         let _m = setup_config_mock(config);
         let _ = setup_or_get_test_usage_limiter().await;
 
@@ -352,6 +353,7 @@ mod tests {
             .build();
         config.validation.price = PriceConfig { model: PriceModel::Free };
         config.kora.bundle.jito.block_engine_url = server.url();
+        config.kora.bundle.jito.simulate_bundle_url = Some(server.url());
         let _m = setup_config_mock(config);
         let _ = setup_or_get_test_usage_limiter().await;
 

--- a/crates/lib/src/rpc_server/method/sign_and_send_bundle.rs
+++ b/crates/lib/src/rpc_server/method/sign_and_send_bundle.rs
@@ -250,7 +250,7 @@ mod tests {
             .with_status(200)
             .with_header("content-type", "application/json")
             .with_body(
-                r#"{"jsonrpc":"2.0","id":1,"result":{"context":{"slot":123},"value":{"summary":"succeeded","transactionResults":[{"err":null,"logs":[]},{"err":null,"logs":[],"preExecutionAccounts":[{"lamports":1000000000,"owner":"11111111111111111111111111111111","data":["","base64"],"executable":false,"rentEpoch":0}],"postExecutionAccounts":[{"lamports":1000000000,"owner":"11111111111111111111111111111111","data":["","base64"],"executable":false,"rentEpoch":0}]},{"err":null,"logs":[]}]}}}"#,
+                r#"{"jsonrpc":"2.0","id":1,"result":{"context":{"slot":123},"value":{"summary":"succeeded","transactionResults":[{"err":null,"logs":["Program 11111111111111111111111111111111 invoke [1]"]},{"err":null,"logs":["Program 11111111111111111111111111111111 invoke [1]"],"preExecutionAccounts":[{"lamports":1000000000,"owner":"11111111111111111111111111111111","data":["","base64"],"executable":false,"rentEpoch":0}],"postExecutionAccounts":[{"lamports":1000000000,"owner":"11111111111111111111111111111111","data":["","base64"],"executable":false,"rentEpoch":0}]},{"err":null,"logs":["Program 11111111111111111111111111111111 invoke [1]"]}]}}}"#,
             )
             .create();
         let mock = server
@@ -342,7 +342,7 @@ mod tests {
             .with_status(200)
             .with_header("content-type", "application/json")
             .with_body(
-                r#"{"jsonrpc":"2.0","id":1,"result":{"context":{"slot":123},"value":{"summary":"succeeded","transactionResults":[{"err":null,"logs":[]},{"err":null,"logs":["Program 11111111111111111111111111111111 invoke [1]"],"preExecutionAccounts":[{"lamports":2500000,"owner":"11111111111111111111111111111111","data":["","base64"],"executable":false,"rentEpoch":0}],"postExecutionAccounts":[{"lamports":1000000,"owner":"11111111111111111111111111111111","data":["","base64"],"executable":false,"rentEpoch":0}]},{"err":null,"logs":[]}]}}}"#,
+                r#"{"jsonrpc":"2.0","id":1,"result":{"context":{"slot":123},"value":{"summary":"succeeded","transactionResults":[{"err":null,"logs":["Program 11111111111111111111111111111111 invoke [1]"]},{"err":null,"logs":["Program 11111111111111111111111111111111 invoke [1]"],"preExecutionAccounts":[{"lamports":2500000,"owner":"11111111111111111111111111111111","data":["","base64"],"executable":false,"rentEpoch":0}],"postExecutionAccounts":[{"lamports":1000000,"owner":"11111111111111111111111111111111","data":["","base64"],"executable":false,"rentEpoch":0}]},{"err":null,"logs":["Program 11111111111111111111111111111111 invoke [1]"]}]}}}"#,
             )
             .create();
 

--- a/crates/lib/src/rpc_server/method/sign_bundle.rs
+++ b/crates/lib/src/rpc_server/method/sign_bundle.rs
@@ -387,6 +387,7 @@ mod tests {
             .build();
         config.validation.price = PriceConfig { model: PriceModel::Free };
         config.kora.bundle.jito.block_engine_url = server.url();
+        config.kora.bundle.jito.simulate_bundle_url = Some(server.url());
         let _m = setup_config_mock(config);
         let _ = setup_or_get_test_usage_limiter().await;
 

--- a/crates/lib/src/rpc_server/method/sign_bundle.rs
+++ b/crates/lib/src/rpc_server/method/sign_bundle.rs
@@ -50,6 +50,8 @@ pub async fn sign_bundle(
     rpc_client: &Arc<RpcClient>,
     request: SignBundleRequest,
 ) -> Result<SignBundleResponse, KoraError> {
+    let SignBundleRequest { transactions, signer_key, sig_verify, user_id, sign_only_indices } =
+        request;
     let config = &get_config()?;
 
     if !config.kora.bundle.enabled {
@@ -57,20 +59,17 @@ pub async fn sign_bundle(
     }
 
     // Validate bundle size on ALL transactions first
-    BundleValidator::validate_jito_bundle_size(&request.transactions)?;
+    BundleValidator::validate_jito_bundle_size(&transactions)?;
 
     // Extract only the transactions we need to process
     let (transactions_to_process, index_to_position) =
-        BundleProcessor::extract_transactions_to_process(
-            &request.transactions,
-            request.sign_only_indices,
-        )?;
+        BundleProcessor::extract_transactions_to_process(&transactions, sign_only_indices.clone())?;
 
-    let signer = get_request_signer_with_signer_key(request.signer_key.as_deref())?;
+    let signer = get_request_signer_with_signer_key(signer_key.as_deref())?;
     let fee_payer = signer.pubkey();
     let payment_destination = config.kora.get_payment_address(&fee_payer)?;
 
-    let sig_verify = request.sig_verify || config.kora.force_sig_verify;
+    let sig_verify = sig_verify || config.kora.force_sig_verify;
     let processor = BundleProcessor::process_bundle(
         &transactions_to_process,
         fee_payer,
@@ -79,7 +78,7 @@ pub async fn sign_bundle(
         rpc_client,
         sig_verify,
         Some(PluginExecutionContext::SignBundle),
-        BundleProcessingMode::CheckUsage(request.user_id.as_deref()),
+        BundleProcessingMode::CheckUsage(user_id.as_deref()),
     )
     .await?;
 
@@ -94,10 +93,24 @@ pub async fn sign_bundle(
 
     // Merge signed transactions back into original positions
     let signed_transactions = BundleProcessor::merge_signed_transactions(
-        &request.transactions,
+        &transactions,
         encoded_signed,
         &index_to_position,
     );
+
+    let signed_indices = BundleValidator::signed_indices_for_bundle(
+        transactions.len(),
+        sign_only_indices.as_deref(),
+    );
+    BundleValidator::simulate_and_validate_sequential_bundle(
+        rpc_client,
+        config,
+        &signed_transactions,
+        &signed_indices,
+        &fee_payer,
+        !sig_verify,
+    )
+    .await?;
 
     Ok(SignBundleResponse { signed_transactions, signer_pubkey: fee_payer.to_string() })
 }

--- a/crates/lib/src/rpc_server/method/sign_bundle.rs
+++ b/crates/lib/src/rpc_server/method/sign_bundle.rs
@@ -122,10 +122,14 @@ mod tests {
         fee::price::{PriceConfig, PriceModel},
         tests::{
             common::{setup_or_get_test_signer, setup_or_get_test_usage_limiter, RpcMockBuilder},
-            config_mock::{ConfigMockBuilder, ValidationConfigBuilder},
+            config_mock::{
+                mock_state::setup_config_mock, ConfigMockBuilder, ValidationConfigBuilder,
+            },
         },
         transaction::TransactionUtil,
     };
+    use mockito::{Matcher, Server};
+    use serde_json::json;
     use solana_message::{Message, VersionedMessage};
     use solana_sdk::pubkey::Pubkey;
     use solana_system_interface::instruction::transfer;
@@ -360,5 +364,72 @@ mod tests {
         assert_eq!(request.signer_key, Some("11111111111111111111111111111111".to_string()));
         assert!(!request.sig_verify);
         assert_eq!(request.sign_only_indices, Some(vec![0, 2]));
+    }
+
+    #[tokio::test]
+    async fn test_sign_bundle_rejects_sequential_outflow_violation() {
+        let mut server = Server::new_async().await;
+        let simulate_mock = server
+            .mock("POST", "/")
+            .match_header("content-type", "application/json")
+            .match_body(Matcher::PartialJson(json!({"method": "simulateBundle"})))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"{"jsonrpc":"2.0","id":1,"result":{"context":{"slot":123},"value":{"summary":"succeeded","transactionResults":[{"err":null,"logs":[]},{"err":null,"logs":["Program 11111111111111111111111111111111 invoke [1]"],"preExecutionAccounts":[{"lamports":2500000,"owner":"11111111111111111111111111111111","data":["","base64"],"executable":false,"rentEpoch":0}],"postExecutionAccounts":[{"lamports":1000000,"owner":"11111111111111111111111111111111","data":["","base64"],"executable":false,"rentEpoch":0}]},{"err":null,"logs":[]}]}}}"#,
+            )
+            .create();
+
+        let mut config = ConfigMockBuilder::new()
+            .with_bundle_enabled(true)
+            .with_usage_limit_enabled(false)
+            .with_max_allowed_lamports(1_000_000)
+            .build();
+        config.validation.price = PriceConfig { model: PriceModel::Free };
+        config.kora.bundle.jito.block_engine_url = server.url();
+        let _m = setup_config_mock(config);
+        let _ = setup_or_get_test_usage_limiter().await;
+
+        let signer_pubkey = setup_or_get_test_signer();
+        let rpc_client = Arc::new(
+            RpcMockBuilder::new()
+                .with_fee_estimate(5000)
+                .with_blockhash()
+                .with_simulation()
+                .build(),
+        );
+
+        let make_non_signed_tx = || {
+            let payer = Pubkey::new_unique();
+            let ix = transfer(&payer, &Pubkey::new_unique(), 1_000_000_000);
+            let message = VersionedMessage::Legacy(Message::new(&[ix], Some(&payer)));
+            let transaction = TransactionUtil::new_unsigned_versioned_transaction(message);
+            TransactionUtil::encode_versioned_transaction(&transaction).unwrap()
+        };
+
+        let signed_ix = transfer(&Pubkey::new_unique(), &Pubkey::new_unique(), 1_000_000_000);
+        let signed_message =
+            VersionedMessage::Legacy(Message::new(&[signed_ix], Some(&signer_pubkey)));
+        let signed_transaction =
+            TransactionUtil::new_unsigned_versioned_transaction(signed_message);
+        let signed_encoded =
+            TransactionUtil::encode_versioned_transaction(&signed_transaction).unwrap();
+
+        let transactions = vec![make_non_signed_tx(), signed_encoded, make_non_signed_tx()];
+        let request = SignBundleRequest {
+            transactions,
+            signer_key: Some(signer_pubkey.to_string()),
+            sig_verify: true,
+            user_id: None,
+            sign_only_indices: Some(vec![1]),
+        };
+
+        let result = sign_bundle(&rpc_client, request).await;
+
+        simulate_mock.assert();
+        assert!(result.is_err(), "Expected sequential outflow validation error");
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("Total transfer amount"), "Unexpected error: {err}");
+        assert!(err.contains("exceeds maximum allowed"), "Unexpected error: {err}");
     }
 }

--- a/crates/lib/src/rpc_server/method/sign_bundle.rs
+++ b/crates/lib/src/rpc_server/method/sign_bundle.rs
@@ -376,7 +376,7 @@ mod tests {
             .with_status(200)
             .with_header("content-type", "application/json")
             .with_body(
-                r#"{"jsonrpc":"2.0","id":1,"result":{"context":{"slot":123},"value":{"summary":"succeeded","transactionResults":[{"err":null,"logs":[]},{"err":null,"logs":["Program 11111111111111111111111111111111 invoke [1]"],"preExecutionAccounts":[{"lamports":2500000,"owner":"11111111111111111111111111111111","data":["","base64"],"executable":false,"rentEpoch":0}],"postExecutionAccounts":[{"lamports":1000000,"owner":"11111111111111111111111111111111","data":["","base64"],"executable":false,"rentEpoch":0}]},{"err":null,"logs":[]}]}}}"#,
+                r#"{"jsonrpc":"2.0","id":1,"result":{"context":{"slot":123},"value":{"summary":"succeeded","transactionResults":[{"err":null,"logs":["Program 11111111111111111111111111111111 invoke [1]"]},{"err":null,"logs":["Program 11111111111111111111111111111111 invoke [1]"],"preExecutionAccounts":[{"lamports":2500000,"owner":"11111111111111111111111111111111","data":["","base64"],"executable":false,"rentEpoch":0}],"postExecutionAccounts":[{"lamports":1000000,"owner":"11111111111111111111111111111111","data":["","base64"],"executable":false,"rentEpoch":0}]},{"err":null,"logs":["Program 11111111111111111111111111111111 invoke [1]"]}]}}}"#,
             )
             .create();
 

--- a/crates/lib/src/tests/config_mock.rs
+++ b/crates/lib/src/tests/config_mock.rs
@@ -1,4 +1,5 @@
 use crate::{
+    bundle::{constant::JITO_MOCK_BLOCK_ENGINE_URL, JitoConfig},
     config::{
         AuthConfig, BundleConfig, CacheConfig, Config, EnabledMethods,
         FeePayerBalanceMetricsConfig, FeePayerPolicy, KoraConfig, LighthouseConfig, MetricsConfig,
@@ -110,7 +111,12 @@ impl ConfigMockBuilder {
                     },
                     usage_limit: UsageLimitConfig::default(),
                     plugins: PluginsConfig::default(),
-                    bundle: BundleConfig::default(),
+                    bundle: BundleConfig {
+                        enabled: false,
+                        jito: JitoConfig {
+                            block_engine_url: JITO_MOCK_BLOCK_ENGINE_URL.to_string(),
+                        },
+                    },
                     lighthouse: LighthouseConfig::default(),
                     force_sig_verify: false,
                     sign_timeout_seconds: 10,
@@ -237,6 +243,16 @@ impl ConfigMockBuilder {
 
     pub fn with_bundle_enabled(mut self, enabled: bool) -> Self {
         self.config.kora.bundle.enabled = enabled;
+        self
+    }
+
+    pub fn with_jito_block_engine_url(mut self, url: impl Into<String>) -> Self {
+        self.config.kora.bundle.jito.block_engine_url = url.into();
+        self
+    }
+
+    pub fn with_mock_jito_block_engine(mut self) -> Self {
+        self.config.kora.bundle.jito.block_engine_url = JITO_MOCK_BLOCK_ENGINE_URL.to_string();
         self
     }
 

--- a/crates/lib/src/tests/config_mock.rs
+++ b/crates/lib/src/tests/config_mock.rs
@@ -115,6 +115,7 @@ impl ConfigMockBuilder {
                         enabled: false,
                         jito: JitoConfig {
                             block_engine_url: JITO_MOCK_BLOCK_ENGINE_URL.to_string(),
+                            simulate_bundle_url: Some(JITO_MOCK_BLOCK_ENGINE_URL.to_string()),
                         },
                     },
                     lighthouse: LighthouseConfig::default(),

--- a/crates/lib/src/validator/bundle_validator.rs
+++ b/crates/lib/src/validator/bundle_validator.rs
@@ -380,6 +380,25 @@ mod tests {
     }
 
     #[test]
+    fn test_validate_jito_bundle_size_boundary() {
+        assert!(BundleValidator::validate_jito_bundle_size(&vec!["tx".to_string(); 1]).is_ok());
+        assert!(BundleValidator::validate_jito_bundle_size(&vec!["tx".to_string(); 4]).is_ok());
+        assert!(BundleValidator::validate_jito_bundle_size(&vec!["tx".to_string(); 5]).is_ok());
+        assert!(BundleValidator::validate_jito_bundle_size(&vec!["tx".to_string(); 6]).is_err());
+        assert!(BundleValidator::validate_jito_bundle_size(&vec!["tx".to_string(); 7]).is_err());
+    }
+
+    #[test]
+    fn test_validate_jito_bundle_size_error_types() {
+        let empty_err = BundleValidator::validate_jito_bundle_size(&[]).unwrap_err();
+        assert!(matches!(empty_err, KoraError::InvalidTransaction(_)));
+
+        let large_err =
+            BundleValidator::validate_jito_bundle_size(&vec!["tx".to_string(); 6]).unwrap_err();
+        assert!(matches!(large_err, KoraError::JitoError(_)));
+    }
+
+    #[test]
     fn test_signed_indices_for_bundle_defaults_to_all() {
         let indices = BundleValidator::signed_indices_for_bundle(4, None);
         assert_eq!(indices, vec![0, 1, 2, 3]);

--- a/crates/lib/src/validator/bundle_validator.rs
+++ b/crates/lib/src/validator/bundle_validator.rs
@@ -122,12 +122,10 @@ impl BundleValidator {
         signed_indices: &[usize],
         simulation_result: &JitoBundleSimulationResult,
     ) -> Result<(), KoraError> {
-        if !signed_indices.is_empty()
-            && simulation_result.transaction_results.len() != encoded_transactions.len()
-        {
+        if simulation_result.transaction_results.len() != encoded_transactions.len() {
             return Err(KoraError::InvalidTransaction(format!(
                 "Bundle simulation returned {} transaction results for {} transactions; \
-                 cannot safely validate signed bundle members sequentially",
+                 cannot safely validate bundle sequentially",
                 simulation_result.transaction_results.len(),
                 encoded_transactions.len()
             )));
@@ -135,34 +133,25 @@ impl BundleValidator {
 
         let allowed_programs = Self::parse_pubkey_set(&config.validation.allowed_programs)?;
         let disallowed_programs = Self::parse_pubkey_set(&config.validation.disallowed_accounts)?;
+        let signed_set: HashSet<usize> = signed_indices.iter().copied().collect();
 
-        for &signed_idx in signed_indices {
-            if signed_idx >= encoded_transactions.len() {
-                continue;
-            }
-
-            let tx_result =
-                simulation_result.transaction_results.get(signed_idx).ok_or_else(|| {
-                    KoraError::InvalidTransaction(format!(
-                        "Bundle simulation missing result for signed transaction index {}",
-                        signed_idx
-                    ))
-                })?;
-
+        for (tx_idx, tx_result) in simulation_result.transaction_results.iter().enumerate() {
             Self::validate_invoked_programs(
                 &allowed_programs,
                 &disallowed_programs,
                 &tx_result.logs,
             )?;
 
-            Self::validate_fee_payer_lamport_outflow(
-                rpc_client,
-                &encoded_transactions[signed_idx],
-                signed_idx,
-                tx_result,
-                config.validation.max_allowed_lamports,
-            )
-            .await?;
+            if signed_set.contains(&tx_idx) {
+                Self::validate_fee_payer_lamport_outflow(
+                    rpc_client,
+                    &encoded_transactions[tx_idx],
+                    tx_idx,
+                    tx_result,
+                    config.validation.max_allowed_lamports,
+                )
+                .await?;
+            }
         }
 
         Ok(())
@@ -572,6 +561,6 @@ mod tests {
 
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
-        assert!(err.contains("cannot safely validate signed bundle members sequentially"));
+        assert!(err.contains("cannot safely validate bundle sequentially"));
     }
 }

--- a/crates/lib/src/validator/bundle_validator.rs
+++ b/crates/lib/src/validator/bundle_validator.rs
@@ -1,7 +1,19 @@
 use crate::{
-    bundle::{constant::JITO_MAX_BUNDLE_SIZE, BundleError, JitoError},
+    bundle::{
+        constant::JITO_MAX_BUNDLE_SIZE, BundleError, JitoBundleAccountConfig, JitoBundleClient,
+        JitoBundleSimulationConfig, JitoBundleSimulationResult,
+        JitoBundleSimulationTransactionResult, JitoError,
+    },
+    config::Config,
+    fee::fee::TransactionFeeUtil,
+    transaction::TransactionUtil,
     KoraError,
 };
+use regex::Regex;
+use serde_json::Value;
+use solana_client::nonblocking::rpc_client::RpcClient;
+use solana_sdk::pubkey::Pubkey;
+use std::{collections::HashSet, str::FromStr, sync::OnceLock};
 
 pub struct BundleValidator {}
 
@@ -15,22 +27,352 @@ impl BundleValidator {
         }
         Ok(())
     }
+
+    pub fn signed_indices_for_bundle(
+        bundle_size: usize,
+        sign_only_indices: Option<&[usize]>,
+    ) -> Vec<usize> {
+        let mut indices: Vec<usize> =
+            sign_only_indices.map(|raw| raw.to_vec()).unwrap_or_else(|| (0..bundle_size).collect());
+
+        indices.retain(|idx| *idx < bundle_size);
+        indices.sort_unstable();
+        indices.dedup();
+        indices
+    }
+
+    pub async fn simulate_and_validate_sequential_bundle(
+        rpc_client: &RpcClient,
+        config: &Config,
+        encoded_transactions: &[String],
+        signed_indices: &[usize],
+        fee_payer: &Pubkey,
+        skip_sig_verify: bool,
+    ) -> Result<JitoBundleSimulationResult, KoraError> {
+        let simulation_config = Self::build_simulation_config_for_signed_indices(
+            encoded_transactions.len(),
+            signed_indices,
+            fee_payer,
+            skip_sig_verify,
+        );
+        let jito_client = JitoBundleClient::new(&config.kora.bundle.jito);
+        let simulation_result = jito_client
+            .simulate_bundle_with_config(encoded_transactions, simulation_config)
+            .await?;
+
+        Self::validate_simulation_policy(
+            rpc_client,
+            config,
+            encoded_transactions,
+            signed_indices,
+            &simulation_result,
+        )
+        .await?;
+
+        Ok(simulation_result)
+    }
+
+    fn build_simulation_config_for_signed_indices(
+        bundle_size: usize,
+        signed_indices: &[usize],
+        fee_payer: &Pubkey,
+        skip_sig_verify: bool,
+    ) -> JitoBundleSimulationConfig {
+        let signed_set: HashSet<usize> = signed_indices.iter().copied().collect();
+        let fee_payer_account = JitoBundleAccountConfig {
+            addresses: vec![fee_payer.to_string()],
+            encoding: Some("base64".to_string()),
+        };
+
+        let pre_execution_accounts_configs =
+            (0..bundle_size)
+                .map(|tx_idx| {
+                    if signed_set.contains(&tx_idx) {
+                        Some(fee_payer_account.clone())
+                    } else {
+                        None
+                    }
+                })
+                .collect::<Vec<Option<JitoBundleAccountConfig>>>();
+
+        let post_execution_accounts_configs =
+            (0..bundle_size)
+                .map(|tx_idx| {
+                    if signed_set.contains(&tx_idx) {
+                        Some(fee_payer_account.clone())
+                    } else {
+                        None
+                    }
+                })
+                .collect::<Vec<Option<JitoBundleAccountConfig>>>();
+
+        JitoBundleSimulationConfig {
+            pre_execution_accounts_configs: Some(pre_execution_accounts_configs),
+            post_execution_accounts_configs: Some(post_execution_accounts_configs),
+            transaction_encoding: Some("base64".to_string()),
+            skip_sig_verify: Some(skip_sig_verify),
+            replace_recent_blockhash: None,
+        }
+    }
+
+    async fn validate_simulation_policy(
+        rpc_client: &RpcClient,
+        config: &Config,
+        encoded_transactions: &[String],
+        signed_indices: &[usize],
+        simulation_result: &JitoBundleSimulationResult,
+    ) -> Result<(), KoraError> {
+        if !signed_indices.is_empty()
+            && simulation_result.transaction_results.len() != encoded_transactions.len()
+        {
+            return Err(KoraError::InvalidTransaction(format!(
+                "Bundle simulation returned {} transaction results for {} transactions; \
+                 cannot safely validate signed bundle members sequentially",
+                simulation_result.transaction_results.len(),
+                encoded_transactions.len()
+            )));
+        }
+
+        let allowed_programs = Self::parse_pubkey_set(&config.validation.allowed_programs)?;
+        let disallowed_programs = Self::parse_pubkey_set(&config.validation.disallowed_accounts)?;
+
+        for &signed_idx in signed_indices {
+            if signed_idx >= encoded_transactions.len() {
+                continue;
+            }
+
+            let tx_result =
+                simulation_result.transaction_results.get(signed_idx).ok_or_else(|| {
+                    KoraError::InvalidTransaction(format!(
+                        "Bundle simulation missing result for signed transaction index {}",
+                        signed_idx
+                    ))
+                })?;
+
+            Self::validate_invoked_programs(
+                &allowed_programs,
+                &disallowed_programs,
+                &tx_result.logs,
+            )?;
+
+            Self::validate_fee_payer_lamport_outflow(
+                rpc_client,
+                &encoded_transactions[signed_idx],
+                signed_idx,
+                tx_result,
+                config.validation.max_allowed_lamports,
+            )
+            .await?;
+        }
+
+        Ok(())
+    }
+
+    fn validate_invoked_programs(
+        allowed_programs: &HashSet<Pubkey>,
+        disallowed_programs: &HashSet<Pubkey>,
+        logs: &[String],
+    ) -> Result<(), KoraError> {
+        let invoked_programs = Self::extract_invoked_programs(logs)?;
+
+        for program_id in invoked_programs {
+            if disallowed_programs.contains(&program_id) {
+                return Err(KoraError::InvalidTransaction(format!(
+                    "Program {} is disallowed",
+                    program_id
+                )));
+            }
+
+            if !allowed_programs.contains(&program_id) {
+                return Err(KoraError::InvalidTransaction(format!(
+                    "Program {} is not in the allowed list",
+                    program_id
+                )));
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn validate_fee_payer_lamport_outflow(
+        rpc_client: &RpcClient,
+        encoded_transaction: &str,
+        signed_idx: usize,
+        tx_result: &JitoBundleSimulationTransactionResult,
+        max_allowed_lamports: u64,
+    ) -> Result<(), KoraError> {
+        let pre_accounts = tx_result.pre_execution_accounts.as_ref().ok_or_else(|| {
+            KoraError::InvalidTransaction(format!(
+                "Bundle simulation did not return pre-execution accounts for signed transaction index {}",
+                signed_idx
+            ))
+        })?;
+        let post_accounts = tx_result.post_execution_accounts.as_ref().ok_or_else(|| {
+            KoraError::InvalidTransaction(format!(
+                "Bundle simulation did not return post-execution accounts for signed transaction index {}",
+                signed_idx
+            ))
+        })?;
+
+        let pre_account = pre_accounts.first().ok_or_else(|| {
+            KoraError::InvalidTransaction(format!(
+                "Bundle simulation returned empty pre-execution accounts for signed transaction index {}",
+                signed_idx
+            ))
+        })?;
+        let post_account = post_accounts.first().ok_or_else(|| {
+            KoraError::InvalidTransaction(format!(
+                "Bundle simulation returned empty post-execution accounts for signed transaction index {}",
+                signed_idx
+            ))
+        })?;
+
+        let pre_lamports = Self::extract_lamports(pre_account).ok_or_else(|| {
+            KoraError::InvalidTransaction(format!(
+                "Bundle simulation pre-execution lamports missing for signed transaction index {}",
+                signed_idx
+            ))
+        })?;
+        let post_lamports = Self::extract_lamports(post_account).ok_or_else(|| {
+            KoraError::InvalidTransaction(format!(
+                "Bundle simulation post-execution lamports missing for signed transaction index {}",
+                signed_idx
+            ))
+        })?;
+
+        let observed_lamport_outflow = pre_lamports.saturating_sub(post_lamports);
+
+        if observed_lamport_outflow == 0 {
+            return Ok(());
+        }
+
+        let transaction = TransactionUtil::decode_b64_transaction(encoded_transaction)?;
+        let estimated_network_fee =
+            TransactionFeeUtil::get_estimate_fee(rpc_client, &transaction.message).await?;
+
+        // Match existing policy semantics by excluding the network signature fee from transfer outflow.
+        let transfer_outflow = observed_lamport_outflow.saturating_sub(estimated_network_fee);
+
+        if transfer_outflow > max_allowed_lamports {
+            return Err(KoraError::InvalidTransaction(format!(
+                "Total transfer amount {} exceeds maximum allowed {}",
+                transfer_outflow, max_allowed_lamports
+            )));
+        }
+
+        Ok(())
+    }
+
+    fn parse_pubkey_set(pubkeys: &[String]) -> Result<HashSet<Pubkey>, KoraError> {
+        pubkeys
+            .iter()
+            .map(|pubkey| {
+                Pubkey::from_str(pubkey).map_err(|e| {
+                    KoraError::InternalServerError(format!(
+                        "Invalid public key `{}` in config: {}",
+                        pubkey, e
+                    ))
+                })
+            })
+            .collect::<Result<HashSet<Pubkey>, KoraError>>()
+    }
+
+    fn extract_invoked_programs(logs: &[String]) -> Result<HashSet<Pubkey>, KoraError> {
+        static PROGRAM_INVOKE_REGEX: OnceLock<Regex> = OnceLock::new();
+        let regex = PROGRAM_INVOKE_REGEX.get_or_init(|| {
+            Regex::new(r"^Program ([1-9A-HJ-NP-Za-km-z]{32,44}) invoke \[\d+\]$")
+                .expect("program invoke regex must be valid")
+        });
+
+        let mut invoked = HashSet::new();
+        for log in logs {
+            if let Some(captures) = regex.captures(log) {
+                if let Some(program) = captures.get(1) {
+                    let program_id = Pubkey::from_str(program.as_str()).map_err(|e| {
+                        KoraError::InvalidTransaction(format!(
+                            "Invalid invoked program id in simulation logs: {}",
+                            e
+                        ))
+                    })?;
+                    invoked.insert(program_id);
+                }
+            }
+        }
+
+        Ok(invoked)
+    }
+
+    fn extract_lamports(account: &Value) -> Option<u64> {
+        account.get("lamports").and_then(|lamports| match lamports {
+            Value::Number(number) => number.as_u64(),
+            Value::String(value) => value.parse::<u64>().ok(),
+            _ => None,
+        })
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::tests::{config_mock::ConfigMockBuilder, rpc_mock::RpcMockBuilder};
+    use serde_json::json;
+    use solana_message::{Message, VersionedMessage};
+    use solana_system_interface::instruction::transfer;
+
+    fn make_test_transaction(fee_payer: &Pubkey) -> String {
+        let instruction = transfer(fee_payer, &Pubkey::new_unique(), 1_000);
+        let message = VersionedMessage::Legacy(Message::new(&[instruction], Some(fee_payer)));
+        let transaction = TransactionUtil::new_unsigned_versioned_transaction(message);
+        TransactionUtil::encode_versioned_transaction(&transaction).unwrap()
+    }
+
+    fn make_tx_result(
+        logs: Vec<String>,
+        pre_lamports: Option<u64>,
+        post_lamports: Option<u64>,
+    ) -> JitoBundleSimulationTransactionResult {
+        let pre_execution_accounts = pre_lamports.map(|lamports| {
+            vec![json!({
+                "lamports": lamports,
+                "owner": "11111111111111111111111111111111",
+                "data": ["", "base64"],
+                "executable": false,
+                "rentEpoch": 0
+            })]
+        });
+        let post_execution_accounts = post_lamports.map(|lamports| {
+            vec![json!({
+                "lamports": lamports,
+                "owner": "11111111111111111111111111111111",
+                "data": ["", "base64"],
+                "executable": false,
+                "rentEpoch": 0
+            })]
+        });
+
+        JitoBundleSimulationTransactionResult {
+            err: None,
+            logs,
+            context: json!({ "slot": 1 }),
+            pre_execution_accounts,
+            post_execution_accounts,
+            units_consumed: Some(1),
+            return_data: None,
+        }
+    }
 
     #[test]
     fn test_validate_jito_bundle_size_empty() {
         let result = BundleValidator::validate_jito_bundle_size(&[]);
         assert!(result.is_err());
     }
+
     #[test]
     fn test_validate_jito_bundle_size_too_large() {
         let result = BundleValidator::validate_jito_bundle_size(&vec!["tx".to_string(); 6]);
         assert!(result.is_err());
     }
+
     #[test]
     fn test_validate_jito_bundle_size_valid() {
         let result = BundleValidator::validate_jito_bundle_size(&vec!["tx".to_string(); 5]);
@@ -38,24 +380,179 @@ mod tests {
     }
 
     #[test]
-    fn test_validate_jito_bundle_size_boundary() {
-        // Test boundary values: 1, 4, 5 should pass; 6, 7 should fail
-        assert!(BundleValidator::validate_jito_bundle_size(&vec!["tx".to_string(); 1]).is_ok());
-        assert!(BundleValidator::validate_jito_bundle_size(&vec!["tx".to_string(); 4]).is_ok());
-        assert!(BundleValidator::validate_jito_bundle_size(&vec!["tx".to_string(); 5]).is_ok());
-        assert!(BundleValidator::validate_jito_bundle_size(&vec!["tx".to_string(); 6]).is_err());
-        assert!(BundleValidator::validate_jito_bundle_size(&vec!["tx".to_string(); 7]).is_err());
+    fn test_signed_indices_for_bundle_defaults_to_all() {
+        let indices = BundleValidator::signed_indices_for_bundle(4, None);
+        assert_eq!(indices, vec![0, 1, 2, 3]);
     }
 
     #[test]
-    fn test_validate_jito_bundle_size_error_types() {
-        // Empty returns BundleError::Empty
-        let empty_err = BundleValidator::validate_jito_bundle_size(&[]).unwrap_err();
-        assert!(matches!(empty_err, KoraError::InvalidTransaction(_)));
+    fn test_signed_indices_for_bundle_dedups_and_filters_oob() {
+        let indices = BundleValidator::signed_indices_for_bundle(3, Some(&[2, 0, 2, 5]));
+        assert_eq!(indices, vec![0, 2]);
+    }
 
-        // Too large returns JitoError::BundleTooLarge
-        let large_err =
-            BundleValidator::validate_jito_bundle_size(&vec!["tx".to_string(); 6]).unwrap_err();
-        assert!(matches!(large_err, KoraError::JitoError(_)));
+    #[test]
+    fn test_build_simulation_config_tracks_only_signed_indices() {
+        let fee_payer = Pubkey::new_unique();
+        let config =
+            BundleValidator::build_simulation_config_for_signed_indices(3, &[1], &fee_payer, false);
+
+        let pre = config.pre_execution_accounts_configs.unwrap();
+        let post = config.post_execution_accounts_configs.unwrap();
+
+        assert!(pre[0].is_none());
+        assert!(pre[2].is_none());
+        assert_eq!(pre[1].as_ref().unwrap().addresses, vec![fee_payer.to_string()]);
+        assert_eq!(post[1].as_ref().unwrap().addresses, vec![fee_payer.to_string()]);
+    }
+
+    #[test]
+    fn test_extract_invoked_programs() {
+        let system_program = "11111111111111111111111111111111";
+        let token_program = "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA";
+        let logs = vec![
+            format!("Program {} invoke [1]", system_program),
+            format!("Program {} invoke [2]", token_program),
+            "Program log: some message".to_string(),
+        ];
+
+        let programs = BundleValidator::extract_invoked_programs(&logs).unwrap();
+        assert!(programs.contains(&Pubkey::from_str(system_program).unwrap()));
+        assert!(programs.contains(&Pubkey::from_str(token_program).unwrap()));
+    }
+
+    #[tokio::test]
+    async fn test_validate_simulation_policy_rejects_disallowed_program() {
+        let fee_payer = Pubkey::new_unique();
+        let encoded_transactions = vec![make_test_transaction(&fee_payer)];
+        let config = ConfigMockBuilder::new()
+            .with_max_allowed_lamports(1_000_000)
+            .with_allowed_programs(vec!["11111111111111111111111111111111".to_string()])
+            .with_disallowed_accounts(vec![
+                "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA".to_string()
+            ])
+            .build();
+        let rpc_client = RpcMockBuilder::new().with_fee_estimate(5_000).build();
+
+        let simulation_result = JitoBundleSimulationResult {
+            context: json!({ "slot": 1 }),
+            summary: Some(json!("succeeded")),
+            transaction_results: vec![make_tx_result(
+                vec!["Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA invoke [1]".to_string()],
+                Some(1_000_000_000),
+                Some(1_000_000_000),
+            )],
+        };
+
+        let result = BundleValidator::validate_simulation_policy(
+            &rpc_client,
+            &config,
+            &encoded_transactions,
+            &[0],
+            &simulation_result,
+        )
+        .await;
+
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("disallowed"));
+    }
+
+    #[tokio::test]
+    async fn test_validate_simulation_policy_rejects_outflow_above_limit() {
+        let fee_payer = Pubkey::new_unique();
+        let encoded_transactions = vec![make_test_transaction(&fee_payer)];
+        let config = ConfigMockBuilder::new()
+            .with_max_allowed_lamports(1_000_000)
+            .with_allowed_programs(vec!["11111111111111111111111111111111".to_string()])
+            .build();
+        let rpc_client = RpcMockBuilder::new().with_fee_estimate(5_000).build();
+
+        let simulation_result = JitoBundleSimulationResult {
+            context: json!({ "slot": 1 }),
+            summary: Some(json!("succeeded")),
+            transaction_results: vec![make_tx_result(
+                vec!["Program 11111111111111111111111111111111 invoke [1]".to_string()],
+                Some(2_000_000),
+                Some(890_000),
+            )],
+        };
+
+        let result = BundleValidator::validate_simulation_policy(
+            &rpc_client,
+            &config,
+            &encoded_transactions,
+            &[0],
+            &simulation_result,
+        )
+        .await;
+
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("Total transfer amount"));
+        assert!(err.contains("exceeds maximum allowed"));
+    }
+
+    #[tokio::test]
+    async fn test_validate_simulation_policy_accepts_outflow_within_limit() {
+        let fee_payer = Pubkey::new_unique();
+        let encoded_transactions = vec![make_test_transaction(&fee_payer)];
+        let config = ConfigMockBuilder::new()
+            .with_max_allowed_lamports(1_000_000)
+            .with_allowed_programs(vec!["11111111111111111111111111111111".to_string()])
+            .build();
+        let rpc_client = RpcMockBuilder::new().with_fee_estimate(5_000).build();
+
+        let simulation_result = JitoBundleSimulationResult {
+            context: json!({ "slot": 1 }),
+            summary: Some(json!("succeeded")),
+            transaction_results: vec![make_tx_result(
+                vec!["Program 11111111111111111111111111111111 invoke [1]".to_string()],
+                Some(2_000_000),
+                Some(1_010_000),
+            )],
+        };
+
+        let result = BundleValidator::validate_simulation_policy(
+            &rpc_client,
+            &config,
+            &encoded_transactions,
+            &[0],
+            &simulation_result,
+        )
+        .await;
+
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_validate_simulation_policy_requires_per_tx_results() {
+        let fee_payer = Pubkey::new_unique();
+        let encoded_transactions =
+            vec![make_test_transaction(&fee_payer), make_test_transaction(&fee_payer)];
+        let config = ConfigMockBuilder::new()
+            .with_max_allowed_lamports(1_000_000)
+            .with_allowed_programs(vec!["11111111111111111111111111111111".to_string()])
+            .build();
+        let rpc_client = RpcMockBuilder::new().with_fee_estimate(5_000).build();
+
+        let simulation_result = JitoBundleSimulationResult {
+            context: json!({ "slot": 1 }),
+            summary: Some(json!("succeeded")),
+            transaction_results: vec![make_tx_result(vec![], Some(1_000_000), Some(1_000_000))],
+        };
+
+        let result = BundleValidator::validate_simulation_policy(
+            &rpc_client,
+            &config,
+            &encoded_transactions,
+            &[1],
+            &simulation_result,
+        )
+        .await;
+
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("cannot safely validate signed bundle members sequentially"));
     }
 }

--- a/crates/lib/src/validator/bundle_validator.rs
+++ b/crates/lib/src/validator/bundle_validator.rs
@@ -164,6 +164,12 @@ impl BundleValidator {
     ) -> Result<(), KoraError> {
         let invoked_programs = Self::extract_invoked_programs(logs)?;
 
+        if invoked_programs.is_empty() {
+            return Err(KoraError::InvalidTransaction(
+                "No invoked programs detected in transaction logs; cannot validate program allowlist".into(),
+            ));
+        }
+
         for program_id in invoked_programs {
             if disallowed_programs.contains(&program_id) {
                 return Err(KoraError::InvalidTransaction(format!(

--- a/crates/lib/src/validator/config_validator.rs
+++ b/crates/lib/src/validator/config_validator.rs
@@ -545,6 +545,16 @@ impl ConfigValidator {
             }
         }
 
+        // Validate bundle configuration
+        if config.kora.bundle.enabled && config.kora.bundle.jito.simulate_bundle_url.is_none() {
+            errors.push(
+                "Bundle support is enabled but jito.simulate_bundle_url is not set. \
+                simulateBundle is a Jito-Solana RPC method and requires a compatible RPC URL \
+                (e.g. a Jito-Solana node, Helius, or QuickNode with Jito add-on)."
+                    .to_string(),
+            );
+        }
+
         // Validate fee payer policy - warn about enabled risky operations
         Self::validate_fee_payer_policy(&config.validation.fee_payer_policy, &mut warnings);
 

--- a/crates/lib/src/validator/transaction_validator.rs
+++ b/crates/lib/src/validator/transaction_validator.rs
@@ -820,7 +820,7 @@ mod tests {
         let mut transaction =
             TransactionUtil::new_unsigned_versioned_transaction_resolved(message).unwrap();
         assert!(validator
-            .validate_transaction(&get_config().unwrap(), &mut transaction, &rpc_client)
+            .validate_transaction(get_config().unwrap(), &mut transaction, &rpc_client)
             .await
             .is_ok());
     }
@@ -848,7 +848,7 @@ mod tests {
         let mut transaction =
             TransactionUtil::new_unsigned_versioned_transaction_resolved(message).unwrap();
         assert!(validator
-            .validate_transaction(&get_config().unwrap(), &mut transaction, &rpc_client)
+            .validate_transaction(get_config().unwrap(), &mut transaction, &rpc_client)
             .await
             .is_err());
     }
@@ -880,7 +880,7 @@ mod tests {
         let mut transaction =
             TransactionUtil::new_unsigned_versioned_transaction_resolved(message).unwrap();
         assert!(validator
-            .validate_transaction(&get_config().unwrap(), &mut transaction, &rpc_client)
+            .validate_transaction(get_config().unwrap(), &mut transaction, &rpc_client)
             .await
             .is_ok());
     }
@@ -909,7 +909,7 @@ mod tests {
         let mut transaction =
             TransactionUtil::new_unsigned_versioned_transaction_resolved(message).unwrap();
         assert!(validator
-            .validate_transaction(&get_config().unwrap(), &mut transaction, &rpc_client)
+            .validate_transaction(get_config().unwrap(), &mut transaction, &rpc_client)
             .await
             .is_err());
     }
@@ -939,7 +939,7 @@ mod tests {
         let mut transaction =
             TransactionUtil::new_unsigned_versioned_transaction_resolved(message).unwrap();
         assert!(validator
-            .validate_transaction(&get_config().unwrap(), &mut transaction, &rpc_client)
+            .validate_transaction(get_config().unwrap(), &mut transaction, &rpc_client)
             .await
             .is_ok());
     }

--- a/examples/jito-bundles/server/kora.toml
+++ b/examples/jito-bundles/server/kora.toml
@@ -146,3 +146,4 @@ enabled = true
 
 [kora.bundle.jito]
 block_engine_url = "https://mainnet.block-engine.jito.wtf"
+simulate_bundle_url = "https://mainnet.rpc.jito.wtf"

--- a/kora.toml
+++ b/kora.toml
@@ -178,3 +178,4 @@ enabled = false
 
 [kora.bundle.jito]
 block_engine_url = "https://mainnet.block-engine.jito.wtf"
+# simulate_bundle_url = "https://mainnet.rpc.jito.wtf"  # Required when bundle.enabled = true

--- a/tests/external/jito_integration.rs
+++ b/tests/external/jito_integration.rs
@@ -5,7 +5,10 @@ const JITO_TESTNET_BLOCK_ENGINE_URL: &str = "https://dallas.testnet.block-engine
 
 #[tokio::test]
 async fn test_jito_mainnet_connection() {
-    let config = JitoConfig { block_engine_url: JITO_TESTNET_BLOCK_ENGINE_URL.to_string() };
+    let config = JitoConfig {
+        block_engine_url: JITO_TESTNET_BLOCK_ENGINE_URL.to_string(),
+        simulate_bundle_url: None,
+    };
     let client = JitoClient::new(&config);
 
     // Query status of non-existent bundle to test connectivity
@@ -23,7 +26,10 @@ async fn test_jito_mainnet_connection() {
 
 #[tokio::test]
 async fn test_jito_testnet_connection() {
-    let config = JitoConfig { block_engine_url: JITO_TESTNET_BLOCK_ENGINE_URL.to_string() };
+    let config = JitoConfig {
+        block_engine_url: JITO_TESTNET_BLOCK_ENGINE_URL.to_string(),
+        simulate_bundle_url: None,
+    };
     let client = JitoClient::new(&config);
 
     // Query status of non-existent bundle to test connectivity
@@ -42,7 +48,10 @@ async fn test_jito_testnet_connection() {
 #[tokio::test]
 async fn test_jito_send_bundle() {
     let ctx = TestContext::new().await.expect("Failed to create test context");
-    let config = JitoConfig { block_engine_url: JITO_TESTNET_BLOCK_ENGINE_URL.to_string() };
+    let config = JitoConfig {
+        block_engine_url: JITO_TESTNET_BLOCK_ENGINE_URL.to_string(),
+        simulate_bundle_url: None,
+    };
     let client = JitoClient::new(&config);
 
     let encoded_tx = ctx

--- a/tests/src/common/fixtures/auth-test.toml
+++ b/tests/src/common/fixtures/auth-test.toml
@@ -107,3 +107,4 @@ enabled = true
 
 [kora.bundle.jito]
 block_engine_url = "mock"
+simulate_bundle_url = "mock"

--- a/tests/src/common/fixtures/gas-swap-plugin-test.toml
+++ b/tests/src/common/fixtures/gas-swap-plugin-test.toml
@@ -111,3 +111,4 @@ enabled = true
 
 [kora.bundle.jito]
 block_engine_url = "mock"
+simulate_bundle_url = "mock"

--- a/tests/src/common/fixtures/kora-test.toml
+++ b/tests/src/common/fixtures/kora-test.toml
@@ -123,3 +123,4 @@ enabled = true
 
 [kora.bundle.jito]
 block_engine_url = "mock"
+simulate_bundle_url = "mock"

--- a/tests/src/common/fixtures/lighthouse-test.toml
+++ b/tests/src/common/fixtures/lighthouse-test.toml
@@ -124,3 +124,4 @@ enabled = true
 
 [kora.bundle.jito]
 block_engine_url = "mock"
+simulate_bundle_url = "mock"

--- a/tests/src/common/fixtures/usage-limit-test.toml
+++ b/tests/src/common/fixtures/usage-limit-test.toml
@@ -16,6 +16,7 @@ enabled = true
 
 [kora.bundle.jito]
 block_engine_url = "https://mainnet.block-engine.jito.wtf"
+simulate_bundle_url = "https://mainnet.rpc.jito.wtf"
 
 [kora.enabled_methods]
 liveness = true


### PR DESCRIPTION
## Summary
- Replace bundle static account-overlap assumptions with sequential `simulateBundle` validation in execution order
- Validate invoked programs for **all** bundle transactions (not just signed indices) from runtime simulation logs
- Enforce fee-payer outflow caps for signed bundle members using simulated pre/post lamport snapshots, failing closed when per-tx results are missing
- Wire sequential validation into `signBundle`, `signAndSendBundle`, and `estimateBundleFee`
- Preserve `sig_verify` semantics by mapping to bundle simulation `skipSigVerify = !sig_verify`
- Extend Jito bundle client parsing to support both simulate response shapes and simulation config/account snapshot requests
- Fail closed on missing/invalid logs in simulateBundle response (no silent fallback to empty logs)
- Check bundle simulation summary failure unconditionally

## Security Context
- Addresses audit finding where standalone pre-bundle simulation let earlier bundle writes change later CPI paths after Kora signs
- Mitigation is bundle-aware sequential simulation validation based on the same transaction order the bundle executes

## Test Plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets`
- [x] `cargo test -p kora-lib bundle_validator -- --nocapture`
- [x] `cargo test -p kora-lib bundle::jito::client::tests -- --nocapture`
- [x] `cargo test -p kora-lib sign_and_send_bundle -- --nocapture`
- [x] `cargo test -p kora-lib sign_bundle -- --nocapture`
- [x] `cargo test -p kora-lib estimate_bundle_fee -- --nocapture`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/solana-foundation/kora/pull/425" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->





## 📊 Unit Test Coverage
![Coverage](https://img.shields.io/badge/coverage-85.5%25-green)

**Unit Test Coverage: 85.5%**

[View Detailed Coverage Report](https://github.com/solana-foundation/kora/actions/runs/24260733174)