### PR TITLE
fix(security): harden Token-2022 extension catch-all and parse failures

### DIFF
--- a/crates/lib/src/bundle/helper.rs
+++ b/crates/lib/src/bundle/helper.rs
@@ -133,7 +133,7 @@ impl BundleProcessor {
             }
 
             validator.validate_transaction(config, &mut resolved_tx, rpc_client).await?;
-            validator.validate_token2022_signing_policies(
+            validator.validate_token2022_transfer_hook_signing_policies(
                 config,
                 &mut resolved_tx,
                 transfer_hook_validation_flow,

--- a/crates/lib/src/bundle/helper.rs
+++ b/crates/lib/src/bundle/helper.rs
@@ -133,6 +133,11 @@ impl BundleProcessor {
             }
 
             validator.validate_transaction(config, &mut resolved_tx, rpc_client).await?;
+            validator.validate_token2022_signing_policies(
+                config,
+                &mut resolved_tx,
+                transfer_hook_validation_flow,
+            )?;
             if let Some(context) = plugin_context {
                 plugin_runner
                     .run(&mut resolved_tx, config, rpc_client, &fee_payer, context)

--- a/crates/lib/src/token/token.rs
+++ b/crates/lib/src/token/token.rs
@@ -118,7 +118,7 @@ pub struct AtaCreationInstructionInfo {
 }
 
 impl TokenUtil {
-    fn should_reject_mutable_transfer_hook(
+    pub(crate) fn should_reject_mutable_transfer_hook(
         config: &Config,
         validation_flow: TransferHookValidationFlow,
     ) -> bool {

--- a/crates/lib/src/transaction/instruction_util.rs
+++ b/crates/lib/src/transaction/instruction_util.rs
@@ -2070,15 +2070,26 @@ impl IxUtils {
                     };
                 }
             } else if program_id == spl_token_2022_interface::ID {
-                let spl_ix = spl_token_2022_interface::instruction::TokenInstruction::unpack(
+                let spl_ix = match spl_token_2022_interface::instruction::TokenInstruction::unpack(
                     &instruction.data,
-                )
-                .map_err(|e| {
-                    KoraError::InvalidTransaction(format!(
-                        "Failed to parse Token-2022 instruction: {}",
-                        sanitize_error!(e)
-                    ))
-                })?;
+                ) {
+                    Ok(ix) => ix,
+                    Err(_) => {
+                        // Cannot decode as a base token instruction — this is either a
+                        // Token-2022 extension-specific encoding (e.g. ReallocateAccount,
+                        // extension initializers) or genuinely malformed data.  Either way,
+                        // capture all accounts so the validator can reject if the fee payer
+                        // appears among them.
+                        Self::push_parsed_spl_instruction(
+                            &mut parsed_instructions,
+                            ParsedSPLInstructionType::SplTokenUnknownExtension,
+                            ParsedSPLInstructionData::SplTokenUnknownExtension {
+                                accounts: instruction.accounts.iter().map(|a| a.pubkey).collect(),
+                            },
+                        );
+                        continue;
+                    }
+                };
                 match spl_ix {
                         #[allow(deprecated)]
                         spl_token_2022_interface::instruction::TokenInstruction::Transfer { amount } => {
@@ -3630,7 +3641,7 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_token_2022_malformed_instruction_returns_error() {
+    fn test_parse_token_2022_malformed_instruction_accounts_captured() {
         use crate::transaction::versioned_transaction::VersionedTransactionResolved;
         use solana_message::{Message, VersionedMessage};
         use solana_sdk::{
@@ -3644,7 +3655,7 @@ mod tests {
         let ix = Instruction {
             program_id: spl_token_2022_interface::ID,
             accounts: vec![AccountMeta::new(payer.pubkey(), true)],
-            data: vec![0xFF, 0xFF, 0xFF], // garbage data — won't unpack
+            data: vec![0xFF, 0xFF, 0xFF], // garbage data — won't unpack as base instruction
         };
 
         let message = VersionedMessage::Legacy(Message::new(&[ix], Some(&payer.pubkey())));
@@ -3652,13 +3663,25 @@ mod tests {
         let resolved_tx = VersionedTransactionResolved::from_kora_built_transaction(&tx)
             .expect("Failed to create resolved transaction");
 
+        // Malformed (or extension-encoded) instructions must NOT error at parse time.
+        // Their accounts are captured as SplTokenUnknownExtension so the validator can
+        // still reject if the fee payer appears among them.
         let result = IxUtils::parse_token_instructions(&resolved_tx);
-        assert!(result.is_err(), "Malformed Token-2022 instruction must return an error");
-        let err = result.unwrap_err().to_string();
-        assert!(
-            err.contains("Failed to parse Token-2022 instruction"),
-            "Error message should describe the parse failure, got: {err}"
-        );
+        assert!(result.is_ok(), "Unparseable Token-2022 instruction must not error at parse time");
+        let parsed = result.unwrap();
+
+        let unknown = parsed.get(&ParsedSPLInstructionType::SplTokenUnknownExtension);
+        assert!(unknown.is_some(), "Accounts should be captured as SplTokenUnknownExtension");
+        let entries = unknown.unwrap();
+        assert_eq!(entries.len(), 1);
+        if let ParsedSPLInstructionData::SplTokenUnknownExtension { accounts } = &entries[0] {
+            assert!(
+                accounts.contains(&payer.pubkey()),
+                "Fee payer pubkey must be captured so validator can check it"
+            );
+        } else {
+            panic!("Expected SplTokenUnknownExtension variant");
+        }
     }
 
     #[test]

--- a/crates/lib/src/transaction/instruction_util.rs
+++ b/crates/lib/src/transaction/instruction_util.rs
@@ -10,6 +10,7 @@ use solana_sdk::{
     pubkey::Pubkey,
 };
 use solana_system_interface::{instruction::SystemInstruction, program::ID as SYSTEM_PROGRAM_ID};
+use solana_transaction_status::parse_token::UiExtensionType;
 use solana_transaction_status_client_types::{
     UiInstruction, UiParsedInstruction, UiPartiallyDecodedInstruction,
 };
@@ -352,6 +353,7 @@ pub const PARSED_DATA_FIELD_FREEZE_ACCOUNT: &str = "freezeAccount";
 pub const PARSED_DATA_FIELD_THAW_ACCOUNT: &str = "thawAccount";
 pub const PARSED_DATA_FIELD_GET_ACCOUNT_DATA_SIZE: &str = "getAccountDataSize";
 pub const PARSED_DATA_FIELD_INITIALIZE_IMMUTABLE_OWNER: &str = "initializeImmutableOwner";
+pub const PARSED_DATA_FIELD_EXTENSION_TYPES: &str = "extensionTypes";
 
 // Additional field names for new instructions
 pub const PARSED_DATA_FIELD_MINT_AUTHORITY: &str = "mintAuthority";
@@ -415,6 +417,114 @@ impl IxUtils {
             "Field '{}' is neither a number nor a string",
             field_name
         )))
+    }
+
+    fn get_token2022_extension_types(
+        info: &serde_json::Value,
+    ) -> Result<Vec<spl_token_2022_interface::extension::ExtensionType>, KoraError> {
+        let Some(extension_types) = info.get(PARSED_DATA_FIELD_EXTENSION_TYPES) else {
+            return Ok(vec![]);
+        };
+
+        let extension_types: Vec<UiExtensionType> = serde_json::from_value(extension_types.clone())
+            .map_err(|e| {
+                KoraError::SerializationError(format!(
+                    "Field '{}' is not a valid Token-2022 extension list: {}",
+                    PARSED_DATA_FIELD_EXTENSION_TYPES, e
+                ))
+            })?;
+
+        extension_types
+            .into_iter()
+            .map(|extension_type| {
+                Ok(match extension_type {
+                    UiExtensionType::Uninitialized => {
+                        spl_token_2022_interface::extension::ExtensionType::Uninitialized
+                    }
+                    UiExtensionType::TransferFeeConfig => {
+                        spl_token_2022_interface::extension::ExtensionType::TransferFeeConfig
+                    }
+                    UiExtensionType::TransferFeeAmount => {
+                        spl_token_2022_interface::extension::ExtensionType::TransferFeeAmount
+                    }
+                    UiExtensionType::MintCloseAuthority => {
+                        spl_token_2022_interface::extension::ExtensionType::MintCloseAuthority
+                    }
+                    UiExtensionType::ConfidentialTransferMint => {
+                        spl_token_2022_interface::extension::ExtensionType::ConfidentialTransferMint
+                    }
+                    UiExtensionType::ConfidentialTransferAccount => {
+                        spl_token_2022_interface::extension::ExtensionType::ConfidentialTransferAccount
+                    }
+                    UiExtensionType::DefaultAccountState => {
+                        spl_token_2022_interface::extension::ExtensionType::DefaultAccountState
+                    }
+                    UiExtensionType::ImmutableOwner => {
+                        spl_token_2022_interface::extension::ExtensionType::ImmutableOwner
+                    }
+                    UiExtensionType::MemoTransfer => {
+                        spl_token_2022_interface::extension::ExtensionType::MemoTransfer
+                    }
+                    UiExtensionType::NonTransferable => {
+                        spl_token_2022_interface::extension::ExtensionType::NonTransferable
+                    }
+                    UiExtensionType::InterestBearingConfig => {
+                        spl_token_2022_interface::extension::ExtensionType::InterestBearingConfig
+                    }
+                    UiExtensionType::CpiGuard => {
+                        spl_token_2022_interface::extension::ExtensionType::CpiGuard
+                    }
+                    UiExtensionType::PermanentDelegate => {
+                        spl_token_2022_interface::extension::ExtensionType::PermanentDelegate
+                    }
+                    UiExtensionType::NonTransferableAccount => {
+                        spl_token_2022_interface::extension::ExtensionType::NonTransferableAccount
+                    }
+                    UiExtensionType::TransferHook => {
+                        spl_token_2022_interface::extension::ExtensionType::TransferHook
+                    }
+                    UiExtensionType::TransferHookAccount => {
+                        spl_token_2022_interface::extension::ExtensionType::TransferHookAccount
+                    }
+                    UiExtensionType::ConfidentialTransferFeeConfig => {
+                        spl_token_2022_interface::extension::ExtensionType::ConfidentialTransferFeeConfig
+                    }
+                    UiExtensionType::ConfidentialTransferFeeAmount => {
+                        spl_token_2022_interface::extension::ExtensionType::ConfidentialTransferFeeAmount
+                    }
+                    UiExtensionType::MetadataPointer => {
+                        spl_token_2022_interface::extension::ExtensionType::MetadataPointer
+                    }
+                    UiExtensionType::TokenMetadata => {
+                        spl_token_2022_interface::extension::ExtensionType::TokenMetadata
+                    }
+                    UiExtensionType::GroupPointer => {
+                        spl_token_2022_interface::extension::ExtensionType::GroupPointer
+                    }
+                    UiExtensionType::GroupMemberPointer => {
+                        spl_token_2022_interface::extension::ExtensionType::GroupMemberPointer
+                    }
+                    UiExtensionType::TokenGroup => {
+                        spl_token_2022_interface::extension::ExtensionType::TokenGroup
+                    }
+                    UiExtensionType::TokenGroupMember => {
+                        spl_token_2022_interface::extension::ExtensionType::TokenGroupMember
+                    }
+                    UiExtensionType::ConfidentialMintBurn => {
+                        spl_token_2022_interface::extension::ExtensionType::ConfidentialMintBurn
+                    }
+                    UiExtensionType::ScaledUiAmount => {
+                        spl_token_2022_interface::extension::ExtensionType::ScaledUiAmount
+                    }
+                    UiExtensionType::Pausable => {
+                        spl_token_2022_interface::extension::ExtensionType::Pausable
+                    }
+                    UiExtensionType::PausableAccount => {
+                        spl_token_2022_interface::extension::ExtensionType::PausableAccount
+                    }
+                })
+            })
+            .collect()
     }
 
     /// Helper method to get account index from hashmap with proper error handling
@@ -1419,7 +1529,18 @@ impl IxUtils {
                     }
                     PARSED_DATA_FIELD_INITIALIZE_ACCOUNT3 => {
                         // InitializeAccount3: [account, mint], owner in data
-                        (vec![18], vec![account_idx, mint_idx])
+                        let data = if is_spl_token_program {
+                            spl_token_interface::instruction::TokenInstruction::InitializeAccount3 {
+                                owner,
+                            }
+                            .pack()
+                        } else {
+                            spl_token_2022_interface::instruction::TokenInstruction::InitializeAccount3 {
+                                owner,
+                            }
+                            .pack()
+                        };
+                        (data, vec![account_idx, mint_idx])
                     }
                     _ => unreachable!(),
                 };
@@ -1497,8 +1618,9 @@ impl IxUtils {
                 let data = if is_spl_token_program {
                     spl_token_interface::instruction::TokenInstruction::GetAccountDataSize.pack()
                 } else {
+                    let extension_types = Self::get_token2022_extension_types(info)?;
                     spl_token_2022_interface::instruction::TokenInstruction::GetAccountDataSize {
-                        extension_types: vec![],
+                        extension_types,
                     }
                     .pack()
                 };
@@ -3235,12 +3357,13 @@ mod tests {
 
     fn create_parsed_token2022_get_account_data_size(
         mint: &Pubkey,
+        extension_types: &[spl_token_2022_interface::extension::ExtensionType],
     ) -> Result<solana_transaction_status_client_types::ParsedInstruction, Box<dyn std::error::Error>>
     {
         let solana_instruction = spl_token_2022_interface::instruction::get_account_data_size(
             &spl_token_2022_interface::ID,
             mint,
-            &[],
+            extension_types,
         )?;
 
         let message = Message::new(&[solana_instruction], None);
@@ -4749,7 +4872,7 @@ mod tests {
         )
         .expect("Failed to create get_account_data_size instruction");
 
-        let solana_parsed = create_parsed_token2022_get_account_data_size(&mint)
+        let solana_parsed = create_parsed_token2022_get_account_data_size(&mint, &[])
             .expect("Failed to create parsed instruction");
 
         let result = IxUtils::reconstruct_spl_token_instruction(
@@ -4761,6 +4884,97 @@ mod tests {
         let compiled = result.unwrap();
         assert_eq!(compiled.program_id_index, 0);
         assert_eq!(compiled.accounts, vec![1]); // mint index
+        assert_eq!(compiled.data, instruction.data);
+    }
+
+    fn create_parsed_token2022_initialize_account3(
+        account: &Pubkey,
+        mint: &Pubkey,
+        owner: &Pubkey,
+    ) -> Result<solana_transaction_status_client_types::ParsedInstruction, Box<dyn std::error::Error>>
+    {
+        let solana_instruction = spl_token_2022_interface::instruction::initialize_account3(
+            &spl_token_2022_interface::ID,
+            account,
+            mint,
+            owner,
+        )?;
+
+        let message = Message::new(&[solana_instruction], None);
+        let compiled_instruction = &message.instructions[0];
+
+        let account_keys_for_parsing = AccountKeys::new(&message.account_keys, None);
+
+        let parsed = parse_instruction::parse(
+            &spl_token_2022_interface::ID,
+            compiled_instruction,
+            &account_keys_for_parsing,
+            None,
+        )?;
+
+        Ok(parsed)
+    }
+
+    #[test]
+    fn test_reconstruct_token2022_get_account_data_size_instruction_with_extensions() {
+        let mint = Pubkey::new_unique();
+        let token_program_id = spl_token_2022_interface::ID;
+        let account_keys = vec![token_program_id, mint];
+        let extension_types = vec![
+            spl_token_2022_interface::extension::ExtensionType::ImmutableOwner,
+            spl_token_2022_interface::extension::ExtensionType::TransferFeeAmount,
+        ];
+
+        let instruction = spl_token_2022_interface::instruction::get_account_data_size(
+            &spl_token_2022_interface::ID,
+            &mint,
+            &extension_types,
+        )
+        .expect("Failed to create get_account_data_size instruction");
+
+        let solana_parsed = create_parsed_token2022_get_account_data_size(&mint, &extension_types)
+            .expect("Failed to create parsed instruction");
+
+        let result = IxUtils::reconstruct_spl_token_instruction(
+            &solana_parsed,
+            &IxUtils::build_account_keys_hashmap(&account_keys),
+        );
+
+        assert!(result.is_ok());
+        let compiled = result.unwrap();
+        assert_eq!(compiled.program_id_index, 0);
+        assert_eq!(compiled.accounts, vec![1]);
+        assert_eq!(compiled.data, instruction.data);
+    }
+
+    #[test]
+    fn test_reconstruct_token2022_initialize_account3_instruction() {
+        let account = Pubkey::new_unique();
+        let mint = Pubkey::new_unique();
+        let owner = Pubkey::new_unique();
+        let token_program_id = spl_token_2022_interface::ID;
+        let account_keys = vec![token_program_id, account, mint];
+
+        let instruction = spl_token_2022_interface::instruction::initialize_account3(
+            &spl_token_2022_interface::ID,
+            &account,
+            &mint,
+            &owner,
+        )
+        .expect("Failed to create initialize_account3 instruction");
+
+        let solana_parsed = create_parsed_token2022_initialize_account3(&account, &mint, &owner)
+            .expect("Failed to create parsed instruction");
+
+        let result = IxUtils::reconstruct_spl_token_instruction(
+            &solana_parsed,
+            &IxUtils::build_account_keys_hashmap(&account_keys),
+        );
+
+        assert!(result.is_ok());
+        let compiled = result.unwrap();
+        assert_eq!(compiled.program_id_index, 0);
+        assert_eq!(compiled.accounts, vec![1, 2]);
         assert_eq!(compiled.data, instruction.data);
     }
 

--- a/crates/lib/src/transaction/instruction_util.rs
+++ b/crates/lib/src/transaction/instruction_util.rs
@@ -96,8 +96,13 @@ pub enum ParsedSPLInstructionType {
     SplTokenFreezeAccount,
     SplTokenThawAccount,
     SplTokenReallocate,
+    SplTokenInitializePausable,
+    SplTokenPause,
+    SplTokenResume,
+    SplTokenInitializeTransferHook,
+    SplTokenTransferHookUpdate,
     /// A Token-2022 extension instruction that was successfully deserialized but
-    /// has no dedicated fee-payer parser (e.g. PausableExtension, TransferHookExtension).
+    /// has no dedicated fee-payer parser.
     /// All account pubkeys are recorded so the validator can reject the transaction
     /// if the fee payer appears among them.
     SplTokenUnknownExtension,
@@ -186,6 +191,26 @@ pub enum ParsedSPLInstructionData {
         payer: Pubkey,
         owner: Pubkey,
         is_2022: bool,
+    },
+    SplTokenInitializePausable {
+        authority: Pubkey,
+    },
+    SplTokenPause {
+        authority: Pubkey,
+        multisig_signers: Vec<Pubkey>,
+    },
+    SplTokenResume {
+        authority: Pubkey,
+        multisig_signers: Vec<Pubkey>,
+    },
+    SplTokenInitializeTransferHook {
+        authority: Option<Pubkey>,
+        program_id: Option<Pubkey>,
+    },
+    SplTokenTransferHookUpdate {
+        authority: Pubkey,
+        multisig_signers: Vec<Pubkey>,
+        program_id: Option<Pubkey>,
     },
     /// Token-2022 extension instruction with no dedicated fee-payer parser.
     /// All accounts from the instruction are captured so the validator can check
@@ -2070,26 +2095,15 @@ impl IxUtils {
                     };
                 }
             } else if program_id == spl_token_2022_interface::ID {
-                let spl_ix = match spl_token_2022_interface::instruction::TokenInstruction::unpack(
+                let spl_ix = spl_token_2022_interface::instruction::TokenInstruction::unpack(
                     &instruction.data,
-                ) {
-                    Ok(ix) => ix,
-                    Err(_) => {
-                        // Cannot decode as a base token instruction — this is either a
-                        // Token-2022 extension-specific encoding (e.g. ReallocateAccount,
-                        // extension initializers) or genuinely malformed data.  Either way,
-                        // capture all accounts so the validator can reject if the fee payer
-                        // appears among them.
-                        Self::push_parsed_spl_instruction(
-                            &mut parsed_instructions,
-                            ParsedSPLInstructionType::SplTokenUnknownExtension,
-                            ParsedSPLInstructionData::SplTokenUnknownExtension {
-                                accounts: instruction.accounts.iter().map(|a| a.pubkey).collect(),
-                            },
-                        );
-                        continue;
-                    }
-                };
+                )
+                .map_err(|e| {
+                    KoraError::InvalidTransaction(format!(
+                        "Failed to parse Token-2022 instruction: {}",
+                        sanitize_error!(e)
+                    ))
+                })?;
                 match spl_ix {
                         #[allow(deprecated)]
                         spl_token_2022_interface::instruction::TokenInstruction::Transfer { amount } => {
@@ -2387,6 +2401,149 @@ impl IxUtils {
                                     owner: instruction.accounts[instruction_indexes::spl_token_reallocate::OWNER_INDEX].pubkey,
                                     is_2022: true,
                                 });
+                        }
+                        spl_token_2022_interface::instruction::TokenInstruction::PausableExtension => {
+                            if instruction.data.len() < 2 {
+                                return Err(KoraError::InvalidTransaction(
+                                    "Failed to parse Token-2022 Pausable instruction".to_string(),
+                                ));
+                            }
+                            let pausable_ix =
+                                spl_token_2022_interface::instruction::decode_instruction_type::<
+                                    spl_token_2022_interface::extension::pausable::instruction::PausableInstruction,
+                                >(&instruction.data[1..])
+                                .map_err(|e| {
+                                    KoraError::InvalidTransaction(format!(
+                                        "Failed to parse Token-2022 Pausable instruction: {}",
+                                        sanitize_error!(e)
+                                    ))
+                                })?;
+
+                            match pausable_ix {
+                                spl_token_2022_interface::extension::pausable::instruction::PausableInstruction::Initialize => {
+                                    validate_number_accounts!(instruction, 1);
+
+                                    let initialize =
+                                        *spl_token_2022_interface::instruction::decode_instruction_data::<
+                                            spl_token_2022_interface::extension::pausable::instruction::InitializeInstructionData,
+                                        >(&instruction.data[1..])
+                                        .map_err(|e| {
+                                            KoraError::InvalidTransaction(format!(
+                                                "Failed to parse Token-2022 Pausable initialize instruction: {}",
+                                                sanitize_error!(e)
+                                            ))
+                                        })?;
+
+                                    Self::push_parsed_spl_instruction(
+                                        &mut parsed_instructions,
+                                        ParsedSPLInstructionType::SplTokenInitializePausable,
+                                        ParsedSPLInstructionData::SplTokenInitializePausable {
+                                            authority: initialize.authority,
+                                        },
+                                    );
+                                }
+                                spl_token_2022_interface::extension::pausable::instruction::PausableInstruction::Pause => {
+                                    validate_number_accounts!(instruction, 2);
+
+                                    Self::push_parsed_spl_instruction(
+                                        &mut parsed_instructions,
+                                        ParsedSPLInstructionType::SplTokenPause,
+                                        ParsedSPLInstructionData::SplTokenPause {
+                                            authority: instruction.accounts[1].pubkey,
+                                            multisig_signers: Self::extract_multisig_signers(
+                                                instruction,
+                                                2,
+                                            ),
+                                        },
+                                    );
+                                }
+                                spl_token_2022_interface::extension::pausable::instruction::PausableInstruction::Resume => {
+                                    validate_number_accounts!(instruction, 2);
+
+                                    Self::push_parsed_spl_instruction(
+                                        &mut parsed_instructions,
+                                        ParsedSPLInstructionType::SplTokenResume,
+                                        ParsedSPLInstructionData::SplTokenResume {
+                                            authority: instruction.accounts[1].pubkey,
+                                            multisig_signers: Self::extract_multisig_signers(
+                                                instruction,
+                                                2,
+                                            ),
+                                        },
+                                    );
+                                }
+                            }
+                        }
+                        spl_token_2022_interface::instruction::TokenInstruction::TransferHookExtension => {
+                            if instruction.data.len() < 2 {
+                                return Err(KoraError::InvalidTransaction(
+                                    "Failed to parse Token-2022 TransferHook instruction"
+                                        .to_string(),
+                                ));
+                            }
+                            let transfer_hook_ix =
+                                spl_token_2022_interface::instruction::decode_instruction_type::<
+                                    spl_token_2022_interface::extension::transfer_hook::instruction::TransferHookInstruction,
+                                >(&instruction.data[1..])
+                                .map_err(|e| {
+                                    KoraError::InvalidTransaction(format!(
+                                        "Failed to parse Token-2022 TransferHook instruction: {}",
+                                        sanitize_error!(e)
+                                    ))
+                                })?;
+
+                            match transfer_hook_ix {
+                                spl_token_2022_interface::extension::transfer_hook::instruction::TransferHookInstruction::Initialize => {
+                                    validate_number_accounts!(instruction, 1);
+
+                                    let initialize =
+                                        *spl_token_2022_interface::instruction::decode_instruction_data::<
+                                            spl_token_2022_interface::extension::transfer_hook::instruction::InitializeInstructionData,
+                                        >(&instruction.data[1..])
+                                        .map_err(|e| {
+                                            KoraError::InvalidTransaction(format!(
+                                                "Failed to parse Token-2022 TransferHook initialize instruction: {}",
+                                                sanitize_error!(e)
+                                            ))
+                                        })?;
+
+                                    Self::push_parsed_spl_instruction(
+                                        &mut parsed_instructions,
+                                        ParsedSPLInstructionType::SplTokenInitializeTransferHook,
+                                        ParsedSPLInstructionData::SplTokenInitializeTransferHook {
+                                            authority: initialize.authority.into(),
+                                            program_id: initialize.program_id.into(),
+                                        },
+                                    );
+                                }
+                                spl_token_2022_interface::extension::transfer_hook::instruction::TransferHookInstruction::Update => {
+                                    validate_number_accounts!(instruction, 2);
+
+                                    let update =
+                                        *spl_token_2022_interface::instruction::decode_instruction_data::<
+                                            spl_token_2022_interface::extension::transfer_hook::instruction::UpdateInstructionData,
+                                        >(&instruction.data[1..])
+                                        .map_err(|e| {
+                                            KoraError::InvalidTransaction(format!(
+                                                "Failed to parse Token-2022 TransferHook update instruction: {}",
+                                                sanitize_error!(e)
+                                            ))
+                                        })?;
+
+                                    Self::push_parsed_spl_instruction(
+                                        &mut parsed_instructions,
+                                        ParsedSPLInstructionType::SplTokenTransferHookUpdate,
+                                        ParsedSPLInstructionData::SplTokenTransferHookUpdate {
+                                            authority: instruction.accounts[1].pubkey,
+                                            multisig_signers: Self::extract_multisig_signers(
+                                                instruction,
+                                                2,
+                                            ),
+                                            program_id: update.program_id.into(),
+                                        },
+                                    );
+                                }
+                            }
                         }
                         spl_token_2022_interface::instruction::TokenInstruction::ConfidentialTransferExtension
                         | spl_token_2022_interface::instruction::TokenInstruction::ConfidentialTransferFeeExtension
@@ -3591,57 +3748,91 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_token_2022_unknown_extension_recorded_for_fee_payer_check() {
-        use crate::transaction::versioned_transaction::VersionedTransactionResolved;
+    fn test_parse_token_2022_pausable_pause_records_authority() {
+        use crate::transaction::TransactionUtil;
         use solana_message::{Message, VersionedMessage};
-        use solana_sdk::{
-            instruction::{AccountMeta, Instruction},
-            signature::{Keypair, Signer},
-            transaction::VersionedTransaction,
-        };
+        use solana_sdk::signature::{Keypair, Signer};
 
         let payer = Keypair::new();
         let authority = Pubkey::new_unique();
+        let mint = Pubkey::new_unique();
 
-        // PausableExtension (discriminator 0x1D) — not explicitly handled by the parser
-        let pausable_data =
-            spl_token_2022_interface::instruction::TokenInstruction::PausableExtension.pack();
-
-        let ix = Instruction {
-            program_id: spl_token_2022_interface::ID,
-            accounts: vec![
-                AccountMeta::new(authority, false),
-                AccountMeta::new_readonly(payer.pubkey(), false),
-            ],
-            data: pausable_data,
-        };
+        let ix = spl_token_2022_interface::extension::pausable::instruction::pause(
+            &spl_token_2022_interface::id(),
+            &mint,
+            &authority,
+            &[],
+        )
+        .unwrap();
 
         let message = VersionedMessage::Legacy(Message::new(&[ix], Some(&payer.pubkey())));
-        let tx = VersionedTransaction::try_new(message, &[&payer]).unwrap();
-        let resolved_tx = VersionedTransactionResolved::from_kora_built_transaction(&tx)
+        let resolved_tx = TransactionUtil::new_unsigned_versioned_transaction_resolved(message)
             .expect("Failed to create resolved transaction");
 
         let result = IxUtils::parse_token_instructions(&resolved_tx);
-        assert!(result.is_ok(), "Unknown extension should be recorded, not rejected at parse time");
+        assert!(result.is_ok(), "Pausable pause should parse successfully");
         let parsed = result.unwrap();
 
-        let unknown = parsed.get(&ParsedSPLInstructionType::SplTokenUnknownExtension);
-        assert!(unknown.is_some(), "Should have an SplTokenUnknownExtension entry");
-        let entries = unknown.unwrap();
+        let entries = parsed.get(&ParsedSPLInstructionType::SplTokenPause).unwrap();
         assert_eq!(entries.len(), 1);
-        if let ParsedSPLInstructionData::SplTokenUnknownExtension { accounts } = &entries[0] {
-            assert!(
-                accounts.contains(&payer.pubkey()),
-                "Fee payer pubkey should be captured in unknown extension accounts"
-            );
-            assert!(accounts.contains(&authority));
+        if let ParsedSPLInstructionData::SplTokenPause {
+            authority: parsed_authority,
+            multisig_signers,
+        } = &entries[0]
+        {
+            assert_eq!(*parsed_authority, authority);
+            assert!(multisig_signers.is_empty());
         } else {
-            panic!("Expected SplTokenUnknownExtension variant");
+            panic!("Expected SplTokenPause variant");
         }
     }
 
     #[test]
-    fn test_parse_token_2022_malformed_instruction_accounts_captured() {
+    fn test_parse_token_2022_transfer_hook_update_records_authority_and_program_id() {
+        use crate::transaction::TransactionUtil;
+        use solana_message::{Message, VersionedMessage};
+        use solana_sdk::signature::{Keypair, Signer};
+
+        let payer = Keypair::new();
+        let mint = Pubkey::new_unique();
+        let authority = Pubkey::new_unique();
+        let new_program_id = Pubkey::new_unique();
+
+        let ix = spl_token_2022_interface::extension::transfer_hook::instruction::update(
+            &spl_token_2022_interface::id(),
+            &mint,
+            &authority,
+            &[],
+            Some(new_program_id),
+        )
+        .unwrap();
+
+        let message = VersionedMessage::Legacy(Message::new(&[ix], Some(&payer.pubkey())));
+        let resolved_tx = TransactionUtil::new_unsigned_versioned_transaction_resolved(message)
+            .expect("Failed to create resolved transaction");
+
+        let result = IxUtils::parse_token_instructions(&resolved_tx);
+        assert!(result.is_ok(), "TransferHook update should parse successfully");
+        let parsed = result.unwrap();
+
+        let entries = parsed.get(&ParsedSPLInstructionType::SplTokenTransferHookUpdate).unwrap();
+        assert_eq!(entries.len(), 1);
+        if let ParsedSPLInstructionData::SplTokenTransferHookUpdate {
+            authority: parsed_authority,
+            multisig_signers,
+            program_id,
+        } = &entries[0]
+        {
+            assert_eq!(*parsed_authority, authority);
+            assert!(multisig_signers.is_empty());
+            assert_eq!(*program_id, Some(new_program_id));
+        } else {
+            panic!("Expected SplTokenTransferHookUpdate variant");
+        }
+    }
+
+    #[test]
+    fn test_parse_token_2022_unknown_extension_accounts_captured() {
         use crate::transaction::versioned_transaction::VersionedTransactionResolved;
         use solana_message::{Message, VersionedMessage};
         use solana_sdk::{
@@ -3655,7 +3846,8 @@ mod tests {
         let ix = Instruction {
             program_id: spl_token_2022_interface::ID,
             accounts: vec![AccountMeta::new(payer.pubkey(), true)],
-            data: vec![0xFF, 0xFF, 0xFF], // garbage data — won't unpack as base instruction
+            data: spl_token_2022_interface::instruction::TokenInstruction::MemoTransferExtension
+                .pack(),
         };
 
         let message = VersionedMessage::Legacy(Message::new(&[ix], Some(&payer.pubkey())));
@@ -3663,11 +3855,8 @@ mod tests {
         let resolved_tx = VersionedTransactionResolved::from_kora_built_transaction(&tx)
             .expect("Failed to create resolved transaction");
 
-        // Malformed (or extension-encoded) instructions must NOT error at parse time.
-        // Their accounts are captured as SplTokenUnknownExtension so the validator can
-        // still reject if the fee payer appears among them.
         let result = IxUtils::parse_token_instructions(&resolved_tx);
-        assert!(result.is_ok(), "Unparseable Token-2022 instruction must not error at parse time");
+        assert!(result.is_ok(), "Unsupported Token-2022 extension should be captured");
         let parsed = result.unwrap();
 
         let unknown = parsed.get(&ParsedSPLInstructionType::SplTokenUnknownExtension);
@@ -3682,6 +3871,33 @@ mod tests {
         } else {
             panic!("Expected SplTokenUnknownExtension variant");
         }
+    }
+
+    #[test]
+    fn test_parse_token_2022_malformed_instruction_rejected() {
+        use crate::transaction::versioned_transaction::VersionedTransactionResolved;
+        use solana_message::{Message, VersionedMessage};
+        use solana_sdk::{
+            instruction::{AccountMeta, Instruction},
+            signature::{Keypair, Signer},
+            transaction::VersionedTransaction,
+        };
+
+        let payer = Keypair::new();
+
+        let ix = Instruction {
+            program_id: spl_token_2022_interface::ID,
+            accounts: vec![AccountMeta::new(payer.pubkey(), true)],
+            data: vec![0xFF, 0xFF, 0xFF],
+        };
+
+        let message = VersionedMessage::Legacy(Message::new(&[ix], Some(&payer.pubkey())));
+        let tx = VersionedTransaction::try_new(message, &[&payer]).unwrap();
+        let resolved_tx = VersionedTransactionResolved::from_kora_built_transaction(&tx)
+            .expect("Failed to create resolved transaction");
+
+        let result = IxUtils::parse_token_instructions(&resolved_tx);
+        assert!(result.is_err(), "Malformed Token-2022 instruction must be rejected");
     }
 
     #[test]

--- a/crates/lib/src/transaction/instruction_util.rs
+++ b/crates/lib/src/transaction/instruction_util.rs
@@ -96,6 +96,11 @@ pub enum ParsedSPLInstructionType {
     SplTokenFreezeAccount,
     SplTokenThawAccount,
     SplTokenReallocate,
+    /// A Token-2022 extension instruction that was successfully deserialized but
+    /// has no dedicated fee-payer parser (e.g. PausableExtension, TransferHookExtension).
+    /// All account pubkeys are recorded so the validator can reject the transaction
+    /// if the fee payer appears among them.
+    SplTokenUnknownExtension,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -181,6 +186,12 @@ pub enum ParsedSPLInstructionData {
         payer: Pubkey,
         owner: Pubkey,
         is_2022: bool,
+    },
+    /// Token-2022 extension instruction with no dedicated fee-payer parser.
+    /// All accounts from the instruction are captured so the validator can check
+    /// whether the fee payer appears among them.
+    SplTokenUnknownExtension {
+        accounts: Vec<Pubkey>,
     },
 }
 
@@ -2059,10 +2070,16 @@ impl IxUtils {
                     };
                 }
             } else if program_id == spl_token_2022_interface::ID {
-                if let Ok(spl_ix) = spl_token_2022_interface::instruction::TokenInstruction::unpack(
+                let spl_ix = spl_token_2022_interface::instruction::TokenInstruction::unpack(
                     &instruction.data,
-                ) {
-                    match spl_ix {
+                )
+                .map_err(|e| {
+                    KoraError::InvalidTransaction(format!(
+                        "Failed to parse Token-2022 instruction: {}",
+                        sanitize_error!(e)
+                    ))
+                })?;
+                match spl_ix {
                         #[allow(deprecated)]
                         spl_token_2022_interface::instruction::TokenInstruction::Transfer { amount } => {
                             validate_number_accounts!(instruction, instruction_indexes::spl_token_transfer::REQUIRED_NUMBER_OF_ACCOUNTS);
@@ -2368,9 +2385,23 @@ impl IxUtils {
                                     .to_string(),
                             ));
                         }
-                        _ => {}
+                        _ => {
+                            // Extension instruction with no dedicated fee-payer parser.
+                            // Record all accounts so the validator can reject if the fee
+                            // payer appears among them.
+                            Self::push_parsed_spl_instruction(
+                                &mut parsed_instructions,
+                                ParsedSPLInstructionType::SplTokenUnknownExtension,
+                                ParsedSPLInstructionData::SplTokenUnknownExtension {
+                                    accounts: instruction
+                                        .accounts
+                                        .iter()
+                                        .map(|a| a.pubkey)
+                                        .collect(),
+                                },
+                            );
+                        }
                     };
-                }
             }
         }
         Ok(parsed_instructions)
@@ -3546,6 +3577,88 @@ mod tests {
 
         let result = IxUtils::parse_token_instructions(&resolved_tx);
         assert!(result.is_err(), "Token-2022 BurnChecked with 2 accounts must be rejected");
+    }
+
+    #[test]
+    fn test_parse_token_2022_unknown_extension_recorded_for_fee_payer_check() {
+        use crate::transaction::versioned_transaction::VersionedTransactionResolved;
+        use solana_message::{Message, VersionedMessage};
+        use solana_sdk::{
+            instruction::{AccountMeta, Instruction},
+            signature::{Keypair, Signer},
+            transaction::VersionedTransaction,
+        };
+
+        let payer = Keypair::new();
+        let authority = Pubkey::new_unique();
+
+        // PausableExtension (discriminator 0x1D) — not explicitly handled by the parser
+        let pausable_data =
+            spl_token_2022_interface::instruction::TokenInstruction::PausableExtension.pack();
+
+        let ix = Instruction {
+            program_id: spl_token_2022_interface::ID,
+            accounts: vec![
+                AccountMeta::new(authority, false),
+                AccountMeta::new_readonly(payer.pubkey(), false),
+            ],
+            data: pausable_data,
+        };
+
+        let message = VersionedMessage::Legacy(Message::new(&[ix], Some(&payer.pubkey())));
+        let tx = VersionedTransaction::try_new(message, &[&payer]).unwrap();
+        let resolved_tx = VersionedTransactionResolved::from_kora_built_transaction(&tx)
+            .expect("Failed to create resolved transaction");
+
+        let result = IxUtils::parse_token_instructions(&resolved_tx);
+        assert!(result.is_ok(), "Unknown extension should be recorded, not rejected at parse time");
+        let parsed = result.unwrap();
+
+        let unknown = parsed.get(&ParsedSPLInstructionType::SplTokenUnknownExtension);
+        assert!(unknown.is_some(), "Should have an SplTokenUnknownExtension entry");
+        let entries = unknown.unwrap();
+        assert_eq!(entries.len(), 1);
+        if let ParsedSPLInstructionData::SplTokenUnknownExtension { accounts } = &entries[0] {
+            assert!(
+                accounts.contains(&payer.pubkey()),
+                "Fee payer pubkey should be captured in unknown extension accounts"
+            );
+            assert!(accounts.contains(&authority));
+        } else {
+            panic!("Expected SplTokenUnknownExtension variant");
+        }
+    }
+
+    #[test]
+    fn test_parse_token_2022_malformed_instruction_returns_error() {
+        use crate::transaction::versioned_transaction::VersionedTransactionResolved;
+        use solana_message::{Message, VersionedMessage};
+        use solana_sdk::{
+            instruction::{AccountMeta, Instruction},
+            signature::{Keypair, Signer},
+            transaction::VersionedTransaction,
+        };
+
+        let payer = Keypair::new();
+
+        let ix = Instruction {
+            program_id: spl_token_2022_interface::ID,
+            accounts: vec![AccountMeta::new(payer.pubkey(), true)],
+            data: vec![0xFF, 0xFF, 0xFF], // garbage data — won't unpack
+        };
+
+        let message = VersionedMessage::Legacy(Message::new(&[ix], Some(&payer.pubkey())));
+        let tx = VersionedTransaction::try_new(message, &[&payer]).unwrap();
+        let resolved_tx = VersionedTransactionResolved::from_kora_built_transaction(&tx)
+            .expect("Failed to create resolved transaction");
+
+        let result = IxUtils::parse_token_instructions(&resolved_tx);
+        assert!(result.is_err(), "Malformed Token-2022 instruction must return an error");
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("Failed to parse Token-2022 instruction"),
+            "Error message should describe the parse failure, got: {err}"
+        );
     }
 
     #[test]

--- a/crates/lib/src/transaction/versioned_transaction.rs
+++ b/crates/lib/src/transaction/versioned_transaction.rs
@@ -306,6 +306,11 @@ impl VersionedTransactionOps for VersionedTransactionResolved {
         } else {
             TransferHookValidationFlow::DelayedSigning
         };
+        validator.validate_token2022_signing_policies(
+            config,
+            self,
+            transfer_hook_validation_flow,
+        )?;
         let fee_calculation = FeeConfigUtil::estimate_kora_fee(
             self,
             &fee_payer,

--- a/crates/lib/src/transaction/versioned_transaction.rs
+++ b/crates/lib/src/transaction/versioned_transaction.rs
@@ -306,7 +306,7 @@ impl VersionedTransactionOps for VersionedTransactionResolved {
         } else {
             TransferHookValidationFlow::DelayedSigning
         };
-        validator.validate_token2022_signing_policies(
+        validator.validate_token2022_transfer_hook_signing_policies(
             config,
             self,
             transfer_hook_validation_flow,

--- a/crates/lib/src/validator/macros.rs
+++ b/crates/lib/src/validator/macros.rs
@@ -73,3 +73,25 @@ macro_rules! validate_alt {
         }
     };
 }
+
+/// Macro to validate Token2022-only instructions with custom fee-payer matching logic
+macro_rules! validate_token2022 {
+    ($self:expr, $instructions:expr, $type:ident, $pattern:pat => $fee_payer_used:expr, $message:expr) => {
+        for instruction in $instructions.get(&ParsedSPLInstructionType::$type).unwrap_or(&vec![]) {
+            if let $pattern = instruction {
+                if $fee_payer_used {
+                    return Err(KoraError::InvalidTransaction($message.to_string()));
+                }
+            }
+        }
+    };
+    ($self:expr, $instructions:expr, $type:ident, $pattern:pat => $fee_payer_used:expr, $policy:expr, $message:expr) => {
+        for instruction in $instructions.get(&ParsedSPLInstructionType::$type).unwrap_or(&vec![]) {
+            if let $pattern = instruction {
+                if $fee_payer_used && !$policy {
+                    return Err(KoraError::InvalidTransaction($message.to_string()));
+                }
+            }
+        }
+    };
+}

--- a/crates/lib/src/validator/transaction_validator.rs
+++ b/crates/lib/src/validator/transaction_validator.rs
@@ -691,14 +691,13 @@ impl TransactionValidator {
                         )?;
                     }
                 }
-                ParsedSPLInstructionData::SplTokenTransferHookUpdate { program_id, .. } => {
-                    if let Some(program_id) = program_id {
-                        self.validate_disallowed_instruction_data_account(
-                            program_id,
-                            "Token2022 TransferHookUpdate program_id",
-                        )?;
-                    }
-                }
+                ParsedSPLInstructionData::SplTokenTransferHookUpdate {
+                    program_id: Some(program_id),
+                    ..
+                } => self.validate_disallowed_instruction_data_account(
+                    program_id,
+                    "Token2022 TransferHookUpdate program_id",
+                )?,
                 _ => {}
             }
         }

--- a/crates/lib/src/validator/transaction_validator.rs
+++ b/crates/lib/src/validator/transaction_validator.rs
@@ -3,7 +3,10 @@ use crate::{
     error::KoraError,
     fee::fee::{FeeConfigUtil, TotalFeeCalculation},
     oracle::PriceSource,
-    token::{interface::TokenMint, token::TokenUtil},
+    token::{
+        interface::TokenMint,
+        token::{TokenUtil, TransferHookValidationFlow},
+    },
     transaction::{
         ParsedALTInstructionData, ParsedALTInstructionType, ParsedSPLInstructionData,
         ParsedSPLInstructionType, ParsedSystemInstructionData, ParsedSystemInstructionType,
@@ -136,6 +139,62 @@ impl TransactionValidator {
         self.validate_transfer_amounts(config, transaction_resolved, rpc_client).await?;
         self.validate_disallowed_accounts(transaction_resolved)?;
         self.validate_fee_payer_usage(transaction_resolved)?;
+
+        Ok(())
+    }
+
+    pub(crate) fn validate_token2022_signing_policies(
+        &self,
+        config: &Config,
+        transaction_resolved: &mut VersionedTransactionResolved,
+        transfer_hook_validation_flow: TransferHookValidationFlow,
+    ) -> Result<(), KoraError> {
+        if !TokenUtil::should_reject_mutable_transfer_hook(config, transfer_hook_validation_flow) {
+            return Ok(());
+        }
+
+        let spl_instructions = transaction_resolved.get_or_parse_spl_instructions()?;
+
+        if let Some(instructions) =
+            spl_instructions.get(&ParsedSPLInstructionType::SplTokenInitializeTransferHook)
+        {
+            for instruction in instructions {
+                if let ParsedSPLInstructionData::SplTokenInitializeTransferHook {
+                    authority: Some(authority),
+                    ..
+                } = instruction
+                {
+                    if *authority == self.fee_payer_pubkey {
+                        return Err(KoraError::InvalidTransaction(
+                            "Fee payer cannot initialize mutable Token2022 TransferHook authority"
+                                .to_string(),
+                        ));
+                    }
+                }
+            }
+        }
+
+        if let Some(instructions) =
+            spl_instructions.get(&ParsedSPLInstructionType::SplTokenTransferHookUpdate)
+        {
+            for instruction in instructions {
+                if let ParsedSPLInstructionData::SplTokenTransferHookUpdate {
+                    authority,
+                    multisig_signers,
+                    ..
+                } = instruction
+                {
+                    if *authority == self.fee_payer_pubkey
+                        || multisig_signers.contains(&self.fee_payer_pubkey)
+                    {
+                        return Err(KoraError::InvalidTransaction(
+                            "Fee payer cannot authorize mutable Token2022 TransferHook updates"
+                                .to_string(),
+                        ));
+                    }
+                }
+            }
+        }
 
         Ok(())
     }
@@ -394,32 +453,92 @@ impl TransactionValidator {
             "ALT CloseLookupTable");
 
         let spl_instructions = transaction_resolved.get_or_parse_spl_instructions()?;
-        for instruction in
-            spl_instructions.get(&ParsedSPLInstructionType::SplTokenReallocate).unwrap_or(&vec![])
+        if let Some(instructions) =
+            spl_instructions.get(&ParsedSPLInstructionType::SplTokenReallocate)
         {
-            if let ParsedSPLInstructionData::SplTokenReallocate { payer, owner, is_2022, .. } =
-                instruction
-            {
-                if *is_2022 && (*payer == self.fee_payer_pubkey || *owner == self.fee_payer_pubkey)
+            for instruction in instructions {
+                if let ParsedSPLInstructionData::SplTokenReallocate {
+                    payer, owner, is_2022, ..
+                } = instruction
                 {
-                    return Err(KoraError::InvalidTransaction(
-                        "Token2022 Reallocate is not allowed when involving fee payer".to_string(),
-                    ));
+                    if *is_2022
+                        && (*payer == self.fee_payer_pubkey || *owner == self.fee_payer_pubkey)
+                    {
+                        return Err(KoraError::InvalidTransaction(
+                            "Token2022 Reallocate is not allowed when involving fee payer"
+                                .to_string(),
+                        ));
+                    }
                 }
             }
         }
 
-        for instruction in spl_instructions
-            .get(&ParsedSPLInstructionType::SplTokenUnknownExtension)
-            .unwrap_or(&vec![])
+        if let Some(instructions) =
+            spl_instructions.get(&ParsedSPLInstructionType::SplTokenInitializePausable)
         {
-            if let ParsedSPLInstructionData::SplTokenUnknownExtension { accounts } = instruction {
-                if accounts.contains(&self.fee_payer_pubkey) {
-                    return Err(KoraError::InvalidTransaction(
-                        "Fee payer cannot be an account in an unsupported Token-2022 extension \
-                        instruction"
-                            .to_string(),
-                    ));
+            for instruction in instructions {
+                if let ParsedSPLInstructionData::SplTokenInitializePausable { authority } =
+                    instruction
+                {
+                    if *authority == self.fee_payer_pubkey
+                        && !self.fee_payer_policy.token_2022.allow_initialize_mint
+                    {
+                        return Err(KoraError::InvalidTransaction(
+                            "Fee payer cannot be set as Token2022 pausable authority".to_string(),
+                        ));
+                    }
+                }
+            }
+        }
+
+        if let Some(instructions) = spl_instructions.get(&ParsedSPLInstructionType::SplTokenPause) {
+            for instruction in instructions {
+                if let ParsedSPLInstructionData::SplTokenPause { authority, multisig_signers } =
+                    instruction
+                {
+                    if (*authority == self.fee_payer_pubkey
+                        || multisig_signers.contains(&self.fee_payer_pubkey))
+                        && !self.fee_payer_policy.token_2022.allow_freeze_account
+                    {
+                        return Err(KoraError::InvalidTransaction(
+                            "Fee payer cannot be used for Token2022 Pause".to_string(),
+                        ));
+                    }
+                }
+            }
+        }
+
+        if let Some(instructions) = spl_instructions.get(&ParsedSPLInstructionType::SplTokenResume)
+        {
+            for instruction in instructions {
+                if let ParsedSPLInstructionData::SplTokenResume { authority, multisig_signers } =
+                    instruction
+                {
+                    if (*authority == self.fee_payer_pubkey
+                        || multisig_signers.contains(&self.fee_payer_pubkey))
+                        && !self.fee_payer_policy.token_2022.allow_thaw_account
+                    {
+                        return Err(KoraError::InvalidTransaction(
+                            "Fee payer cannot be used for Token2022 Resume".to_string(),
+                        ));
+                    }
+                }
+            }
+        }
+
+        if let Some(instructions) =
+            spl_instructions.get(&ParsedSPLInstructionType::SplTokenUnknownExtension)
+        {
+            for instruction in instructions {
+                if let ParsedSPLInstructionData::SplTokenUnknownExtension { accounts } = instruction
+                {
+                    if accounts.contains(&self.fee_payer_pubkey) {
+                        return Err(KoraError::InvalidTransaction(
+                            "Fee payer cannot be an account in an unsupported Token-2022 extension \
+                            instruction"
+                                .to_string(),
+                        ));
+                    }
                 }
             }
         }
@@ -549,6 +668,37 @@ impl TransactionValidator {
                         )?;
                     }
                 }
+                ParsedSPLInstructionData::SplTokenInitializePausable { authority } => {
+                    self.validate_disallowed_instruction_data_account(
+                        authority,
+                        "Token2022 InitializePausable authority",
+                    )?;
+                }
+                ParsedSPLInstructionData::SplTokenInitializeTransferHook {
+                    authority,
+                    program_id,
+                } => {
+                    if let Some(authority) = authority {
+                        self.validate_disallowed_instruction_data_account(
+                            authority,
+                            "Token2022 InitializeTransferHook authority",
+                        )?;
+                    }
+                    if let Some(program_id) = program_id {
+                        self.validate_disallowed_instruction_data_account(
+                            program_id,
+                            "Token2022 InitializeTransferHook program_id",
+                        )?;
+                    }
+                }
+                ParsedSPLInstructionData::SplTokenTransferHookUpdate { program_id, .. } => {
+                    if let Some(program_id) = program_id {
+                        self.validate_disallowed_instruction_data_account(
+                            program_id,
+                            "Token2022 TransferHookUpdate program_id",
+                        )?;
+                    }
+                }
                 _ => {}
             }
         }
@@ -646,7 +796,7 @@ impl TransactionValidator {
 #[cfg(test)]
 mod tests {
     use crate::{
-        config::{Config, FeePayerPolicy},
+        config::{Config, FeePayerPolicy, TransferHookPolicy},
         state::{get_config, update_config},
         tests::{
             account_mock::{MintAccountMockBuilder, TokenAccountMockBuilder},
@@ -664,7 +814,7 @@ mod tests {
     use solana_compute_budget_interface::ComputeBudgetInstruction;
     use solana_message::{Message, VersionedMessage};
     use solana_sdk::{
-        instruction::{AccountMeta, Instruction},
+        instruction::Instruction,
         signature::{Keypair, Signer},
     };
     use solana_system_interface::{
@@ -4112,23 +4262,22 @@ mod tests {
 
     #[tokio::test]
     #[serial]
-    async fn test_token2022_unknown_extension_with_fee_payer_rejected() {
+    async fn test_token2022_pause_with_fee_payer_rejected() {
         let fee_payer = Keypair::new();
         let rpc_client = RpcMockBuilder::new().build();
         setup_token2022_config_with_policy(FeePayerPolicy::default());
 
         let config = get_config().unwrap();
         let validator = TransactionValidator::new(config, fee_payer.pubkey()).unwrap();
+        let mint = Pubkey::new_unique();
 
-        // PausableExtension — fee payer is an account in the instruction
-        let ix = Instruction {
-            program_id: spl_token_2022_interface::id(),
-            accounts: vec![
-                AccountMeta::new(Pubkey::new_unique(), false),
-                AccountMeta::new_readonly(fee_payer.pubkey(), true),
-            ],
-            data: spl_token_2022_interface::instruction::TokenInstruction::PausableExtension.pack(),
-        };
+        let ix = spl_token_2022_interface::extension::pausable::instruction::pause(
+            &spl_token_2022_interface::id(),
+            &mint,
+            &fee_payer.pubkey(),
+            &[],
+        )
+        .unwrap();
 
         let message = VersionedMessage::Legacy(Message::new(&[ix], Some(&fee_payer.pubkey())));
         let mut transaction =
@@ -4136,36 +4285,183 @@ mod tests {
 
         let result = validator.validate_transaction(config, &mut transaction, &rpc_client).await;
         assert!(
-            matches!(result, Err(KoraError::InvalidTransaction(ref msg)) if msg.contains("unsupported Token-2022 extension")),
-            "Expected rejection when fee payer appears in unknown extension instruction, got: {result:?}"
+            matches!(result, Err(KoraError::InvalidTransaction(ref msg)) if msg.contains("Token2022 Pause")),
+            "Expected rejection when fee payer is the pausable authority, got: {result:?}"
         );
     }
 
     #[tokio::test]
     #[serial]
-    async fn test_token2022_unknown_extension_without_fee_payer_allowed() {
+    async fn test_token2022_resume_allowed_when_policy_explicitly_enabled() {
         let fee_payer = Keypair::new();
         let rpc_client = RpcMockBuilder::new().build();
-        setup_token2022_config_with_policy(FeePayerPolicy::default());
+        let mut policy = FeePayerPolicy::default();
+        policy.token_2022.allow_thaw_account = true;
+        setup_token2022_config_with_policy(policy);
 
         let config = get_config().unwrap();
         let validator = TransactionValidator::new(config, fee_payer.pubkey()).unwrap();
+        let mint = Pubkey::new_unique();
 
-        let other_authority = Pubkey::new_unique();
-
-        // PausableExtension — fee payer is NOT among the instruction accounts
-        let ix = Instruction {
-            program_id: spl_token_2022_interface::id(),
-            accounts: vec![AccountMeta::new(other_authority, true)],
-            data: spl_token_2022_interface::instruction::TokenInstruction::PausableExtension.pack(),
-        };
+        let ix = spl_token_2022_interface::extension::pausable::instruction::resume(
+            &spl_token_2022_interface::id(),
+            &mint,
+            &fee_payer.pubkey(),
+            &[],
+        )
+        .unwrap();
 
         let message = VersionedMessage::Legacy(Message::new(&[ix], Some(&fee_payer.pubkey())));
         let mut transaction =
             TransactionUtil::new_unsigned_versioned_transaction_resolved(message).unwrap();
 
         let result = validator.validate_transaction(config, &mut transaction, &rpc_client).await;
-        assert!(result.is_ok(), "Should allow unknown extension instruction when fee payer is not an account: {result:?}");
+        assert!(result.is_ok(), "Explicit thaw opt-in should allow Token2022 Resume: {result:?}");
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_token2022_pausable_initialize_rejects_fee_payer_authority_by_default() {
+        let fee_payer = Keypair::new();
+        let rpc_client = RpcMockBuilder::new().build();
+        setup_token2022_config_with_policy(FeePayerPolicy::default());
+
+        let config = get_config().unwrap();
+        let validator = TransactionValidator::new(config, fee_payer.pubkey()).unwrap();
+        let mint = Pubkey::new_unique();
+
+        let ix = spl_token_2022_interface::extension::pausable::instruction::initialize(
+            &spl_token_2022_interface::id(),
+            &mint,
+            &fee_payer.pubkey(),
+        )
+        .unwrap();
+
+        let message = VersionedMessage::Legacy(Message::new(&[ix], Some(&fee_payer.pubkey())));
+        let mut transaction =
+            TransactionUtil::new_unsigned_versioned_transaction_resolved(message).unwrap();
+
+        let result = validator.validate_transaction(config, &mut transaction, &rpc_client).await;
+        assert!(
+            matches!(result, Err(KoraError::InvalidTransaction(ref msg)) if msg.contains("Token2022 pausable authority")),
+            "Expected rejection when fee payer is assigned as pausable authority, got: {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_token2022_transfer_hook_update_rejected_when_policy_denies() {
+        let fee_payer = Keypair::new();
+        let rpc_client = RpcMockBuilder::new().build();
+        setup_token2022_config_with_policy(FeePayerPolicy::default());
+
+        let mut config = get_config().unwrap().clone();
+        config.validation.token_2022.transfer_hook_policy = TransferHookPolicy::DenyAll;
+        let validator = TransactionValidator::new(&config, fee_payer.pubkey()).unwrap();
+        let mint = Pubkey::new_unique();
+        let program_id = Pubkey::new_unique();
+
+        let ix = spl_token_2022_interface::extension::transfer_hook::instruction::update(
+            &spl_token_2022_interface::id(),
+            &mint,
+            &fee_payer.pubkey(),
+            &[],
+            Some(program_id),
+        )
+        .unwrap();
+
+        let message = VersionedMessage::Legacy(Message::new(&[ix], Some(&fee_payer.pubkey())));
+        let mut transaction =
+            TransactionUtil::new_unsigned_versioned_transaction_resolved(message).unwrap();
+
+        validator.validate_transaction(&config, &mut transaction, &rpc_client).await.unwrap();
+
+        let result = validator.validate_token2022_signing_policies(
+            &config,
+            &mut transaction,
+            TransferHookValidationFlow::DelayedSigning,
+        );
+        assert!(
+            matches!(result, Err(KoraError::InvalidTransaction(ref msg)) if msg.contains("TransferHook")),
+            "Expected transfer-hook policy rejection, got: {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_token2022_transfer_hook_update_allowed_for_immediate_send_when_policy_is_delayed_only(
+    ) {
+        let fee_payer = Keypair::new();
+        let rpc_client = RpcMockBuilder::new().build();
+        setup_token2022_config_with_policy(FeePayerPolicy::default());
+
+        let mut config = get_config().unwrap().clone();
+        config.validation.token_2022.transfer_hook_policy =
+            TransferHookPolicy::DenyMutableForDelayedSigning;
+        let validator = TransactionValidator::new(&config, fee_payer.pubkey()).unwrap();
+        let mint = Pubkey::new_unique();
+        let program_id = Pubkey::new_unique();
+
+        let ix = spl_token_2022_interface::extension::transfer_hook::instruction::update(
+            &spl_token_2022_interface::id(),
+            &mint,
+            &fee_payer.pubkey(),
+            &[],
+            Some(program_id),
+        )
+        .unwrap();
+
+        let message = VersionedMessage::Legacy(Message::new(&[ix], Some(&fee_payer.pubkey())));
+        let mut transaction =
+            TransactionUtil::new_unsigned_versioned_transaction_resolved(message).unwrap();
+
+        validator.validate_transaction(&config, &mut transaction, &rpc_client).await.unwrap();
+
+        let result = validator.validate_token2022_signing_policies(
+            &config,
+            &mut transaction,
+            TransferHookValidationFlow::ImmediateSignAndSend,
+        );
+        assert!(
+            result.is_ok(),
+            "Immediate-sign flow should be allowed under delayed-only policy: {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_token2022_transfer_hook_initialize_disallowed_program_id_rejected() {
+        let fee_payer = Keypair::new();
+        let disallowed_program_id = Pubkey::new_unique();
+        let mint = Pubkey::new_unique();
+        let authority = Pubkey::new_unique();
+        let rpc_client = RpcMockBuilder::new().build();
+        setup_config_with_policy_and_disallowed(
+            FeePayerPolicy::default(),
+            vec![spl_token_2022_interface::id().to_string()],
+            vec![disallowed_program_id.to_string()],
+        );
+
+        let config = get_config().unwrap();
+        let validator = TransactionValidator::new(config, fee_payer.pubkey()).unwrap();
+
+        let ix = spl_token_2022_interface::extension::transfer_hook::instruction::initialize(
+            &spl_token_2022_interface::id(),
+            &mint,
+            Some(authority),
+            Some(disallowed_program_id),
+        )
+        .unwrap();
+
+        let message = VersionedMessage::Legacy(Message::new(&[ix], Some(&fee_payer.pubkey())));
+        let mut transaction =
+            TransactionUtil::new_unsigned_versioned_transaction_resolved(message).unwrap();
+
+        let result = validator.validate_transaction(config, &mut transaction, &rpc_client).await;
+        assert!(
+            matches!(result, Err(KoraError::InvalidTransaction(ref msg)) if msg.contains("InitializeTransferHook program_id")),
+            "Expected disallowed transfer-hook program id rejection, got: {result:?}"
+        );
     }
 
     #[tokio::test]

--- a/crates/lib/src/validator/transaction_validator.rs
+++ b/crates/lib/src/validator/transaction_validator.rs
@@ -155,46 +155,21 @@ impl TransactionValidator {
 
         let spl_instructions = transaction_resolved.get_or_parse_spl_instructions()?;
 
-        if let Some(instructions) =
-            spl_instructions.get(&ParsedSPLInstructionType::SplTokenInitializeTransferHook)
-        {
-            for instruction in instructions {
-                if let ParsedSPLInstructionData::SplTokenInitializeTransferHook {
-                    authority: Some(authority),
-                    ..
-                } = instruction
-                {
-                    if *authority == self.fee_payer_pubkey {
-                        return Err(KoraError::InvalidTransaction(
-                            "Fee payer cannot initialize mutable Token2022 TransferHook authority"
-                                .to_string(),
-                        ));
-                    }
-                }
-            }
-        }
+        validate_token2022!(self, spl_instructions, SplTokenInitializeTransferHook,
+            ParsedSPLInstructionData::SplTokenInitializeTransferHook {
+                authority: Some(authority),
+                ..
+            } => *authority == self.fee_payer_pubkey,
+            "Fee payer cannot initialize mutable Token2022 TransferHook authority");
 
-        if let Some(instructions) =
-            spl_instructions.get(&ParsedSPLInstructionType::SplTokenTransferHookUpdate)
-        {
-            for instruction in instructions {
-                if let ParsedSPLInstructionData::SplTokenTransferHookUpdate {
-                    authority,
-                    multisig_signers,
-                    ..
-                } = instruction
-                {
-                    if *authority == self.fee_payer_pubkey
-                        || multisig_signers.contains(&self.fee_payer_pubkey)
-                    {
-                        return Err(KoraError::InvalidTransaction(
-                            "Fee payer cannot authorize mutable Token2022 TransferHook updates"
-                                .to_string(),
-                        ));
-                    }
-                }
-            }
-        }
+        validate_token2022!(self, spl_instructions, SplTokenTransferHookUpdate,
+            ParsedSPLInstructionData::SplTokenTransferHookUpdate {
+                authority,
+                multisig_signers,
+                ..
+            } => *authority == self.fee_payer_pubkey
+                || multisig_signers.contains(&self.fee_payer_pubkey) ,
+            "Fee payer cannot authorize mutable Token2022 TransferHook updates");
 
         Ok(())
     }
@@ -453,95 +428,40 @@ impl TransactionValidator {
             "ALT CloseLookupTable");
 
         let spl_instructions = transaction_resolved.get_or_parse_spl_instructions()?;
-        if let Some(instructions) =
-            spl_instructions.get(&ParsedSPLInstructionType::SplTokenReallocate)
-        {
-            for instruction in instructions {
-                if let ParsedSPLInstructionData::SplTokenReallocate {
-                    payer, owner, is_2022, ..
-                } = instruction
-                {
-                    if *is_2022
-                        && (*payer == self.fee_payer_pubkey || *owner == self.fee_payer_pubkey)
-                    {
-                        return Err(KoraError::InvalidTransaction(
-                            "Token2022 Reallocate is not allowed when involving fee payer"
-                                .to_string(),
-                        ));
-                    }
-                }
-            }
-        }
+        validate_token2022!(self, spl_instructions, SplTokenReallocate,
+            ParsedSPLInstructionData::SplTokenReallocate {
+                payer,
+                owner,
+                is_2022,
+                ..
+            } => *is_2022
+                && (*payer == self.fee_payer_pubkey || *owner == self.fee_payer_pubkey) ,
+            "Token2022 Reallocate is not allowed when involving fee payer");
 
-        if let Some(instructions) =
-            spl_instructions.get(&ParsedSPLInstructionType::SplTokenInitializePausable)
-        {
-            for instruction in instructions {
-                if let ParsedSPLInstructionData::SplTokenInitializePausable { authority } =
-                    instruction
-                {
-                    if *authority == self.fee_payer_pubkey
-                        && !self.fee_payer_policy.token_2022.allow_initialize_mint
-                    {
-                        return Err(KoraError::InvalidTransaction(
-                            "Fee payer cannot be set as Token2022 pausable authority".to_string(),
-                        ));
-                    }
-                }
-            }
-        }
+        validate_token2022!(self, spl_instructions, SplTokenInitializePausable,
+            ParsedSPLInstructionData::SplTokenInitializePausable { authority } =>
+            *authority == self.fee_payer_pubkey,
+            self.fee_payer_policy.token_2022.allow_initialize_mint,
+            "Fee payer cannot be set as Token2022 pausable authority");
 
-        if let Some(instructions) = spl_instructions.get(&ParsedSPLInstructionType::SplTokenPause) {
-            for instruction in instructions {
-                if let ParsedSPLInstructionData::SplTokenPause { authority, multisig_signers } =
-                    instruction
-                {
-                    if (*authority == self.fee_payer_pubkey
-                        || multisig_signers.contains(&self.fee_payer_pubkey))
-                        && !self.fee_payer_policy.token_2022.allow_freeze_account
-                    {
-                        return Err(KoraError::InvalidTransaction(
-                            "Fee payer cannot be used for Token2022 Pause".to_string(),
-                        ));
-                    }
-                }
-            }
-        }
+        validate_token2022!(self, spl_instructions, SplTokenPause,
+            ParsedSPLInstructionData::SplTokenPause { authority, multisig_signers } =>
+            (*authority == self.fee_payer_pubkey
+                || multisig_signers.contains(&self.fee_payer_pubkey)),
+            self.fee_payer_policy.token_2022.allow_freeze_account,
+            "Fee payer cannot be used for Token2022 Pause");
 
-        if let Some(instructions) = spl_instructions.get(&ParsedSPLInstructionType::SplTokenResume)
-        {
-            for instruction in instructions {
-                if let ParsedSPLInstructionData::SplTokenResume { authority, multisig_signers } =
-                    instruction
-                {
-                    if (*authority == self.fee_payer_pubkey
-                        || multisig_signers.contains(&self.fee_payer_pubkey))
-                        && !self.fee_payer_policy.token_2022.allow_thaw_account
-                    {
-                        return Err(KoraError::InvalidTransaction(
-                            "Fee payer cannot be used for Token2022 Resume".to_string(),
-                        ));
-                    }
-                }
-            }
-        }
+        validate_token2022!(self, spl_instructions, SplTokenResume,
+            ParsedSPLInstructionData::SplTokenResume { authority, multisig_signers } =>
+            (*authority == self.fee_payer_pubkey
+                || multisig_signers.contains(&self.fee_payer_pubkey)),
+            self.fee_payer_policy.token_2022.allow_thaw_account,
+            "Fee payer cannot be used for Token2022 Resume");
 
-        if let Some(instructions) =
-            spl_instructions.get(&ParsedSPLInstructionType::SplTokenUnknownExtension)
-        {
-            for instruction in instructions {
-                if let ParsedSPLInstructionData::SplTokenUnknownExtension { accounts } = instruction
-                {
-                    if accounts.contains(&self.fee_payer_pubkey) {
-                        return Err(KoraError::InvalidTransaction(
-                            "Fee payer cannot be an account in an unsupported Token-2022 extension \
-                            instruction"
-                                .to_string(),
-                        ));
-                    }
-                }
-            }
-        }
+        validate_token2022!(self, spl_instructions, SplTokenUnknownExtension,
+            ParsedSPLInstructionData::SplTokenUnknownExtension { accounts } =>
+            accounts.contains(&self.fee_payer_pubkey),
+            "Fee payer cannot be an account in an unsupported Token-2022 extension instruction");
 
         Ok(())
     }

--- a/crates/lib/src/validator/transaction_validator.rs
+++ b/crates/lib/src/validator/transaction_validator.rs
@@ -143,7 +143,7 @@ impl TransactionValidator {
         Ok(())
     }
 
-    pub(crate) fn validate_token2022_signing_policies(
+    pub(crate) fn validate_token2022_transfer_hook_signing_policies(
         &self,
         config: &Config,
         transaction_resolved: &mut VersionedTransactionResolved,
@@ -4295,7 +4295,7 @@ mod tests {
 
         validator.validate_transaction(&config, &mut transaction, &rpc_client).await.unwrap();
 
-        let result = validator.validate_token2022_signing_policies(
+        let result = validator.validate_token2022_transfer_hook_signing_policies(
             &config,
             &mut transaction,
             TransferHookValidationFlow::DelayedSigning,
@@ -4336,7 +4336,7 @@ mod tests {
 
         validator.validate_transaction(&config, &mut transaction, &rpc_client).await.unwrap();
 
-        let result = validator.validate_token2022_signing_policies(
+        let result = validator.validate_token2022_transfer_hook_signing_policies(
             &config,
             &mut transaction,
             TransferHookValidationFlow::ImmediateSignAndSend,

--- a/crates/lib/src/validator/transaction_validator.rs
+++ b/crates/lib/src/validator/transaction_validator.rs
@@ -409,6 +409,21 @@ impl TransactionValidator {
             }
         }
 
+        for instruction in spl_instructions
+            .get(&ParsedSPLInstructionType::SplTokenUnknownExtension)
+            .unwrap_or(&vec![])
+        {
+            if let ParsedSPLInstructionData::SplTokenUnknownExtension { accounts } = instruction {
+                if accounts.contains(&self.fee_payer_pubkey) {
+                    return Err(KoraError::InvalidTransaction(
+                        "Fee payer cannot be an account in an unsupported Token-2022 extension \
+                        instruction"
+                            .to_string(),
+                    ));
+                }
+            }
+        }
+
         Ok(())
     }
 
@@ -648,7 +663,10 @@ mod tests {
     };
     use solana_compute_budget_interface::ComputeBudgetInstruction;
     use solana_message::{Message, VersionedMessage};
-    use solana_sdk::instruction::Instruction;
+    use solana_sdk::{
+        instruction::{AccountMeta, Instruction},
+        signature::{Keypair, Signer},
+    };
     use solana_system_interface::{
         instruction::{
             assign, create_account, create_account_with_seed, transfer, transfer_with_seed,
@@ -4090,6 +4108,64 @@ mod tests {
         } else {
             panic!("Expected InvalidTransaction error for token2022 reallocate");
         }
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_token2022_unknown_extension_with_fee_payer_rejected() {
+        let fee_payer = Keypair::new();
+        let rpc_client = RpcMockBuilder::new().build();
+        setup_token2022_config_with_policy(FeePayerPolicy::default());
+
+        let config = get_config().unwrap();
+        let validator = TransactionValidator::new(config, fee_payer.pubkey()).unwrap();
+
+        // PausableExtension — fee payer is an account in the instruction
+        let ix = Instruction {
+            program_id: spl_token_2022_interface::id(),
+            accounts: vec![
+                AccountMeta::new(Pubkey::new_unique(), false),
+                AccountMeta::new_readonly(fee_payer.pubkey(), true),
+            ],
+            data: spl_token_2022_interface::instruction::TokenInstruction::PausableExtension.pack(),
+        };
+
+        let message = VersionedMessage::Legacy(Message::new(&[ix], Some(&fee_payer.pubkey())));
+        let mut transaction =
+            TransactionUtil::new_unsigned_versioned_transaction_resolved(message).unwrap();
+
+        let result = validator.validate_transaction(config, &mut transaction, &rpc_client).await;
+        assert!(
+            matches!(result, Err(KoraError::InvalidTransaction(ref msg)) if msg.contains("unsupported Token-2022 extension")),
+            "Expected rejection when fee payer appears in unknown extension instruction, got: {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_token2022_unknown_extension_without_fee_payer_allowed() {
+        let fee_payer = Keypair::new();
+        let rpc_client = RpcMockBuilder::new().build();
+        setup_token2022_config_with_policy(FeePayerPolicy::default());
+
+        let config = get_config().unwrap();
+        let validator = TransactionValidator::new(config, fee_payer.pubkey()).unwrap();
+
+        let other_authority = Pubkey::new_unique();
+
+        // PausableExtension — fee payer is NOT among the instruction accounts
+        let ix = Instruction {
+            program_id: spl_token_2022_interface::id(),
+            accounts: vec![AccountMeta::new(other_authority, true)],
+            data: spl_token_2022_interface::instruction::TokenInstruction::PausableExtension.pack(),
+        };
+
+        let message = VersionedMessage::Legacy(Message::new(&[ix], Some(&fee_payer.pubkey())));
+        let mut transaction =
+            TransactionUtil::new_unsigned_versioned_transaction_resolved(message).unwrap();
+
+        let result = validator.validate_transaction(config, &mut transaction, &rpc_client).await;
+        assert!(result.is_ok(), "Should allow unknown extension instruction when fee payer is not an account: {result:?}");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- **KORA-17**: The Token-2022 instruction parser had `_ => {}` silently dropping extension instructions (e.g. `PausableExtension`, `TransferHookExtension`). These extensions can designate the fee payer as an authority (pause authority, hook authority) with no policy enforcement. Now, any such instruction records all its account pubkeys as `SplTokenUnknownExtension`; the validator rejects the transaction if the fee payer appears among those accounts — but allows it when the fee payer is absent (so legitimate extension use isn't broken).
- **KORA-13**: `if let Ok(spl_ix) = TokenInstruction::unpack(...)` was silently skipping Token-2022 instructions that failed to parse (malformed data or future instruction types). Token-2022 is a first-class supported program — if we can't parse an instruction we can't validate it, so the transaction is now rejected with a clear error.
- Adds `SplTokenUnknownExtension` variant to `ParsedSPLInstructionType` and `ParsedSPLInstructionData`

## Test plan

- [ ] `just fmt` passes
- [ ] `just unit-test` (lib) passes — 671/671, 4 new tests added
- [ ] `just build` passes
- [ ] Verify `PausableExtension` with fee payer in accounts is rejected
- [ ] Verify `PausableExtension` without fee payer in accounts is allowed
- [ ] Verify malformed Token-2022 instruction data returns a parse error

Fixes TOO-314 (KORA-13, KORA-17)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/solana-foundation/kora/pull/434" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->






## 📊 Unit Test Coverage
![Coverage](https://img.shields.io/badge/coverage-86.2%25-green)

**Unit Test Coverage: 86.2%**

[View Detailed Coverage Report](https://github.com/solana-foundation/kora/actions/runs/24739746697)