### PR TITLE
Fix/okx fixes

### DIFF
--- a/crates/lib/src/fee/fee.rs
+++ b/crates/lib/src/fee/fee.rs
@@ -30,7 +30,7 @@ pub struct TotalFeeCalculation {
     pub total_fee_lamports: u64,
     pub base_fee: u64,
     pub kora_signature_fee: u64,
-    pub fee_payer_outflow: u64,
+    pub fee_payer_outflow: i128,
     pub payment_instruction_fee: u64,
     pub transfer_fee_amount: u64,
 }
@@ -40,7 +40,7 @@ impl TotalFeeCalculation {
         total_fee_lamports: u64,
         base_fee: u64,
         kora_signature_fee: u64,
-        fee_payer_outflow: u64,
+        fee_payer_outflow: i128,
         payment_instruction_fee: u64,
         transfer_fee_amount: u64,
     ) -> Self {
@@ -66,16 +66,17 @@ impl TotalFeeCalculation {
     }
 
     pub fn get_total_fee_lamports(&self) -> Result<u64, KoraError> {
-        self.base_fee
-            .checked_add(self.kora_signature_fee)
+        let sum = (self.base_fee as i128)
+            .checked_add(self.kora_signature_fee as i128)
             .and_then(|sum| sum.checked_add(self.fee_payer_outflow))
-            .and_then(|sum| sum.checked_add(self.payment_instruction_fee))
-            .and_then(|sum| sum.checked_add(self.transfer_fee_amount))
+            .and_then(|sum| sum.checked_add(self.payment_instruction_fee as i128))
+            .and_then(|sum| sum.checked_add(self.transfer_fee_amount as i128))
             .ok_or_else(|| {
                 log::error!("Fee calculation overflow: base_fee={}, kora_signature_fee={}, fee_payer_outflow={}, payment_instruction_fee={}, transfer_fee_amount={}",
                     self.base_fee, self.kora_signature_fee, self.fee_payer_outflow, self.payment_instruction_fee, self.transfer_fee_amount);
                 KoraError::ValidationError("Fee calculation overflow".to_string())
-            })
+            })?;
+        Ok(sum.max(0) as u64)
     }
 }
 
@@ -253,11 +254,12 @@ impl FeeConfigUtil {
             0
         };
 
-        let total_fee_lamports = base_fee
-            .checked_add(kora_signature_fee)
+        let total_fee_lamports = (base_fee as i128)
+            .checked_add(kora_signature_fee as i128)
             .and_then(|sum| sum.checked_add(fee_payer_outflow))
-            .and_then(|sum| sum.checked_add(fee_for_payment_instruction))
-            .and_then(|sum| sum.checked_add(transfer_fee_config_amount))
+            .and_then(|sum| sum.checked_add(fee_for_payment_instruction as i128))
+            .and_then(|sum| sum.checked_add(transfer_fee_config_amount as i128))
+            .map(|sum| sum.max(0) as u64)
             .ok_or_else(|| {
                 log::error!("Fee calculation overflow: base_fee={}, kora_signature_fee={}, fee_payer_outflow={}, payment_instruction_fee={}, transfer_fee_amount={}",
                     base_fee, kora_signature_fee, fee_payer_outflow, fee_for_payment_instruction, transfer_fee_config_amount);
@@ -394,8 +396,10 @@ impl FeeConfigUtil {
         transaction: &mut VersionedTransactionResolved,
         rpc_client: &RpcClient,
         config: &Config,
-    ) -> Result<u64, KoraError> {
-        let mut total = 0u64;
+    ) -> Result<i128, KoraError> {
+        // Use i128 to correctly handle net outflow when inflows are processed
+        // before outflows. With u64, saturating_sub on 0 would silently discard inflows.
+        let mut total: i128 = 0;
 
         // Calculate SOL outflow from System Program instructions
         let parsed_system_instructions = transaction.get_or_parse_system_instructions()?;
@@ -408,13 +412,16 @@ impl FeeConfigUtil {
                 instruction
             {
                 if *sender == *fee_payer_pubkey {
-                    total = total.checked_add(*lamports).ok_or_else(|| {
+                    total = total.checked_add(*lamports as i128).ok_or_else(|| {
                         log::error!("Outflow calculation overflow in SystemTransfer");
                         KoraError::ValidationError("Outflow calculation overflow".to_string())
                     })?;
                 }
                 if *receiver == *fee_payer_pubkey {
-                    total = total.saturating_sub(*lamports);
+                    total = total.checked_sub(*lamports as i128).ok_or_else(|| {
+                        log::error!("Inflow calculation overflow in SystemTransfer");
+                        KoraError::ValidationError("Inflow calculation overflow".to_string())
+                    })?;
                 }
             }
         }
@@ -427,7 +434,7 @@ impl FeeConfigUtil {
                 instruction
             {
                 if *payer == *fee_payer_pubkey {
-                    total = total.checked_add(*lamports).ok_or_else(|| {
+                    total = total.checked_add(*lamports as i128).ok_or_else(|| {
                         log::error!("Outflow calculation overflow in SystemCreateAccount");
                         KoraError::ValidationError("Outflow calculation overflow".to_string())
                     })?;
@@ -446,13 +453,16 @@ impl FeeConfigUtil {
             } = instruction
             {
                 if *nonce_authority == *fee_payer_pubkey {
-                    total = total.checked_add(*lamports).ok_or_else(|| {
+                    total = total.checked_add(*lamports as i128).ok_or_else(|| {
                         log::error!("Outflow calculation overflow in SystemWithdrawNonceAccount");
                         KoraError::ValidationError("Outflow calculation overflow".to_string())
                     })?;
                 }
                 if *recipient == *fee_payer_pubkey {
-                    total = total.saturating_sub(*lamports);
+                    total = total.checked_sub(*lamports as i128).ok_or_else(|| {
+                        log::error!("Inflow calculation overflow in SystemWithdrawNonceAccount");
+                        KoraError::ValidationError("Inflow calculation overflow".to_string())
+                    })?;
                 }
             }
         }
@@ -472,7 +482,7 @@ impl FeeConfigUtil {
             )
             .await?;
 
-            total = total.checked_add(spl_outflow).ok_or_else(|| {
+            total = total.checked_add(spl_outflow as i128).ok_or_else(|| {
                 log::error!("Fee payer outflow overflow: sol={}, spl={}", total, spl_outflow);
                 KoraError::ValidationError("Fee payer outflow calculation overflow".to_string())
             })?;
@@ -842,7 +852,7 @@ mod tests {
         )
         .await
         .unwrap();
-        assert_eq!(outflow, 0, "Transfer to fee payer should subtract from outflow (saturating)");
+        assert_eq!(outflow, -50_000, "Transfer to fee payer should be negative (net inflow)");
 
         // Test 3: Other account as sender - should not affect outflow
         let other_sender = Pubkey::new_unique();
@@ -918,8 +928,8 @@ mod tests {
         .await
         .unwrap();
         assert_eq!(
-            outflow, 0,
-            "TransferWithSeed to fee payer should subtract from outflow (saturating)"
+            outflow, -75_000,
+            "TransferWithSeed to fee payer should be negative (net inflow)"
         );
     }
 
@@ -1051,8 +1061,8 @@ mod tests {
         .await
         .unwrap();
         assert_eq!(
-            outflow, 0,
-            "WithdrawNonceAccount to fee payer should subtract from outflow (saturating)"
+            outflow, -25_000,
+            "WithdrawNonceAccount to fee payer should be negative (net inflow)"
         );
     }
 

--- a/crates/lib/src/fee/fee.rs
+++ b/crates/lib/src/fee/fee.rs
@@ -448,16 +448,12 @@ impl FeeConfigUtil {
         {
             if let ParsedSystemInstructionData::SystemWithdrawNonceAccount {
                 lamports,
-                nonce_authority,
                 recipient,
+                ..
             } = instruction
             {
-                if *nonce_authority == *fee_payer_pubkey {
-                    total = total.checked_add(*lamports as i128).ok_or_else(|| {
-                        log::error!("Outflow calculation overflow in SystemWithdrawNonceAccount");
-                        KoraError::ValidationError("Outflow calculation overflow".to_string())
-                    })?;
-                }
+                // Funds are withdrawn from the nonce account, not from the authority.
+                // Only the recipient matters for fee payer flow: it's an inflow.
                 if *recipient == *fee_payer_pubkey {
                     total = total.checked_sub(*lamports as i128).ok_or_else(|| {
                         log::error!("Inflow calculation overflow in SystemWithdrawNonceAccount");
@@ -1022,7 +1018,8 @@ mod tests {
         let fee_payer = Pubkey::new_unique();
         let recipient = Pubkey::new_unique();
 
-        // Test 1: Fee payer as nonce account (outflow)
+        // Test 1: Fee payer as nonce authority - should NOT add to outflow
+        // (funds come from the nonce account, not the authority)
         let withdraw_instruction =
             withdraw_nonce_account(&nonce_account, &fee_payer, &recipient, 50_000);
         let message =
@@ -1039,8 +1036,8 @@ mod tests {
         .await
         .unwrap();
         assert_eq!(
-            outflow, 50_000,
-            "WithdrawNonceAccount from fee payer nonce should add to outflow"
+            outflow, 0,
+            "WithdrawNonceAccount with fee payer as authority should not affect outflow"
         );
 
         // Test 2: Fee payer as recipient (inflow)

--- a/crates/lib/src/token/token.rs
+++ b/crates/lib/src/token/token.rs
@@ -419,10 +419,7 @@ impl TokenUtil {
         config: &Config,
     ) -> Result<u64, KoraError> {
         // Collect all outflow transfers (fee payer as source) grouped by mint
-        let mut mint_to_transfers: HashMap<
-            Pubkey,
-            Vec<(u64, bool)>, // (amount, is_2022)
-        > = HashMap::new();
+        let mut mint_to_transfers: HashMap<Pubkey, Vec<u64>> = HashMap::new();
 
         for transfer in spl_transfers {
             if let ParsedSPLInstructionData::SplTokenTransfer {
@@ -430,7 +427,6 @@ impl TokenUtil {
                 owner,
                 mint,
                 source_address,
-                is_2022,
                 ..
             } = transfer
             {
@@ -454,10 +450,7 @@ impl TokenUtil {
                             })?;
                         token_account.mint()
                     };
-                    mint_to_transfers
-                        .entry(mint_pubkey)
-                        .or_default()
-                        .push((*amount, *is_2022));
+                    mint_to_transfers.entry(mint_pubkey).or_default().push(*amount);
                 }
             }
         }
@@ -516,7 +509,7 @@ impl TokenUtil {
                 .get(mint)
                 .ok_or_else(|| KoraError::RpcError(format!("No decimals data for mint {mint}")))?;
 
-            for (amount, _is_2022) in transfers {
+            for amount in transfers {
                 // Convert token amount to lamports value using Decimal
                 let amount_decimal = Decimal::from_u64(*amount).ok_or_else(|| {
                     KoraError::ValidationError("Invalid transfer amount".to_string())

--- a/crates/lib/src/token/token.rs
+++ b/crates/lib/src/token/token.rs
@@ -21,7 +21,6 @@ use rust_decimal::{
 };
 use solana_client::nonblocking::rpc_client::RpcClient;
 use solana_sdk::{instruction::Instruction, native_token::LAMPORTS_PER_SOL, pubkey::Pubkey};
-use spl_associated_token_account_interface::address::get_associated_token_address_with_program_id;
 use std::{
     collections::{HashMap, HashSet},
     str::FromStr,
@@ -419,10 +418,10 @@ impl TokenUtil {
         rpc_client: &RpcClient,
         config: &Config,
     ) -> Result<u64, KoraError> {
-        // Collect all unique mints that need price lookups
+        // Collect all outflow transfers (fee payer as source) grouped by mint
         let mut mint_to_transfers: HashMap<
             Pubkey,
-            Vec<(u64, bool, bool)>, // (amount, is_outflow, is_2022)
+            Vec<(u64, bool)>, // (amount, is_2022)
         > = HashMap::new();
 
         for transfer in spl_transfers {
@@ -431,12 +430,11 @@ impl TokenUtil {
                 owner,
                 mint,
                 source_address,
-                destination_address,
                 is_2022,
                 ..
             } = transfer
             {
-                // Check if fee payer is the source (outflow)
+                // Only count outflows (fee payer as source)
                 if *owner == *fee_payer {
                     let mint_pubkey = if let Some(m) = mint {
                         *m
@@ -459,68 +457,7 @@ impl TokenUtil {
                     mint_to_transfers
                         .entry(mint_pubkey)
                         .or_default()
-                        .push((*amount, true, *is_2022));
-                } else {
-                    // Check if fee payer owns the destination (inflow)
-                    // We need to check the destination token account owner
-                    if let Some(mint_pubkey) = mint {
-                        // Get destination account to check owner
-                        match CacheUtil::get_account(config, rpc_client, destination_address, false)
-                            .await
-                        {
-                            Ok(dest_account) => {
-                                let token_program =
-                                    TokenType::get_token_program_from_owner(&dest_account.owner)?;
-                                let token_account = token_program
-                                    .unpack_token_account(&dest_account.data)
-                                    .map_err(|e| {
-                                        KoraError::TokenOperationError(format!(
-                                            "Failed to unpack destination token account {}: {}",
-                                            destination_address, e
-                                        ))
-                                    })?;
-                                if token_account.owner() == *fee_payer {
-                                    mint_to_transfers
-                                        .entry(*mint_pubkey)
-                                        .or_default()
-                                        .push((*amount, false, *is_2022)); // inflow
-                                }
-                            }
-                            Err(e) => {
-                                // If we get Account not found error, we try to match it to the ATA derivation for the fee payer
-                                // in case that ATA is being created in the current instruction
-                                if matches!(e, KoraError::AccountNotFound(_)) {
-                                    let spl_ata =
-                                        spl_associated_token_account_interface::address::get_associated_token_address(
-                                            fee_payer,
-                                            mint_pubkey,
-                                        );
-                                    let token2022_ata =
-                                        get_associated_token_address_with_program_id(
-                                            fee_payer,
-                                            mint_pubkey,
-                                            &spl_token_2022_interface::id(),
-                                        );
-
-                                    // If destination matches a valid ATA for fee payer, count as inflow
-                                    if *destination_address == spl_ata
-                                        || *destination_address == token2022_ata
-                                    {
-                                        mint_to_transfers
-                                            .entry(*mint_pubkey)
-                                            .or_default()
-                                            .push((*amount, false, *is_2022)); // inflow
-                                    }
-                                    // Otherwise, it's not fee payer's account, continue to next transfer
-                                } else {
-                                    // Skip if destination account doesn't exist or can't be fetched
-                                    // This could be problematic for non ATA token accounts created
-                                    // during the transaction
-                                    continue;
-                                }
-                            }
-                        }
-                    }
+                        .push((*amount, *is_2022));
                 }
             }
         }
@@ -569,10 +506,7 @@ impl TokenUtil {
             mint_decimals.insert(*mint, decimals);
         }
 
-        // Calculate total value
-        let mut total_lamports = 0u64;
-        let mut token2022_mints: HashMap<Pubkey, Box<dyn TokenMint>> = HashMap::new();
-        let mut cached_epoch: Option<u64> = None;
+        let mut total_lamports: u64 = 0;
 
         for (mint, transfers) in mint_to_transfers.iter() {
             let price = prices
@@ -582,25 +516,9 @@ impl TokenUtil {
                 .get(mint)
                 .ok_or_else(|| KoraError::RpcError(format!("No decimals data for mint {mint}")))?;
 
-            for (amount, is_outflow, is_2022) in transfers {
-                let mut effective_amount = *amount;
-
-                // Token2022 transfer fees are withheld from destination credits.
-                // Net inflows to fee-payer-owned accounts must be credited post-fee.
-                if *is_2022 && !*is_outflow {
-                    effective_amount = Self::calculate_token2022_net_amount(
-                        *amount,
-                        mint,
-                        rpc_client,
-                        config,
-                        &mut cached_epoch,
-                        &mut token2022_mints,
-                    )
-                    .await?;
-                }
-
+            for (amount, _is_2022) in transfers {
                 // Convert token amount to lamports value using Decimal
-                let amount_decimal = Decimal::from_u64(effective_amount).ok_or_else(|| {
+                let amount_decimal = Decimal::from_u64(*amount).ok_or_else(|| {
                     KoraError::ValidationError("Invalid transfer amount".to_string())
                 })?;
                 let decimals_scale = Decimal::from_u64(10u64.pow(*decimals as u32))
@@ -616,7 +534,7 @@ impl TokenUtil {
                     .and_then(|result| result.checked_div(decimals_scale))
                     .ok_or_else(|| {
                         log::error!("Token value calculation overflow: amount={}, price={}, decimals={}, lamports_per_sol={}",
-                            effective_amount,
+                            amount,
                             price.price,
                             decimals,
                             lamports_per_sol
@@ -628,16 +546,10 @@ impl TokenUtil {
                     KoraError::ValidationError("Lamports value overflow".to_string())
                 })?;
 
-                if *is_outflow {
-                    // Add outflow to total
-                    total_lamports = total_lamports.checked_add(lamports).ok_or_else(|| {
-                        log::error!("SPL outflow calculation overflow");
-                        KoraError::ValidationError("SPL outflow calculation overflow".to_string())
-                    })?;
-                } else {
-                    // Subtract inflow from total (using saturating_sub to prevent underflow)
-                    total_lamports = total_lamports.saturating_sub(lamports);
-                }
+                total_lamports = total_lamports.checked_add(lamports).ok_or_else(|| {
+                    log::error!("SPL outflow calculation overflow");
+                    KoraError::ValidationError("SPL outflow calculation overflow".to_string())
+                })?;
             }
         }
 
@@ -967,6 +879,8 @@ mod tests_token {
         pod::PodMint,
     };
 
+    use spl_associated_token_account_interface::address::get_associated_token_address_with_program_id;
+
     use super::*;
 
     fn create_token2022_mint_account_with_transfer_fee(
@@ -1287,12 +1201,12 @@ mod tests_token {
     }
 
     #[tokio::test]
-    async fn test_calculate_spl_transfers_value_in_lamports_token2022_inflow_uses_net_amount() {
+    async fn test_calculate_spl_transfers_value_in_lamports_ignores_inflows() {
         let _lock = ConfigMockBuilder::new().with_cache_enabled(false).build_and_setup();
         let config = get_config().unwrap();
 
         let fee_payer = Pubkey::new_unique();
-        let attacker = Pubkey::new_unique();
+        let other = Pubkey::new_unique();
         let mint = Pubkey::from_str(USDC_DEVNET_MINT).unwrap();
         let amount = 100_000_000u64; // 100 USDC
 
@@ -1302,18 +1216,19 @@ mod tests_token {
             &spl_token_2022_interface::id(),
         );
 
+        // One outflow from fee payer, one inflow to fee payer — only outflow should be counted
         let spl_transfers = vec![
             ParsedSPLInstructionData::SplTokenTransfer {
                 amount,
                 owner: fee_payer,
                 mint: Some(mint),
                 source_address: Pubkey::new_unique(),
-                destination_address: attacker,
+                destination_address: other,
                 is_2022: true,
             },
             ParsedSPLInstructionData::SplTokenTransfer {
                 amount,
-                owner: attacker,
+                owner: other,
                 mint: Some(mint),
                 source_address: Pubkey::new_unique(),
                 destination_address: fee_payer_token2022_ata,
@@ -1321,10 +1236,7 @@ mod tests_token {
             },
         ];
 
-        let mint_account = create_token2022_mint_account_with_transfer_fee(6, 100, 1_000_000);
-        let rpc_client = RpcMockBuilder::new()
-            .with_account_not_found()
-            .build_with_sequential_accounts(vec![&mint_account, &mint_account]);
+        let rpc_client = RpcMockBuilder::new().with_mint_account(6).build();
 
         let spl_outflow_value = TokenUtil::calculate_spl_transfers_value_in_lamports(
             &spl_transfers,
@@ -1335,9 +1247,9 @@ mod tests_token {
         .await
         .unwrap();
 
-        // Fee payer sends 100 USDC out and receives 99 USDC back (1 USDC transfer fee withheld).
-        // Expected net outflow = 1 USDC => 7_500_000 lamports at mock pricing.
-        assert_eq!(spl_outflow_value, 7_500_000);
+        // Only fee payer's outflow of 100 USDC is counted; the inflow is ignored.
+        // 100 USDC at mock price = 750_000_000 lamports.
+        assert_eq!(spl_outflow_value, 750_000_000);
     }
 
     #[tokio::test]

--- a/crates/lib/src/validator/transaction_validator.rs
+++ b/crates/lib/src/validator/transaction_validator.rs
@@ -540,13 +540,14 @@ impl TransactionValidator {
         transaction_resolved: &mut VersionedTransactionResolved,
         rpc_client: &RpcClient,
     ) -> Result<u64, KoraError> {
-        FeeConfigUtil::calculate_fee_payer_outflow(
+        let net = FeeConfigUtil::calculate_fee_payer_outflow(
             &self.fee_payer_pubkey,
             transaction_resolved,
             rpc_client,
             config,
         )
-        .await
+        .await?;
+        Ok(net.max(0) as u64)
     }
 
     pub async fn validate_token_payment(


### PR DESCRIPTION
  - Use signed arithmetic (i128) for fee payer outflow accumulation. The total and total_lamports accumulators in calculate_fee_payer_outflow and calculate_spl_transfers_value_in_lamports were u64, so 
  saturating_sub on 0 silently discarded inflows when they were processed before outflows (e.g. inflow 100 then outflow 200 → 200 instead of the correct 100). Switching to i128 lets negative
  intermediate values propagate correctly and offset the base fee in estimate_transaction_fee.                                                                                                           
  - Remove SPL token inflow detection from calculate_spl_transfers_value_in_lamports. estimate_kora_fee returns the net outflow of SOL plus the gross outflow of SPL tokens, and then                  
  validate_token_payment independently verifies that the gross inflow of SPL covers this value. Netting SPL inflows inside the outflow calculation was therefore incorrect — it double-counted inflows   
  and required unnecessary RPC calls to resolve destination token accounts.
  - Remove incorrect nonce authority outflow in WithdrawNonceAccount. WithdrawNonceAccount withdraws funds from the nonce account, not from the authority. The fee payer being the nonce_authority does  
  not constitute an outflow — only the recipient case (inflow to fee payer) is relevant.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/solana-foundation/kora/pull/427" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
