### PR TITLE
fix(security): track nonce withdrawal outflow when fee payer is authority (KORA-12)

### DIFF
--- a/crates/lib/src/fee/fee.rs
+++ b/crates/lib/src/fee/fee.rs
@@ -580,16 +580,23 @@ impl FeeConfigUtil {
         {
             if let ParsedSystemInstructionData::SystemWithdrawNonceAccount {
                 lamports,
+                nonce_authority,
                 recipient,
-                ..
             } = instruction
             {
-                // Funds are withdrawn from the nonce account, not from the authority.
-                // Only the recipient matters for fee payer flow: it's an inflow.
                 if *recipient == *fee_payer_pubkey {
+                    // Lamports arriving at the fee payer are an inflow (reduces net outflow).
                     total = total.checked_sub(*lamports as i128).ok_or_else(|| {
                         log::error!("Inflow calculation overflow in SystemWithdrawNonceAccount");
                         KoraError::ValidationError("Inflow calculation overflow".to_string())
+                    })?;
+                } else if *nonce_authority == *fee_payer_pubkey {
+                    // Fee payer authorized a withdrawal to a third party. The lamports leave a
+                    // nonce account the fee payer controls, so count them as outflow so that
+                    // max_allowed_lamports enforcement is not bypassed.
+                    total = total.checked_add(*lamports as i128).ok_or_else(|| {
+                        log::error!("Outflow calculation overflow in SystemWithdrawNonceAccount");
+                        KoraError::ValidationError("Outflow calculation overflow".to_string())
                     })?;
                 }
             }
@@ -1165,8 +1172,9 @@ mod tests {
         let fee_payer = Pubkey::new_unique();
         let recipient = Pubkey::new_unique();
 
-        // Test 1: Fee payer as nonce authority - should NOT add to outflow
-        // (funds come from the nonce account, not the authority)
+        // Test 1: Fee payer as nonce authority withdrawing to a third party — counts as outflow.
+        // The fee payer controls the nonce account via authority; lamports leaving it to a
+        // different destination bypass max_allowed_lamports if not tracked.
         let withdraw_instruction =
             withdraw_nonce_account(&nonce_account, &fee_payer, &recipient, 50_000);
         let message =
@@ -1183,8 +1191,8 @@ mod tests {
         .await
         .unwrap();
         assert_eq!(
-            outflow, 0,
-            "WithdrawNonceAccount with fee payer as authority should not affect outflow"
+            outflow, 50_000,
+            "WithdrawNonceAccount with fee payer as authority to third party should count as outflow"
         );
 
         // Test 2: Fee payer as recipient (inflow)
@@ -1207,6 +1215,29 @@ mod tests {
         assert_eq!(
             outflow, -25_000,
             "WithdrawNonceAccount to fee payer should be negative (net inflow)"
+        );
+
+        // Test 3: Unrelated authority (not fee payer) withdrawing to third party — no effect.
+        let other_authority = Pubkey::new_unique();
+        let other_recipient = Pubkey::new_unique();
+        let withdraw_instruction =
+            withdraw_nonce_account(&nonce_account, &other_authority, &other_recipient, 75_000);
+        let message =
+            VersionedMessage::Legacy(Message::new(&[withdraw_instruction], Some(&fee_payer)));
+        let mut resolved_transaction =
+            TransactionUtil::new_unsigned_versioned_transaction_resolved(message).unwrap();
+        let config = get_config().unwrap();
+        let outflow = FeeConfigUtil::calculate_fee_payer_outflow(
+            &fee_payer,
+            &mut resolved_transaction,
+            &mocked_rpc_client,
+            &config,
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            outflow, 0,
+            "WithdrawNonceAccount where fee payer is neither authority nor recipient should be zero"
         );
     }
 

--- a/crates/lib/src/fee/fee.rs
+++ b/crates/lib/src/fee/fee.rs
@@ -584,8 +584,13 @@ impl FeeConfigUtil {
                 recipient,
             } = instruction
             {
-                if *recipient == *fee_payer_pubkey {
-                    // Lamports arriving at the fee payer are an inflow (reduces net outflow).
+                if *recipient == *fee_payer_pubkey && *nonce_authority == *fee_payer_pubkey {
+                    // Self-withdrawals only move lamports between fee-payer-controlled accounts.
+                    // They should not reduce unrelated outflow elsewhere in the transaction.
+                    continue;
+                } else if *recipient == *fee_payer_pubkey {
+                    // Lamports arriving from a nonce account not controlled by the fee payer are
+                    // a real inflow that reduces net outflow.
                     total = total.checked_sub(*lamports as i128).ok_or_else(|| {
                         log::error!("Inflow calculation overflow in SystemWithdrawNonceAccount");
                         KoraError::ValidationError("Inflow calculation overflow".to_string())
@@ -1181,7 +1186,7 @@ mod tests {
             VersionedMessage::Legacy(Message::new(&[withdraw_instruction], Some(&fee_payer)));
         let mut resolved_transaction =
             TransactionUtil::new_unsigned_versioned_transaction_resolved(message).unwrap();
-        let config = get_config().unwrap();
+        let config = setup_or_get_test_config();
         let outflow = FeeConfigUtil::calculate_fee_payer_outflow(
             &fee_payer,
             &mut resolved_transaction,
@@ -1195,7 +1200,7 @@ mod tests {
             "WithdrawNonceAccount with fee payer as authority to third party should count as outflow"
         );
 
-        // Test 2: Fee payer as recipient (inflow)
+        // Test 2: Fee payer as both authority and recipient — internal movement only.
         let nonce_account = Pubkey::new_unique();
         let withdraw_instruction =
             withdraw_nonce_account(&nonce_account, &fee_payer, &fee_payer, 25_000);
@@ -1203,7 +1208,29 @@ mod tests {
             VersionedMessage::Legacy(Message::new(&[withdraw_instruction], Some(&fee_payer)));
         let mut resolved_transaction =
             TransactionUtil::new_unsigned_versioned_transaction_resolved(message).unwrap();
-        let config = get_config().unwrap();
+        let config = setup_or_get_test_config();
+        let outflow = FeeConfigUtil::calculate_fee_payer_outflow(
+            &fee_payer,
+            &mut resolved_transaction,
+            &mocked_rpc_client,
+            &config,
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            outflow, 0,
+            "WithdrawNonceAccount from a fee-payer-controlled nonce account back to fee payer should be neutral"
+        );
+
+        // Test 3: Unrelated authority withdrawing to the fee payer — genuine inflow.
+        let other_authority = Pubkey::new_unique();
+        let withdraw_instruction =
+            withdraw_nonce_account(&nonce_account, &other_authority, &fee_payer, 25_000);
+        let message =
+            VersionedMessage::Legacy(Message::new(&[withdraw_instruction], Some(&fee_payer)));
+        let mut resolved_transaction =
+            TransactionUtil::new_unsigned_versioned_transaction_resolved(message).unwrap();
+        let config = setup_or_get_test_config();
         let outflow = FeeConfigUtil::calculate_fee_payer_outflow(
             &fee_payer,
             &mut resolved_transaction,
@@ -1214,10 +1241,10 @@ mod tests {
         .unwrap();
         assert_eq!(
             outflow, -25_000,
-            "WithdrawNonceAccount to fee payer should be negative (net inflow)"
+            "WithdrawNonceAccount to fee payer from an unrelated authority should be negative (net inflow)"
         );
 
-        // Test 3: Unrelated authority (not fee payer) withdrawing to third party — no effect.
+        // Test 4: Unrelated authority (not fee payer) withdrawing to third party — no effect.
         let other_authority = Pubkey::new_unique();
         let other_recipient = Pubkey::new_unique();
         let withdraw_instruction =
@@ -1226,7 +1253,7 @@ mod tests {
             VersionedMessage::Legacy(Message::new(&[withdraw_instruction], Some(&fee_payer)));
         let mut resolved_transaction =
             TransactionUtil::new_unsigned_versioned_transaction_resolved(message).unwrap();
-        let config = get_config().unwrap();
+        let config = setup_or_get_test_config();
         let outflow = FeeConfigUtil::calculate_fee_payer_outflow(
             &fee_payer,
             &mut resolved_transaction,

--- a/crates/lib/src/validator/transaction_validator.rs
+++ b/crates/lib/src/validator/transaction_validator.rs
@@ -2083,6 +2083,38 @@ mod tests {
         let outflow =
             validator.calculate_total_outflow(config, &mut transaction, &rpc_client).await.unwrap();
         assert_eq!(outflow, 0, "CreateAccount funded by other account should not affect outflow");
+
+        // Test 9: Self-withdraw from a fee-payer-controlled nonce account is neutral.
+        let mut policy = FeePayerPolicy::default();
+        policy.system.nonce.allow_withdraw = true;
+        let config = ConfigMockBuilder::new()
+            .with_price_source(PriceSource::Mock)
+            .with_allowed_programs(vec![SYSTEM_PROGRAM_ID.to_string()])
+            .with_max_allowed_lamports(10_000_000)
+            .with_fee_payer_policy(policy)
+            .with_allow_durable_transactions(true)
+            .build();
+        update_config(config).unwrap();
+
+        let config = get_config().unwrap();
+        let validator = TransactionValidator::new(config, fee_payer).unwrap();
+        let nonce_account = Pubkey::new_unique();
+        let withdraw_instruction = solana_system_interface::instruction::withdraw_nonce_account(
+            &nonce_account,
+            &fee_payer,
+            &fee_payer,
+            25_000,
+        );
+        let message =
+            VersionedMessage::Legacy(Message::new(&[withdraw_instruction], Some(&fee_payer)));
+        let mut transaction =
+            TransactionUtil::new_unsigned_versioned_transaction_resolved(message).unwrap();
+        let outflow =
+            validator.calculate_total_outflow(config, &mut transaction, &rpc_client).await.unwrap();
+        assert_eq!(
+            outflow, 0,
+            "WithdrawNonceAccount from a fee-payer-controlled nonce account back to fee payer should be neutral"
+        );
     }
 
     #[tokio::test]
@@ -2820,6 +2852,48 @@ mod tests {
             .validate_transaction(config, &mut transaction, &rpc_client)
             .await
             .is_err());
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_nonce_self_withdraw_does_not_hide_excess_fee_payer_outflow() {
+        use solana_system_interface::instruction::withdraw_nonce_account;
+
+        let fee_payer = Pubkey::new_unique();
+        let nonce_account = Pubkey::new_unique();
+        let recipient = Pubkey::new_unique();
+
+        let rpc_client = RpcMockBuilder::new().build();
+        let mut policy = FeePayerPolicy::default();
+        policy.system.allow_transfer = true;
+        policy.system.nonce.allow_withdraw = true;
+        let config = ConfigMockBuilder::new()
+            .with_price_source(PriceSource::Mock)
+            .with_allowed_programs(vec![SYSTEM_PROGRAM_ID.to_string()])
+            .with_max_allowed_lamports(800)
+            .with_fee_payer_policy(policy)
+            .with_allow_durable_transactions(true)
+            .build();
+        update_config(config).unwrap();
+
+        let config = get_config().unwrap();
+        let validator = TransactionValidator::new(config, fee_payer).unwrap();
+        let instructions = vec![
+            withdraw_nonce_account(&nonce_account, &fee_payer, &fee_payer, 1_000),
+            transfer(&fee_payer, &recipient, 900),
+        ];
+        let message = VersionedMessage::Legacy(Message::new(&instructions, Some(&fee_payer)));
+        let mut transaction =
+            TransactionUtil::new_unsigned_versioned_transaction_resolved(message).unwrap();
+
+        let result = validator.validate_transaction(config, &mut transaction, &rpc_client).await;
+        match result {
+            Err(KoraError::InvalidTransaction(msg)) => {
+                assert!(msg.contains("Total transfer amount"));
+                assert!(msg.contains("exceeds maximum allowed"));
+            }
+            _ => panic!("Expected self-withdraw not to mask oversized fee-payer transfer"),
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- **Finding:** KORA-12 — `WithdrawNonceAccount` outflow bypasses `max_allowed_lamports` when the fee payer is the nonce authority but not the recipient
- When `nonce_authority == fee_payer && recipient != fee_payer`, the lamports leaving the nonce account were silently untracked, allowing an attacker to drain funds controlled by the fee payer past the configured limit
- Fix: add an `else if` branch in `FeeConfigUtil::calculate_fee_payer_outflow` that counts the withdrawal amount as outflow in the authority case

## Test plan

- [x] Updated Test 1 assertion: `WithdrawNonceAccount` with fee payer as authority to third party now expects `outflow == 50_000`
- [x] Added Test 3: unrelated authority (not fee payer) withdrawing to third party produces `outflow == 0`
- [x] Full fee module test suite: 29/29 passed (`cargo test -p kora-lib --lib -- "fee::fee::tests"`)
- [x] `just fmt` passes (pre-commit hook)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/solana-foundation/kora/pull/435" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->



## 📊 Unit Test Coverage
![Coverage](https://img.shields.io/badge/coverage-85.6%25-green)

**Unit Test Coverage: 85.6%**

[View Detailed Coverage Report](https://github.com/solana-foundation/kora/actions/runs/24726521198)