### PR TITLE
fix(security): validate CreateAccount owner program against allowed list

### DIFF
--- a/crates/lib/src/transaction/instruction_util.rs
+++ b/crates/lib/src/transaction/instruction_util.rs
@@ -47,6 +47,7 @@ pub enum ParsedSystemInstructionData {
         lamports: u64,
         payer: Pubkey,
         new_account: Pubkey,
+        owner: Pubkey,
     },
     // Includes withdraw nonce account
     SystemWithdrawNonceAccount {
@@ -1515,10 +1516,10 @@ impl IxUtils {
             // Handle System Program transfers and account creation
             if program_id == SYSTEM_PROGRAM_ID {
                 match bincode::deserialize::<SystemInstruction>(&instruction.data) {
-                    Ok(SystemInstruction::CreateAccount { lamports, .. })
-                    | Ok(SystemInstruction::CreateAccountWithSeed { lamports, .. }) => {
+                    Ok(SystemInstruction::CreateAccount { lamports, owner, .. })
+                    | Ok(SystemInstruction::CreateAccountWithSeed { lamports, owner, .. }) => {
                         parse_system_instruction!(parsed_instructions, instruction, system_create_account, SystemCreateAccount, SystemCreateAccount {
-                            lamports: lamports;
+                            lamports: lamports, owner: owner;
                             payer: instruction_indexes::system_create_account::PAYER_INDEX,
                             new_account: instruction_indexes::system_create_account::NEW_ACCOUNT_INDEX
                         });
@@ -3187,10 +3188,12 @@ mod tests {
                 lamports: parsed_lamports,
                 payer: parsed_payer,
                 new_account: parsed_new_account,
+                owner: parsed_owner,
             } => {
                 assert_eq!(*parsed_lamports, lamports);
                 assert_eq!(*parsed_payer, payer.pubkey());
                 assert_eq!(*parsed_new_account, new_account.pubkey());
+                assert_eq!(*parsed_owner, owner);
             }
             _ => panic!("Expected SystemCreateAccount variant"),
         }
@@ -3243,10 +3246,12 @@ mod tests {
                 lamports: parsed_lamports,
                 payer: parsed_payer,
                 new_account: parsed_new_account,
+                owner: parsed_owner,
             } => {
                 assert_eq!(*parsed_lamports, lamports);
                 assert_eq!(*parsed_payer, payer.pubkey());
                 assert_eq!(*parsed_new_account, new_account);
+                assert_eq!(*parsed_owner, owner);
             }
             _ => panic!("Expected SystemCreateAccount variant"),
         }

--- a/crates/lib/src/validator/macros.rs
+++ b/crates/lib/src/validator/macros.rs
@@ -1,5 +1,21 @@
 /// Macro to validate system instructions with consistent pattern
 macro_rules! validate_system {
+    ($self:expr, $instructions:expr, $type:ident, $pattern:pat => $account:expr, $policy:expr, $name:expr, $extra:block) => {
+        for instruction in $instructions.get(&ParsedSystemInstructionType::$type).unwrap_or(&vec![])
+        {
+            if let $pattern = instruction {
+                if *$account == $self.fee_payer_pubkey {
+                    if !$policy {
+                        return Err(KoraError::InvalidTransaction(format!(
+                            "Fee payer cannot be used for '{}'",
+                            $name
+                        )));
+                    }
+                    $extra
+                }
+            }
+        }
+    };
     ($self:expr, $instructions:expr, $type:ident, $pattern:pat => $account:expr, $policy:expr, $name:expr) => {
         for instruction in $instructions.get(&ParsedSystemInstructionType::$type).unwrap_or(&vec![])
         {

--- a/crates/lib/src/validator/transaction_validator.rs
+++ b/crates/lib/src/validator/transaction_validator.rs
@@ -254,33 +254,21 @@ impl TransactionValidator {
             self.fee_payer_policy.system.allow_allocate, "System Allocate");
 
         validate_system!(self, system_instructions, SystemCreateAccount,
-            ParsedSystemInstructionData::SystemCreateAccount { payer, .. } => payer,
-            self.fee_payer_policy.system.allow_create_account, "System Create Account");
-
-        // Validate CreateAccount owner program is allowed
-        for instruction in system_instructions
-            .get(&ParsedSystemInstructionType::SystemCreateAccount)
-            .unwrap_or(&vec![])
-        {
-            if let ParsedSystemInstructionData::SystemCreateAccount { owner, payer, .. } =
-                instruction
-            {
-                if *payer == self.fee_payer_pubkey {
-                    if !self.allowed_programs.contains(owner) {
-                        return Err(KoraError::InvalidTransaction(format!(
-                            "CreateAccount owner program {} is not in the allowed programs list",
-                            owner
-                        )));
-                    }
-                    if self.disallowed_accounts.contains(owner) {
-                        return Err(KoraError::InvalidTransaction(format!(
-                            "CreateAccount owner program {} is in the disallowed accounts list",
-                            owner
-                        )));
-                    }
-                }
+        ParsedSystemInstructionData::SystemCreateAccount { payer, owner, .. } => payer,
+        self.fee_payer_policy.system.allow_create_account, "System Create Account", {
+            if !self.allowed_programs.contains(owner) {
+                return Err(KoraError::InvalidTransaction(format!(
+                    "CreateAccount owner program {} is not in the allowed programs list",
+                    owner
+                )));
             }
-        }
+            if self.disallowed_accounts.contains(owner) {
+                return Err(KoraError::InvalidTransaction(format!(
+                    "CreateAccount owner program {} is in the disallowed accounts list",
+                    owner
+                )));
+            }
+        });
 
         validate_system!(self, system_instructions, SystemInitializeNonceAccount,
             ParsedSystemInstructionData::SystemInitializeNonceAccount { nonce_authority, .. } => nonce_authority,

--- a/crates/lib/src/validator/transaction_validator.rs
+++ b/crates/lib/src/validator/transaction_validator.rs
@@ -257,6 +257,31 @@ impl TransactionValidator {
             ParsedSystemInstructionData::SystemCreateAccount { payer, .. } => payer,
             self.fee_payer_policy.system.allow_create_account, "System Create Account");
 
+        // Validate CreateAccount owner program is allowed
+        for instruction in system_instructions
+            .get(&ParsedSystemInstructionType::SystemCreateAccount)
+            .unwrap_or(&vec![])
+        {
+            if let ParsedSystemInstructionData::SystemCreateAccount { owner, payer, .. } =
+                instruction
+            {
+                if *payer == self.fee_payer_pubkey {
+                    if !self.allowed_programs.contains(owner) {
+                        return Err(KoraError::InvalidTransaction(format!(
+                            "CreateAccount owner program {} is not in the allowed programs list",
+                            owner
+                        )));
+                    }
+                    if self.disallowed_accounts.contains(owner) {
+                        return Err(KoraError::InvalidTransaction(format!(
+                            "CreateAccount owner program {} is in the disallowed accounts list",
+                            owner
+                        )));
+                    }
+                }
+            }
+        }
+
         validate_system!(self, system_instructions, SystemInitializeNonceAccount,
             ParsedSystemInstructionData::SystemInitializeNonceAccount { nonce_authority, .. } => nonce_authority,
             self.fee_payer_policy.system.nonce.allow_initialize, "System Initialize Nonce Account");
@@ -2501,7 +2526,8 @@ mod tests {
 
         let fee_payer = Pubkey::new_unique();
         let new_account = Pubkey::new_unique();
-        let owner = Pubkey::new_unique();
+        // Use System Program as owner since it's in allowed_programs
+        let owner = SYSTEM_PROGRAM_ID;
 
         // Test with allow_create_account = true
         let rpc_client = RpcMockBuilder::new().build();
@@ -2536,6 +2562,65 @@ mod tests {
             .validate_transaction(config, &mut transaction, &rpc_client)
             .await
             .is_err());
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_fee_payer_policy_create_account_rejects_disallowed_owner() {
+        use solana_system_interface::instruction::create_account;
+
+        let fee_payer = Pubkey::new_unique();
+        let new_account = Pubkey::new_unique();
+        let disallowed_owner = Pubkey::new_unique();
+
+        let rpc_client = RpcMockBuilder::new().build();
+        let mut policy = FeePayerPolicy::default();
+        policy.system.allow_create_account = true;
+        setup_config_with_policy(policy);
+
+        let config = get_config().unwrap();
+        let validator = TransactionValidator::new(config, fee_payer).unwrap();
+        let instruction = create_account(&fee_payer, &new_account, 1000, 100, &disallowed_owner);
+        let message = VersionedMessage::Legacy(Message::new(&[instruction], Some(&fee_payer)));
+        let mut transaction =
+            TransactionUtil::new_unsigned_versioned_transaction_resolved(message).unwrap();
+
+        let result = validator.validate_transaction(config, &mut transaction, &rpc_client).await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("not in the allowed programs list"));
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_fee_payer_policy_create_account_allows_valid_owner() {
+        use solana_system_interface::instruction::create_account;
+
+        let fee_payer = Pubkey::new_unique();
+        let new_account = Pubkey::new_unique();
+        let allowed_owner = Pubkey::new_unique();
+
+        let rpc_client = RpcMockBuilder::new().build();
+        let mut policy = FeePayerPolicy::default();
+        policy.system.allow_create_account = true;
+        let config = ConfigMockBuilder::new()
+            .with_price_source(PriceSource::Mock)
+            .with_allowed_programs(vec![SYSTEM_PROGRAM_ID.to_string(), allowed_owner.to_string()])
+            .with_max_allowed_lamports(1_000_000)
+            .with_fee_payer_policy(policy)
+            .build();
+        setup_both_configs(config);
+
+        let config = get_config().unwrap();
+        let validator = TransactionValidator::new(config, fee_payer).unwrap();
+        let instruction = create_account(&fee_payer, &new_account, 1000, 100, &allowed_owner);
+        let message = VersionedMessage::Legacy(Message::new(&[instruction], Some(&fee_payer)));
+        let mut transaction =
+            TransactionUtil::new_unsigned_versioned_transaction_resolved(message).unwrap();
+
+        assert!(validator
+            .validate_transaction(config, &mut transaction, &rpc_client)
+            .await
+            .is_ok());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- Parses the `owner` program field from `SystemCreateAccount`/`CreateAccountWithSeed` instructions (previously discarded with `..`)
- Validates the owner program is in `allowed_programs` and not in `disallowed_accounts` when the fee payer funds the account creation
- Adds unit tests for both rejection (disallowed owner) and acceptance (allowed owner) paths

**Addresses KORA-18 from security scan #2 (TOO-314).**

## Context
The instruction parser was discarding the `owner` field from `CreateAccount` instructions, meaning validation never checked what program would own the newly created account. An attacker could create accounts owned by arbitrary programs (including those not in `allowed_programs`) using the fee payer's funds.

## Test plan
- [x] Existing `test_fee_payer_policy_create_account` updated to use allowed owner — passes
- [x] New `test_fee_payer_policy_create_account_rejects_disallowed_owner` — verifies rejection
- [x] New `test_fee_payer_policy_create_account_allows_valid_owner` — verifies custom allowed owner passes
- [x] All instruction_util parsing tests pass (owner field now asserted)
- [x] `cargo build` succeeds
- [x] `cargo fmt` clean
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/solana-foundation/kora/pull/431" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->



## 📊 Unit Test Coverage
![Coverage](https://img.shields.io/badge/coverage-85.6%25-green)

**Unit Test Coverage: 85.6%**

[View Detailed Coverage Report](https://github.com/solana-foundation/kora/actions/runs/24731123168)