### PR TITLE
fix: harden fee payer accounting and move CI secrets to Doppler

### DIFF
--- a/.github/workflows/fork-external-live-manual.yml
+++ b/.github/workflows/fork-external-live-manual.yml
@@ -11,6 +11,7 @@ on:
 permissions:
   actions: write
   contents: read
+  id-token: write
   issues: write
   pull-requests: write
 
@@ -75,9 +76,15 @@ jobs:
       - name: Setup Solana CLI
         uses: ./.github/actions/setup-solana
 
+      - uses: dopplerhq/secrets-fetch-action@v2.0.0
+        with:
+          auth-method: oidc
+          doppler-identity-id: ${{ vars.DOPPLER_SERVICE_IDENTITY_ID }}
+          doppler-project: ${{ vars.DOPPLER_PROJECT || 'kora' }}
+          doppler-config: ${{ vars.DOPPLER_CONFIG_EXTERNAL_LIVE || vars.DOPPLER_CONFIG_CI || 'stg_github' }}
+          inject-env-vars: true
+
       - name: Ensure Jupiter API key is configured
-        env:
-          JUPITER_API_KEY: ${{ secrets.JUPITER_API_KEY }}
         run: |
           if [ -z "${JUPITER_API_KEY}" ]; then
             echo "JUPITER_API_KEY is required for fork external live tests." >&2
@@ -88,8 +95,6 @@ jobs:
         uses: ./.github/actions/run-test-runner
         with:
           filters: "--filter external_live"
-        env:
-          JUPITER_API_KEY: ${{ secrets.JUPITER_API_KEY }}
 
       - name: Cleanup test environment
         if: always()

--- a/.github/workflows/rust-unit.yml
+++ b/.github/workflows/rust-unit.yml
@@ -28,6 +28,7 @@ jobs:
     timeout-minutes: 15
     permissions:
       contents: read
+      id-token: write
       pull-requests: write
     steps:
       - uses: actions/checkout@v4
@@ -47,12 +48,18 @@ jobs:
       - name: Setup Solana CLI
         uses: ./.github/actions/setup-solana
 
+      - uses: dopplerhq/secrets-fetch-action@v2.0.0
+        with:
+          auth-method: oidc
+          doppler-identity-id: ${{ vars.DOPPLER_SERVICE_IDENTITY_ID }}
+          doppler-project: ${{ vars.DOPPLER_PROJECT || 'kora' }}
+          doppler-config: ${{ vars.DOPPLER_CONFIG_CI || 'stg_github' }}
+          inject-env-vars: true
+
       - name: Install cargo-llvm-cov for coverage
         run: cargo install cargo-llvm-cov
 
       - name: Run unit tests with coverage
-        env:
-          JUPITER_API_KEY: ${{ secrets.JUPITER_API_KEY }}
         run: |
           echo "🧪 Running unit tests with coverage instrumentation..."
           cargo llvm-cov clean --workspace

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -40,6 +40,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     timeout-minutes: 25
+    permissions:
+      contents: read
+      id-token: write
     strategy:
       fail-fast: false
       matrix:
@@ -65,12 +68,18 @@ jobs:
       - name: Setup Solana CLI
         uses: ./.github/actions/setup-solana
 
+      - uses: dopplerhq/secrets-fetch-action@v2.0.0
+        with:
+          auth-method: oidc
+          doppler-identity-id: ${{ vars.DOPPLER_SERVICE_IDENTITY_ID }}
+          doppler-project: ${{ vars.DOPPLER_PROJECT || 'kora' }}
+          doppler-config: ${{ vars.DOPPLER_CONFIG_CI || 'stg_github' }}
+          inject-env-vars: true
+
       - name: Run integration tests
         uses: ./.github/actions/run-test-runner
         with:
           filters: "--filter ${{ matrix.test-group }}"
-        env:
-          JUPITER_API_KEY: ${{ secrets.JUPITER_API_KEY }}
 
       - name: Cleanup test environment
         if: always()

--- a/crates/lib/src/bundle/helper.rs
+++ b/crates/lib/src/bundle/helper.rs
@@ -177,23 +177,18 @@ impl BundleProcessor {
         }
 
         // Phase 2: Calculate payments with cross-tx ATA visibility
-        let mut total_payment_lamports = 0u64;
+        let mut bundle_payment_totals = crate::token::token::PaymentLamportTotals::default();
         let mut total_solana_estimated_fee = 0u64;
         for resolved in resolved_transactions.iter_mut() {
-            if let Some(payment) = TokenUtil::find_payment_in_transaction(
+            let payment_totals = TokenUtil::calculate_payment_lamport_totals(
                 config,
                 resolved,
                 rpc_client,
                 payment_destination,
                 Some(&all_bundle_instructions),
             )
-            .await?
-            {
-                total_payment_lamports =
-                    total_payment_lamports.checked_add(payment).ok_or_else(|| {
-                        KoraError::ValidationError("Payment calculation overflow".to_string())
-                    })?;
-            }
+            .await?;
+            bundle_payment_totals.checked_add_assign(payment_totals)?;
 
             let fee = TransactionFeeUtil::get_estimate_fee_resolved(rpc_client, resolved).await?;
             total_solana_estimated_fee =
@@ -203,6 +198,8 @@ impl BundleProcessor {
 
             validator.validate_lamport_fee(total_solana_estimated_fee)?;
         }
+
+        let total_payment_lamports = bundle_payment_totals.net_payment().unwrap_or(0);
 
         Ok(Self {
             resolved_transactions,
@@ -307,6 +304,44 @@ mod tests {
     fn test_transfer_hook_validation_flow_for_bundle_estimation_context() {
         let flow = transfer_hook_validation_flow_for_bundle(None);
         assert_eq!(flow, TransferHookValidationFlow::ImmediateSignAndSend);
+    }
+
+    #[test]
+    fn test_bundle_payment_netting_zeroes_cross_transaction_refund_loop() {
+        let mut bundle_payment_totals = crate::token::token::PaymentLamportTotals::default();
+        bundle_payment_totals
+            .checked_add_assign(crate::token::token::PaymentLamportTotals {
+                inflow: 7_500_000,
+                outflow: 0,
+            })
+            .unwrap();
+        bundle_payment_totals
+            .checked_add_assign(crate::token::token::PaymentLamportTotals {
+                inflow: 0,
+                outflow: 7_500_000,
+            })
+            .unwrap();
+
+        assert_eq!(bundle_payment_totals.net_payment(), None);
+    }
+
+    #[test]
+    fn test_bundle_payment_netting_preserves_positive_residual() {
+        let mut bundle_payment_totals = crate::token::token::PaymentLamportTotals::default();
+        bundle_payment_totals
+            .checked_add_assign(crate::token::token::PaymentLamportTotals {
+                inflow: 10_000_000,
+                outflow: 0,
+            })
+            .unwrap();
+        bundle_payment_totals
+            .checked_add_assign(crate::token::token::PaymentLamportTotals {
+                inflow: 0,
+                outflow: 2_500_000,
+            })
+            .unwrap();
+
+        assert_eq!(bundle_payment_totals.net_payment(), Some(7_500_000));
     }
 
     #[test]

--- a/crates/lib/src/bundle/helper.rs
+++ b/crates/lib/src/bundle/helper.rs
@@ -6,7 +6,7 @@ use crate::{
     lighthouse::LighthouseUtil,
     plugin::{PluginExecutionContext, TransactionPluginRunner},
     signer::bundle_signer::BundleSigner,
-    token::token::{TokenUtil, TransferHookValidationFlow},
+    token::token::{PaymentLamportTotals, TokenUtil, TransferHookValidationFlow},
     transaction::{TransactionUtil, VersionedTransactionResolved},
     usage_limit::UsageTracker,
     validator::transaction_validator::TransactionValidator,
@@ -177,7 +177,7 @@ impl BundleProcessor {
         }
 
         // Phase 2: Calculate payments with cross-tx ATA visibility
-        let mut bundle_payment_totals = crate::token::token::PaymentLamportTotals::default();
+        let mut bundle_payment_totals = PaymentLamportTotals::default();
         let mut total_solana_estimated_fee = 0u64;
         for resolved in resolved_transactions.iter_mut() {
             let payment_totals = TokenUtil::calculate_payment_lamport_totals(
@@ -308,18 +308,12 @@ mod tests {
 
     #[test]
     fn test_bundle_payment_netting_zeroes_cross_transaction_refund_loop() {
-        let mut bundle_payment_totals = crate::token::token::PaymentLamportTotals::default();
+        let mut bundle_payment_totals = PaymentLamportTotals::default();
         bundle_payment_totals
-            .checked_add_assign(crate::token::token::PaymentLamportTotals {
-                inflow: 7_500_000,
-                outflow: 0,
-            })
+            .checked_add_assign(PaymentLamportTotals { inflow: 7_500_000, outflow: 0 })
             .unwrap();
         bundle_payment_totals
-            .checked_add_assign(crate::token::token::PaymentLamportTotals {
-                inflow: 0,
-                outflow: 7_500_000,
-            })
+            .checked_add_assign(PaymentLamportTotals { inflow: 0, outflow: 7_500_000 })
             .unwrap();
 
         assert_eq!(bundle_payment_totals.net_payment(), None);
@@ -327,18 +321,12 @@ mod tests {
 
     #[test]
     fn test_bundle_payment_netting_preserves_positive_residual() {
-        let mut bundle_payment_totals = crate::token::token::PaymentLamportTotals::default();
+        let mut bundle_payment_totals = PaymentLamportTotals::default();
         bundle_payment_totals
-            .checked_add_assign(crate::token::token::PaymentLamportTotals {
-                inflow: 10_000_000,
-                outflow: 0,
-            })
+            .checked_add_assign(PaymentLamportTotals { inflow: 10_000_000, outflow: 0 })
             .unwrap();
         bundle_payment_totals
-            .checked_add_assign(crate::token::token::PaymentLamportTotals {
-                inflow: 0,
-                outflow: 2_500_000,
-            })
+            .checked_add_assign(PaymentLamportTotals { inflow: 0, outflow: 2_500_000 })
             .unwrap();
 
         assert_eq!(bundle_payment_totals.net_payment(), Some(7_500_000));

--- a/crates/lib/src/bundle/helper.rs
+++ b/crates/lib/src/bundle/helper.rs
@@ -199,7 +199,7 @@ impl BundleProcessor {
             validator.validate_lamport_fee(total_solana_estimated_fee)?;
         }
 
-        let total_payment_lamports = bundle_payment_totals.net_payment().unwrap_or(0);
+        let total_payment_lamports = bundle_payment_totals.net_payment();
 
         Ok(Self {
             resolved_transactions,
@@ -316,7 +316,7 @@ mod tests {
             .checked_add_assign(PaymentLamportTotals { inflow: 0, outflow: 7_500_000 })
             .unwrap();
 
-        assert_eq!(bundle_payment_totals.net_payment(), None);
+        assert_eq!(bundle_payment_totals.net_payment(), 0);
     }
 
     #[test]
@@ -329,7 +329,7 @@ mod tests {
             .checked_add_assign(PaymentLamportTotals { inflow: 0, outflow: 2_500_000 })
             .unwrap();
 
-        assert_eq!(bundle_payment_totals.net_payment(), Some(7_500_000));
+        assert_eq!(bundle_payment_totals.net_payment(), 7_500_000);
     }
 
     #[test]

--- a/crates/lib/src/constant.rs
+++ b/crates/lib/src/constant.rs
@@ -220,12 +220,14 @@ pub mod instruction_indexes {
         pub const OWNER_INDEX: usize = 3;
     }
 
-    // ATA instruction indexes
+    // ATA Create/CreateIdempotent account layout:
+    // https://github.com/solana-program/associated-token-account/blob/7af39d84438199e7e488adc379baa8ee0b8085c0/interface/src/instruction.rs#L19-L38
     pub mod ata_instruction_indexes {
         pub const PAYER_INDEX: usize = 0;
         pub const ATA_ADDRESS_INDEX: usize = 1;
         pub const WALLET_OWNER_INDEX: usize = 2;
         pub const MINT_INDEX: usize = 3;
+        pub const SYSTEM_PROGRAM_INDEX: usize = 4;
         pub const TOKEN_PROGRAM_INDEX: usize = 5;
         pub const MIN_ACCOUNTS: usize = 6;
     }

--- a/crates/lib/src/constant.rs
+++ b/crates/lib/src/constant.rs
@@ -221,9 +221,11 @@ pub mod instruction_indexes {
 
     // ATA instruction indexes
     pub mod ata_instruction_indexes {
+        pub const PAYER_INDEX: usize = 0;
         pub const ATA_ADDRESS_INDEX: usize = 1;
         pub const WALLET_OWNER_INDEX: usize = 2;
         pub const MINT_INDEX: usize = 3;
+        pub const TOKEN_PROGRAM_INDEX: usize = 5;
         pub const MIN_ACCOUNTS: usize = 6;
     }
 

--- a/crates/lib/src/constant.rs
+++ b/crates/lib/src/constant.rs
@@ -49,8 +49,9 @@ pub const DEFAULT_MAX_REQUEST_BODY_SIZE: usize = 2 * 1024 * 1024; // 2 MB
 // Instruction indexes for the instructions that we support to parse from the transaction
 pub mod instruction_indexes {
     pub mod system_create_account {
-        pub const REQUIRED_NUMBER_OF_ACCOUNTS: usize = 1;
+        pub const REQUIRED_NUMBER_OF_ACCOUNTS: usize = 2;
         pub const PAYER_INDEX: usize = 0;
+        pub const NEW_ACCOUNT_INDEX: usize = 1;
     }
 
     pub mod system_transfer {

--- a/crates/lib/src/fee/fee.rs
+++ b/crates/lib/src/fee/fee.rs
@@ -614,7 +614,7 @@ impl FeeConfigUtil {
         let ata_outflow =
             Self::calculate_ata_creation_outflow(fee_payer_pubkey, transaction, rpc_client, config)
                 .await?;
-        total = total.checked_add(ata_outflow).ok_or_else(|| {
+        total = total.checked_add(ata_outflow as i128).ok_or_else(|| {
             log::error!(
                 "Outflow calculation overflow in ATA accounting: sol_total={}, ata_outflow={}",
                 total,

--- a/crates/lib/src/fee/fee.rs
+++ b/crates/lib/src/fee/fee.rs
@@ -1,4 +1,7 @@
-use std::str::FromStr;
+use std::{
+    collections::{HashMap, HashSet},
+    str::FromStr,
+};
 
 use crate::{
     config::Config,
@@ -7,7 +10,7 @@ use crate::{
     fee::price::PriceModel,
     token::{
         spl_token_2022::Token2022Mint,
-        token::{TokenType, TokenUtil, TransferHookValidationFlow},
+        token::{AtaCreationInstructionInfo, TokenType, TokenUtil, TransferHookValidationFlow},
         TokenState,
     },
     transaction::{
@@ -23,7 +26,9 @@ use crate::cache::CacheUtil;
 use crate::tests::cache_mock::MockCacheUtil as CacheUtil;
 use solana_client::nonblocking::rpc_client::RpcClient;
 use solana_message::VersionedMessage;
+use solana_program_pack::Pack;
 use solana_sdk::pubkey::Pubkey;
+use solana_system_interface::{instruction::SystemInstruction, program::ID as SYSTEM_PROGRAM_ID};
 
 #[derive(Debug, Clone)]
 pub struct TotalFeeCalculation {
@@ -389,6 +394,146 @@ impl FeeConfigUtil {
         }
     }
 
+    fn collect_system_created_accounts_by_fee_payer(
+        transaction: &VersionedTransactionResolved,
+        fee_payer_pubkey: &Pubkey,
+    ) -> HashSet<Pubkey> {
+        transaction
+            .all_instructions
+            .iter()
+            .filter(|instruction| instruction.program_id == SYSTEM_PROGRAM_ID)
+            .filter_map(|instruction| {
+                if instruction.accounts.len() < 2 {
+                    return None;
+                }
+
+                match bincode::deserialize::<SystemInstruction>(&instruction.data) {
+                    Ok(SystemInstruction::CreateAccount { .. })
+                    | Ok(SystemInstruction::CreateAccountWithSeed { .. }) => {
+                        let payer = instruction.accounts[0].pubkey;
+                        let new_account = instruction.accounts[1].pubkey;
+                        if payer == *fee_payer_pubkey {
+                            Some(new_account)
+                        } else {
+                            None
+                        }
+                    }
+                    _ => None,
+                }
+            })
+            .collect()
+    }
+
+    async fn estimate_ata_account_len(
+        ata_creation: &AtaCreationInstructionInfo,
+        rpc_client: &RpcClient,
+        config: &Config,
+        token2022_account_len_cache: &mut HashMap<Pubkey, usize>,
+    ) -> Result<usize, KoraError> {
+        if ata_creation.token_program == spl_token_interface::id() {
+            return Ok(spl_token_interface::state::Account::LEN);
+        }
+
+        if ata_creation.token_program == spl_token_2022_interface::id() {
+            if let Some(account_len) = token2022_account_len_cache.get(&ata_creation.mint) {
+                return Ok(*account_len);
+            }
+
+            let mint_state = TokenUtil::get_mint(config, rpc_client, &ata_creation.mint).await?;
+            let account_len = if let Some(token2022_mint) =
+                mint_state.as_any().downcast_ref::<Token2022Mint>()
+            {
+                let required_account_extensions =
+                    spl_token_2022_interface::extension::ExtensionType::get_required_init_account_extensions(
+                        &token2022_mint.extensions_types,
+                    );
+
+                spl_token_2022_interface::extension::ExtensionType::try_calculate_account_len::<
+                    spl_token_2022_interface::state::Account,
+                >(&required_account_extensions)
+                .map_err(|e| {
+                    KoraError::ValidationError(format!(
+                        "Failed to estimate Token2022 ATA account size for mint {}: {}",
+                        ata_creation.mint, e
+                    ))
+                })?
+            } else {
+                spl_token_interface::state::Account::LEN
+            };
+
+            token2022_account_len_cache.insert(ata_creation.mint, account_len);
+            return Ok(account_len);
+        }
+
+        // Unsupported token programs should fail on-chain, but use conservative SPL account length
+        // for safety if they are present in a transaction we are estimating.
+        Ok(spl_token_interface::state::Account::LEN)
+    }
+
+    async fn calculate_ata_creation_outflow(
+        fee_payer_pubkey: &Pubkey,
+        transaction: &VersionedTransactionResolved,
+        rpc_client: &RpcClient,
+        config: &Config,
+    ) -> Result<u64, KoraError> {
+        let ata_creations = TokenUtil::find_fee_payer_ata_creations(
+            &transaction.all_instructions,
+            fee_payer_pubkey,
+        );
+        if ata_creations.is_empty() {
+            return Ok(0);
+        }
+
+        let system_created_accounts =
+            Self::collect_system_created_accounts_by_fee_payer(transaction, fee_payer_pubkey);
+        let mut rent_cache_by_account_len: HashMap<usize, u64> = HashMap::new();
+        let mut token2022_account_len_cache: HashMap<Pubkey, usize> = HashMap::new();
+        let mut total = 0u64;
+
+        for ata_creation in ata_creations {
+            // If simulation already surfaced the underlying SystemCreateAccount CPI for this ATA,
+            // it has already been counted from parsed system instructions.
+            if system_created_accounts.contains(&ata_creation.ata_address) {
+                continue;
+            }
+
+            let account_len = Self::estimate_ata_account_len(
+                &ata_creation,
+                rpc_client,
+                config,
+                &mut token2022_account_len_cache,
+            )
+            .await?;
+
+            let rent_lamports = if let Some(rent) = rent_cache_by_account_len.get(&account_len) {
+                *rent
+            } else {
+                let rent = rpc_client
+                    .get_minimum_balance_for_rent_exemption(account_len)
+                    .await
+                    .map_err(|e| {
+                        KoraError::RpcError(format!(
+                            "Failed to fetch rent exemption for account length {}: {}",
+                            account_len, e
+                        ))
+                    })?;
+                rent_cache_by_account_len.insert(account_len, rent);
+                rent
+            };
+
+            total = total.checked_add(rent_lamports).ok_or_else(|| {
+                log::error!(
+                    "Outflow calculation overflow in ATA creation accounting: total={}, rent={}",
+                    total,
+                    rent_lamports
+                );
+                KoraError::ValidationError("Outflow calculation overflow".to_string())
+            })?;
+        }
+
+        Ok(total)
+    }
+
     /// Calculate the total outflow (SOL + SPL token value) that could occur for a fee payer account in a transaction.
     /// This includes SOL transfers, account creation, SPL token transfers, and other operations that could drain the fee payer's balance.
     pub async fn calculate_fee_payer_outflow(
@@ -462,6 +607,21 @@ impl FeeConfigUtil {
                 }
             }
         }
+
+        // ATA Create/CreateIdempotent can be no-ops during simulation depending on prestate.
+        // Charge conservative rent for fee-payer-funded ATA creations whenever inner SystemCreateAccount
+        // did not surface, preventing stale-state rent drain windows.
+        let ata_outflow =
+            Self::calculate_ata_creation_outflow(fee_payer_pubkey, transaction, rpc_client, config)
+                .await?;
+        total = total.checked_add(ata_outflow).ok_or_else(|| {
+            log::error!(
+                "Outflow calculation overflow in ATA accounting: sol_total={}, ata_outflow={}",
+                total,
+                ata_outflow
+            );
+            KoraError::ValidationError("Outflow calculation overflow".to_string())
+        })?;
 
         // Calculate SPL token transfer outflow (converted to lamports value)
         let spl_instructions = transaction.get_or_parse_spl_instructions()?;
@@ -1122,6 +1282,96 @@ mod tests {
         .await
         .unwrap();
         assert_eq!(outflow, 0, "Non-system program should not affect outflow");
+    }
+
+    #[tokio::test]
+    async fn test_calculate_fee_payer_outflow_ata_idempotent_without_inner_create() {
+        let _m = ConfigMockBuilder::new().build_and_setup();
+        let fee_payer = Pubkey::new_unique();
+        let owner = Pubkey::new_unique();
+        let mint = Pubkey::new_unique();
+
+        let mocked_rpc_client = RpcMockBuilder::new()
+            .with_custom_mock(
+                solana_client::rpc_request::RpcRequest::GetMinimumBalanceForRentExemption,
+                serde_json::json!(2_039_280),
+            )
+            .build();
+
+        let ata_ix =
+            spl_associated_token_account_interface::instruction::create_associated_token_account_idempotent(
+                &fee_payer,
+                &owner,
+                &mint,
+                &spl_token_interface::id(),
+            );
+        let message = VersionedMessage::Legacy(Message::new(&[ata_ix], Some(&fee_payer)));
+        let mut resolved_transaction =
+            TransactionUtil::new_unsigned_versioned_transaction_resolved(message).unwrap();
+
+        let config = get_config().unwrap();
+        let outflow = FeeConfigUtil::calculate_fee_payer_outflow(
+            &fee_payer,
+            &mut resolved_transaction,
+            &mocked_rpc_client,
+            &config,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            outflow, 2_039_280,
+            "ATA idempotent without surfaced inner create should conservatively charge ATA rent"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_calculate_fee_payer_outflow_ata_not_double_counted_with_system_create() {
+        let _m = ConfigMockBuilder::new().build_and_setup();
+        let fee_payer = Pubkey::new_unique();
+        let owner = Pubkey::new_unique();
+        let mint = Pubkey::new_unique();
+        let ata_address =
+            spl_associated_token_account_interface::address::get_associated_token_address(
+                &owner, &mint,
+            );
+
+        let mocked_rpc_client = RpcMockBuilder::new()
+            .with_custom_mock(
+                solana_client::rpc_request::RpcRequest::GetMinimumBalanceForRentExemption,
+                serde_json::json!(2_039_280),
+            )
+            .build();
+
+        let ata_ix =
+            spl_associated_token_account_interface::instruction::create_associated_token_account_idempotent(
+                &fee_payer,
+                &owner,
+                &mint,
+                &spl_token_interface::id(),
+            );
+        let system_create_ix =
+            create_account(&fee_payer, &ata_address, 123_456, 165, &spl_token_interface::id());
+
+        let message =
+            VersionedMessage::Legacy(Message::new(&[ata_ix, system_create_ix], Some(&fee_payer)));
+        let mut resolved_transaction =
+            TransactionUtil::new_unsigned_versioned_transaction_resolved(message).unwrap();
+
+        let config = get_config().unwrap();
+        let outflow = FeeConfigUtil::calculate_fee_payer_outflow(
+            &fee_payer,
+            &mut resolved_transaction,
+            &mocked_rpc_client,
+            &config,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            outflow, 123_456,
+            "When SystemCreateAccount for the ATA is present, ATA rent fallback must not double count"
+        );
     }
 
     #[tokio::test]

--- a/crates/lib/src/fee/fee.rs
+++ b/crates/lib/src/fee/fee.rs
@@ -28,6 +28,7 @@ use solana_client::nonblocking::rpc_client::RpcClient;
 use solana_message::VersionedMessage;
 use solana_program_pack::Pack;
 use solana_sdk::pubkey::Pubkey;
+use spl_token_2022_interface::{extension::ExtensionType, state::Account as Token2022Account};
 #[derive(Debug, Clone)]
 pub struct TotalFeeCalculation {
     pub total_fee_lamports: u64,
@@ -408,34 +409,37 @@ impl FeeConfigUtil {
             }
 
             let mint_state = TokenUtil::get_mint(config, rpc_client, &ata_creation.mint).await?;
-            let account_len = if let Some(token2022_mint) =
-                mint_state.as_any().downcast_ref::<Token2022Mint>()
-            {
-                let required_account_extensions =
-                    spl_token_2022_interface::extension::ExtensionType::get_required_init_account_extensions(
-                        &token2022_mint.extensions_types,
-                    );
+            let account_len =
+                if let Some(token2022_mint) = mint_state.as_any().downcast_ref::<Token2022Mint>() {
+                    let mut required_account_extensions =
+                        ExtensionType::get_required_init_account_extensions(
+                            &token2022_mint.extensions_types,
+                        );
+                    if !required_account_extensions.contains(&ExtensionType::ImmutableOwner) {
+                        required_account_extensions.push(ExtensionType::ImmutableOwner);
+                    }
 
-                spl_token_2022_interface::extension::ExtensionType::try_calculate_account_len::<
-                    spl_token_2022_interface::state::Account,
-                >(&required_account_extensions)
-                .map_err(|e| {
-                    KoraError::ValidationError(format!(
-                        "Failed to estimate Token2022 ATA account size for mint {}: {}",
-                        ata_creation.mint, e
-                    ))
-                })?
-            } else {
-                spl_token_interface::state::Account::LEN
-            };
+                    ExtensionType::try_calculate_account_len::<Token2022Account>(
+                        &required_account_extensions,
+                    )
+                    .map_err(|e| {
+                        KoraError::ValidationError(format!(
+                            "Failed to estimate Token2022 ATA account size for mint {}: {}",
+                            ata_creation.mint, e
+                        ))
+                    })?
+                } else {
+                    spl_token_interface::state::Account::LEN
+                };
 
             token2022_account_len_cache.insert(ata_creation.mint, account_len);
             return Ok(account_len);
         }
 
-        // Unsupported token programs should fail on-chain, but use conservative SPL account length
-        // for safety if they are present in a transaction we are estimating.
-        Ok(spl_token_interface::state::Account::LEN)
+        Err(KoraError::ValidationError(format!(
+            "Unsupported token program {} for ATA {}; cannot safely estimate rent",
+            ata_creation.token_program, ata_creation.ata_address
+        )))
     }
 
     async fn calculate_ata_creation_outflow(
@@ -1354,6 +1358,107 @@ mod tests {
         assert_eq!(
             outflow, 123_456,
             "When SystemCreateAccount for the ATA is present, ATA rent fallback must not double count"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_calculate_fee_payer_outflow_duplicate_ata_idempotent_only_charged_once() {
+        let _m = ConfigMockBuilder::new().build_and_setup();
+        let fee_payer = Pubkey::new_unique();
+        let owner = Pubkey::new_unique();
+        let mint = Pubkey::new_unique();
+
+        let mocked_rpc_client = RpcMockBuilder::new()
+            .with_custom_mock(
+                solana_client::rpc_request::RpcRequest::GetMinimumBalanceForRentExemption,
+                serde_json::json!(2_039_280),
+            )
+            .build();
+
+        let ata_ix_1 =
+            spl_associated_token_account_interface::instruction::create_associated_token_account_idempotent(
+                &fee_payer,
+                &owner,
+                &mint,
+                &spl_token_interface::id(),
+            );
+        let ata_ix_2 =
+            spl_associated_token_account_interface::instruction::create_associated_token_account_idempotent(
+                &fee_payer,
+                &owner,
+                &mint,
+                &spl_token_interface::id(),
+            );
+
+        let message =
+            VersionedMessage::Legacy(Message::new(&[ata_ix_1, ata_ix_2], Some(&fee_payer)));
+        let mut resolved_transaction =
+            TransactionUtil::new_unsigned_versioned_transaction_resolved(message).unwrap();
+
+        let config = get_config().unwrap();
+        let outflow = FeeConfigUtil::calculate_fee_payer_outflow(
+            &fee_payer,
+            &mut resolved_transaction,
+            &mocked_rpc_client,
+            &config,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            outflow, 2_039_280,
+            "Duplicate ATA creates for the same account should only charge rent once"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_calculate_fee_payer_outflow_multiple_distinct_ata_idempotent_charged_per_ata() {
+        let _m = ConfigMockBuilder::new().build_and_setup();
+        let fee_payer = Pubkey::new_unique();
+        let owner = Pubkey::new_unique();
+        let mint_a = Pubkey::new_unique();
+        let mint_b = Pubkey::new_unique();
+
+        let mocked_rpc_client = RpcMockBuilder::new()
+            .with_custom_mock(
+                solana_client::rpc_request::RpcRequest::GetMinimumBalanceForRentExemption,
+                serde_json::json!(2_039_280),
+            )
+            .build();
+
+        let ata_ix_a =
+            spl_associated_token_account_interface::instruction::create_associated_token_account_idempotent(
+                &fee_payer,
+                &owner,
+                &mint_a,
+                &spl_token_interface::id(),
+            );
+        let ata_ix_b =
+            spl_associated_token_account_interface::instruction::create_associated_token_account_idempotent(
+                &fee_payer,
+                &owner,
+                &mint_b,
+                &spl_token_interface::id(),
+            );
+
+        let message =
+            VersionedMessage::Legacy(Message::new(&[ata_ix_a, ata_ix_b], Some(&fee_payer)));
+        let mut resolved_transaction =
+            TransactionUtil::new_unsigned_versioned_transaction_resolved(message).unwrap();
+
+        let config = get_config().unwrap();
+        let outflow = FeeConfigUtil::calculate_fee_payer_outflow(
+            &fee_payer,
+            &mut resolved_transaction,
+            &mocked_rpc_client,
+            &config,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            outflow, 4_078_560,
+            "Distinct ATA creates should each contribute rent to outflow"
         );
     }
 

--- a/crates/lib/src/fee/fee.rs
+++ b/crates/lib/src/fee/fee.rs
@@ -488,12 +488,16 @@ impl FeeConfigUtil {
             Self::collect_system_created_accounts_by_fee_payer(transaction, fee_payer_pubkey);
         let mut rent_cache_by_account_len: HashMap<usize, u64> = HashMap::new();
         let mut token2022_account_len_cache: HashMap<Pubkey, usize> = HashMap::new();
+        let mut seen_ata_addresses = HashSet::new();
         let mut total = 0u64;
 
         for ata_creation in ata_creations {
             // If simulation already surfaced the underlying SystemCreateAccount CPI for this ATA,
             // it has already been counted from parsed system instructions.
             if system_created_accounts.contains(&ata_creation.ata_address) {
+                continue;
+            }
+            if !seen_ata_addresses.insert(ata_creation.ata_address) {
                 continue;
             }
 

--- a/crates/lib/src/fee/fee.rs
+++ b/crates/lib/src/fee/fee.rs
@@ -28,8 +28,6 @@ use solana_client::nonblocking::rpc_client::RpcClient;
 use solana_message::VersionedMessage;
 use solana_program_pack::Pack;
 use solana_sdk::pubkey::Pubkey;
-use solana_system_interface::{instruction::SystemInstruction, program::ID as SYSTEM_PROGRAM_ID};
-
 #[derive(Debug, Clone)]
 pub struct TotalFeeCalculation {
     pub total_fee_lamports: u64,
@@ -394,36 +392,6 @@ impl FeeConfigUtil {
         }
     }
 
-    fn collect_system_created_accounts_by_fee_payer(
-        transaction: &VersionedTransactionResolved,
-        fee_payer_pubkey: &Pubkey,
-    ) -> HashSet<Pubkey> {
-        transaction
-            .all_instructions
-            .iter()
-            .filter(|instruction| instruction.program_id == SYSTEM_PROGRAM_ID)
-            .filter_map(|instruction| {
-                if instruction.accounts.len() < 2 {
-                    return None;
-                }
-
-                match bincode::deserialize::<SystemInstruction>(&instruction.data) {
-                    Ok(SystemInstruction::CreateAccount { .. })
-                    | Ok(SystemInstruction::CreateAccountWithSeed { .. }) => {
-                        let payer = instruction.accounts[0].pubkey;
-                        let new_account = instruction.accounts[1].pubkey;
-                        if payer == *fee_payer_pubkey {
-                            Some(new_account)
-                        } else {
-                            None
-                        }
-                    }
-                    _ => None,
-                }
-            })
-            .collect()
-    }
-
     async fn estimate_ata_account_len(
         ata_creation: &AtaCreationInstructionInfo,
         rpc_client: &RpcClient,
@@ -472,7 +440,7 @@ impl FeeConfigUtil {
 
     async fn calculate_ata_creation_outflow(
         fee_payer_pubkey: &Pubkey,
-        transaction: &VersionedTransactionResolved,
+        transaction: &mut VersionedTransactionResolved,
         rpc_client: &RpcClient,
         config: &Config,
     ) -> Result<u64, KoraError> {
@@ -484,8 +452,19 @@ impl FeeConfigUtil {
             return Ok(0);
         }
 
-        let system_created_accounts =
-            Self::collect_system_created_accounts_by_fee_payer(transaction, fee_payer_pubkey);
+        let system_created_accounts: HashSet<Pubkey> =
+            transaction
+                .get_or_parse_system_instructions()?
+                .get(&ParsedSystemInstructionType::SystemCreateAccount)
+                .unwrap_or(&vec![])
+                .iter()
+                .filter_map(|instruction| match instruction {
+                    ParsedSystemInstructionData::SystemCreateAccount {
+                        payer, new_account, ..
+                    } if *payer == *fee_payer_pubkey => Some(*new_account),
+                    _ => None,
+                })
+                .collect();
         let mut rent_cache_by_account_len: HashMap<usize, u64> = HashMap::new();
         let mut token2022_account_len_cache: HashMap<Pubkey, usize> = HashMap::new();
         let mut seen_ata_addresses = HashSet::new();
@@ -579,7 +558,7 @@ impl FeeConfigUtil {
             .get(&ParsedSystemInstructionType::SystemCreateAccount)
             .unwrap_or(&vec![])
         {
-            if let ParsedSystemInstructionData::SystemCreateAccount { lamports, payer } =
+            if let ParsedSystemInstructionData::SystemCreateAccount { lamports, payer, .. } =
                 instruction
             {
                 if *payer == *fee_payer_pubkey {

--- a/crates/lib/src/token/token.rs
+++ b/crates/lib/src/token/token.rs
@@ -21,6 +21,7 @@ use rust_decimal::{
 };
 use solana_client::nonblocking::rpc_client::RpcClient;
 use solana_sdk::{instruction::Instruction, native_token::LAMPORTS_PER_SOL, pubkey::Pubkey};
+use spl_associated_token_account_interface::program::id as ata_program_id;
 use std::{
     collections::{HashMap, HashSet},
     str::FromStr,
@@ -64,13 +65,15 @@ pub(crate) struct PaymentLamportTotals {
 }
 
 impl PaymentLamportTotals {
-    pub(crate) fn net_payment(self) -> Option<u64> {
-        let net_payment_lamports = self.inflow.saturating_sub(self.outflow);
-        if net_payment_lamports > 0 {
-            Some(net_payment_lamports)
-        } else {
-            None
+    pub(crate) fn net_payment(self) -> u64 {
+        if self.outflow > self.inflow {
+            log::warn!(
+                "Net-negative payment detected: inflow={}, outflow={}",
+                self.inflow,
+                self.outflow
+            );
         }
+        self.inflow.saturating_sub(self.outflow)
     }
 
     pub(crate) fn checked_add_assign(&mut self, other: Self) -> Result<(), KoraError> {
@@ -325,15 +328,18 @@ impl TokenUtil {
     pub fn parse_ata_creation_instruction(
         instruction: &Instruction,
     ) -> Option<AtaCreationInstructionInfo> {
-        let ata_program_id = spl_associated_token_account_interface::program::id();
-        if instruction.program_id != ata_program_id
+        if instruction.program_id != ata_program_id()
             || instruction.accounts.len()
                 < constant::instruction_indexes::ata_instruction_indexes::MIN_ACCOUNTS
         {
             return None;
         }
 
-        let discriminator = instruction.data.first().copied().unwrap_or(0);
+        // The ATA program treats empty instruction data as the legacy Create variant.
+        let discriminator = match instruction.data.first() {
+            Some(discriminator) => *discriminator,
+            None => 0,
+        };
         let is_idempotent = match discriminator {
             0 => false,
             1 => true,
@@ -790,8 +796,7 @@ impl TokenUtil {
         }
     }
 
-    /// Find the total payment amount in a transaction to the expected destination.
-    /// Returns the total payment in lamports, or None if no valid payment found.
+    /// Calculate payment inflow/outflow totals for transfers involving the expected destination.
     ///
     /// For bundles, pass `bundle_instructions` to enable cross-tx ATA lookup
     /// (e.g., ATA created in Tx1, payment in Tx2).
@@ -874,7 +879,7 @@ impl TokenUtil {
                     continue;
                 }
 
-                if *is_2022 && is_inflow && !is_outflow {
+                if *is_2022 && is_inflow {
                     if let Some((_, _, destination_exists)) = destination_account_info.as_ref() {
                         if *destination_exists {
                             TokenUtil::validate_token2022_extensions_for_payment(
@@ -947,8 +952,8 @@ impl TokenUtil {
         Ok(totals)
     }
 
-    /// Find the total payment amount in a transaction to the expected destination.
-    /// Returns the total payment in lamports, or None if no valid payment found.
+    /// Find the net payment amount in a transaction to the expected destination.
+    /// Returns the total payment in lamports, saturating at 0 when outflow exceeds inflow.
     ///
     /// For bundles, pass `bundle_instructions` to enable cross-tx ATA lookup
     /// (e.g., ATA created in Tx1, payment in Tx2).
@@ -958,7 +963,7 @@ impl TokenUtil {
         rpc_client: &RpcClient,
         expected_destination_owner: &Pubkey,
         bundle_instructions: Option<&[Instruction]>,
-    ) -> Result<Option<u64>, KoraError> {
+    ) -> Result<u64, KoraError> {
         Self::calculate_payment_lamport_totals(
             config,
             transaction_resolved,
@@ -991,7 +996,7 @@ impl TokenUtil {
         )
         .await?;
 
-        Ok(payment.unwrap_or(0) >= required_lamports)
+        Ok(payment >= required_lamports)
     }
 }
 
@@ -1004,7 +1009,9 @@ mod tests_token {
             common::{MintAccountMockBuilder, RpcMockBuilder, TokenAccountMockBuilder},
             config_mock::ConfigMockBuilder,
         },
+        transaction::TransactionUtil,
     };
+    use solana_message::{Message, VersionedMessage};
     use spl_token_2022_interface::{
         extension::{
             transfer_fee::TransferFeeConfig, BaseStateWithExtensionsMut, ExtensionType,
@@ -1185,9 +1192,9 @@ mod tests_token {
 
     #[test]
     fn test_payment_lamport_totals_net_payment() {
-        assert_eq!(PaymentLamportTotals { inflow: 10, outflow: 4 }.net_payment(), Some(6));
-        assert_eq!(PaymentLamportTotals { inflow: 4, outflow: 4 }.net_payment(), None);
-        assert_eq!(PaymentLamportTotals { inflow: 4, outflow: 10 }.net_payment(), None);
+        assert_eq!(PaymentLamportTotals { inflow: 10, outflow: 4 }.net_payment(), 6);
+        assert_eq!(PaymentLamportTotals { inflow: 4, outflow: 4 }.net_payment(), 0);
+        assert_eq!(PaymentLamportTotals { inflow: 4, outflow: 10 }.net_payment(), 0);
     }
 
     #[test]
@@ -1677,6 +1684,72 @@ mod tests_token {
         assert!(!error_msg.contains("Blocked account extension found on source account"));
     }
 
+    #[tokio::test]
+    async fn test_calculate_payment_lamport_totals_validates_token2022_when_both_sides_match_expected_owner(
+    ) {
+        let _lock = ConfigMockBuilder::new()
+            .with_cache_enabled(false)
+            .with_blocked_token2022_mint_extensions(vec!["transfer_fee_config".to_string()])
+            .build_and_setup();
+
+        let expected_destination_owner = Pubkey::new_unique();
+        let source_address = Pubkey::new_unique();
+        let destination_address = Pubkey::new_unique();
+        let mint = Pubkey::from_str(USDC_DEVNET_MINT).unwrap();
+
+        let source_account = TokenAccountMockBuilder::new()
+            .with_mint(&mint)
+            .with_owner(&expected_destination_owner)
+            .build_token2022();
+        let destination_account = TokenAccountMockBuilder::new()
+            .with_mint(&mint)
+            .with_owner(&expected_destination_owner)
+            .build_token2022();
+        let mint_account = MintAccountMockBuilder::new()
+            .with_decimals(6)
+            .with_extension(ExtensionType::TransferFeeConfig)
+            .build_token2022();
+
+        let instruction = spl_token_2022_interface::instruction::transfer_checked(
+            &spl_token_2022_interface::id(),
+            &source_address,
+            &mint,
+            &destination_address,
+            &expected_destination_owner,
+            &[],
+            1_000_000,
+            6,
+        )
+        .unwrap();
+        let message = VersionedMessage::Legacy(Message::new(
+            &[instruction],
+            Some(&expected_destination_owner),
+        ));
+        let mut transaction_resolved =
+            TransactionUtil::new_unsigned_versioned_transaction_resolved(message).unwrap();
+
+        let rpc_client = RpcMockBuilder::new().build_with_sequential_accounts(vec![
+            &source_account,
+            &destination_account,
+            &mint_account,
+            &source_account,
+        ]);
+
+        let config = get_config().unwrap();
+        let result = TokenUtil::calculate_payment_lamport_totals(
+            &config,
+            &mut transaction_resolved,
+            &rpc_client,
+            &expected_destination_owner,
+            None,
+        )
+        .await;
+
+        assert!(result.is_err());
+        let error_msg = result.unwrap_err().to_string();
+        assert!(error_msg.contains("Blocked mint extension found on mint account"));
+    }
+
     #[test]
     fn test_config_token2022_extension_blocking() {
         use spl_token_2022_interface::extension::ExtensionType;
@@ -1886,6 +1959,64 @@ mod tests_token {
         assert_eq!(parsed.mint, mint);
         assert_eq!(parsed.token_program, spl_token_interface::id());
         assert!(parsed.is_idempotent);
+    }
+
+    #[test]
+    fn test_parse_ata_creation_instruction_non_idempotent() {
+        let payer = Pubkey::new_unique();
+        let owner = Pubkey::new_unique();
+        let mint = Pubkey::new_unique();
+
+        let ix =
+            spl_associated_token_account_interface::instruction::create_associated_token_account(
+                &payer,
+                &owner,
+                &mint,
+                &spl_token_interface::id(),
+            );
+
+        let parsed = TokenUtil::parse_ata_creation_instruction(&ix).expect("ATA should parse");
+        assert_eq!(parsed.payer, payer);
+        assert_eq!(parsed.wallet_owner, owner);
+        assert_eq!(parsed.mint, mint);
+        assert_eq!(parsed.token_program, spl_token_interface::id());
+        assert!(!parsed.is_idempotent);
+    }
+
+    #[test]
+    fn test_parse_ata_creation_instruction_empty_data_is_legacy_create() {
+        let payer = Pubkey::new_unique();
+        let owner = Pubkey::new_unique();
+        let mint = Pubkey::new_unique();
+        let ata_address =
+            get_associated_token_address_with_program_id(&owner, &mint, &spl_token_interface::id());
+
+        let ix = Instruction {
+            program_id: ata_program_id(),
+            accounts: vec![
+                solana_sdk::instruction::AccountMeta::new(payer, true),
+                solana_sdk::instruction::AccountMeta::new(ata_address, false),
+                solana_sdk::instruction::AccountMeta::new_readonly(owner, false),
+                solana_sdk::instruction::AccountMeta::new_readonly(mint, false),
+                solana_sdk::instruction::AccountMeta::new_readonly(
+                    solana_system_interface::program::ID,
+                    false,
+                ),
+                solana_sdk::instruction::AccountMeta::new_readonly(
+                    spl_token_interface::id(),
+                    false,
+                ),
+            ],
+            data: vec![],
+        };
+
+        let parsed = TokenUtil::parse_ata_creation_instruction(&ix).expect("ATA should parse");
+        assert_eq!(parsed.payer, payer);
+        assert_eq!(parsed.ata_address, ata_address);
+        assert_eq!(parsed.wallet_owner, owner);
+        assert_eq!(parsed.mint, mint);
+        assert_eq!(parsed.token_program, spl_token_interface::id());
+        assert!(!parsed.is_idempotent);
     }
 
     #[test]

--- a/crates/lib/src/token/token.rs
+++ b/crates/lib/src/token/token.rs
@@ -57,6 +57,45 @@ impl TokenType {
     }
 }
 
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct PaymentLamportTotals {
+    pub(crate) inflow: u64,
+    pub(crate) outflow: u64,
+}
+
+impl PaymentLamportTotals {
+    pub(crate) fn net_payment(self) -> Option<u64> {
+        let net_payment_lamports = self.inflow.saturating_sub(self.outflow);
+        if net_payment_lamports > 0 {
+            Some(net_payment_lamports)
+        } else {
+            None
+        }
+    }
+
+    pub(crate) fn checked_add_assign(&mut self, other: Self) -> Result<(), KoraError> {
+        self.inflow = self.inflow.checked_add(other.inflow).ok_or_else(|| {
+            log::error!(
+                "Payment inflow accumulation overflow: total={}, new_payment={}",
+                self.inflow,
+                other.inflow
+            );
+            KoraError::ValidationError("Payment inflow accumulation overflow".to_string())
+        })?;
+
+        self.outflow = self.outflow.checked_add(other.outflow).ok_or_else(|| {
+            log::error!(
+                "Payment outflow accumulation overflow: total={}, new_payment={}",
+                self.outflow,
+                other.outflow
+            );
+            KoraError::ValidationError("Payment outflow accumulation overflow".to_string())
+        })?;
+
+        Ok(())
+    }
+}
+
 pub struct TokenUtil;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -724,25 +763,51 @@ impl TokenUtil {
         Ok(())
     }
 
+    async fn resolve_token_account_owner_and_mint(
+        config: &Config,
+        rpc_client: &RpcClient,
+        token_program: &dyn TokenInterface,
+        account_address: &Pubkey,
+        all_instructions: &[Instruction],
+    ) -> Result<Option<(Pubkey, Pubkey, bool)>, KoraError> {
+        match CacheUtil::get_account(config, rpc_client, account_address, true).await {
+            Ok(account) => {
+                let token_state =
+                    token_program.unpack_token_account(&account.data).map_err(|e| {
+                        KoraError::InvalidTransaction(format!("Invalid token account: {e}"))
+                    })?;
+
+                Ok(Some((token_state.owner(), token_state.mint(), true)))
+            }
+            Err(e) => {
+                if matches!(e, KoraError::AccountNotFound(_)) {
+                    Ok(Self::find_ata_creation_for_destination(all_instructions, account_address)
+                        .map(|(wallet_owner, ata_mint)| (wallet_owner, ata_mint, false)))
+                } else {
+                    Err(KoraError::RpcError(e.to_string()))
+                }
+            }
+        }
+    }
+
     /// Find the total payment amount in a transaction to the expected destination.
     /// Returns the total payment in lamports, or None if no valid payment found.
     ///
     /// For bundles, pass `bundle_instructions` to enable cross-tx ATA lookup
     /// (e.g., ATA created in Tx1, payment in Tx2).
-    pub async fn find_payment_in_transaction(
+    pub(crate) async fn calculate_payment_lamport_totals(
         config: &Config,
         transaction_resolved: &mut VersionedTransactionResolved,
         rpc_client: &RpcClient,
         expected_destination_owner: &Pubkey,
         bundle_instructions: Option<&[Instruction]>,
-    ) -> Result<Option<u64>, KoraError> {
-        let mut total_inflow_lamport_value = 0u64;
-        let mut total_outflow_lamport_value = 0u64;
+    ) -> Result<PaymentLamportTotals, KoraError> {
+        let mut totals = PaymentLamportTotals::default();
         let mut cached_epoch: Option<u64> = None;
         let mut token2022_mints: HashMap<Pubkey, Box<dyn TokenMint>> = HashMap::new();
 
         let all_instructions = bundle_instructions
-            .map(|bi| bi.to_vec())
+            .map(|instructions| instructions.to_vec())
             .unwrap_or_else(|| transaction_resolved.all_instructions.clone());
 
         for instruction in transaction_resolved
@@ -751,7 +816,6 @@ impl TokenUtil {
             .unwrap_or(&vec![])
         {
             if let ParsedSPLInstructionData::SplTokenTransfer {
-                owner,
                 source_address,
                 destination_address,
                 mint,
@@ -760,153 +824,82 @@ impl TokenUtil {
                 ..
             } = instruction
             {
-                // Track net movement for the expected destination owner.
-                // This prevents counting a same-transaction refund loop as valid payment.
-                let source_owner_and_mint =
-                    match CacheUtil::get_account(config, rpc_client, source_address, true).await {
-                        Ok(source_account) => {
-                            let source_token_program =
-                                TokenType::get_token_program_from_owner(&source_account.owner)?;
-                            let source_token_state = source_token_program
-                                .unpack_token_account(&source_account.data)
-                                .map_err(|e| {
-                                    KoraError::InvalidTransaction(format!(
-                                        "Invalid source token account: {e}"
-                                    ))
-                                })?;
-
-                            Some((source_token_state.owner(), source_token_state.mint()))
-                        }
-                        Err(KoraError::AccountNotFound(_)) => None,
-                        Err(e) => {
-                            return Err(KoraError::RpcError(e.to_string()));
-                        }
-                    };
-
-                let source_owner_matches = source_owner_and_mint
-                    .as_ref()
-                    .map(|(source_owner, _)| *source_owner == *expected_destination_owner)
-                    // Fallback for account-creation-in-transaction edge cases.
-                    .unwrap_or(*owner == *expected_destination_owner);
-
-                if source_owner_matches {
-                    let outflow_mint = source_owner_and_mint
-                        .as_ref()
-                        .map(|(_, source_mint)| *source_mint)
-                        .or(*mint);
-
-                    if let Some(outflow_mint) = outflow_mint {
-                        if config.validation.supports_token(&outflow_mint.to_string()) {
-                            let outflow_lamport_value =
-                                TokenUtil::calculate_token_value_in_lamports(
-                                    *amount,
-                                    &outflow_mint,
-                                    rpc_client,
-                                    config,
-                                )
-                                .await?;
-
-                            total_outflow_lamport_value = total_outflow_lamport_value
-                                .checked_add(outflow_lamport_value)
-                                .ok_or_else(|| {
-                                    log::error!(
-                                        "Payment outflow accumulation overflow: total={}, new_outflow={}",
-                                        total_outflow_lamport_value,
-                                        outflow_lamport_value
-                                    );
-                                    KoraError::ValidationError(
-                                        "Payment outflow accumulation overflow".to_string(),
-                                    )
-                                })?;
-                        }
-                    } else {
-                        log::warn!(
-                            "Unable to resolve mint for potential payment outflow from source account {}",
-                            source_address
-                        );
-                    }
-                }
-
                 let token_program: Box<dyn TokenInterface> = if *is_2022 {
                     Box::new(Token2022Program::new())
                 } else {
                     Box::new(TokenProgram::new())
                 };
 
-                // Get destination owner and mint - the ATA may not exist yet if being created
-                // in this transaction (or another transaction in the bundle)
-                let (destination_owner, token_mint, destination_exists) =
-                    match CacheUtil::get_account(config, rpc_client, destination_address, true)
-                        .await
-                    {
-                        Ok(destination_account) => {
-                            let token_state = token_program
-                                .unpack_token_account(&destination_account.data)
-                                .map_err(|e| {
-                                    KoraError::InvalidTransaction(format!(
-                                        "Invalid token account: {e}"
-                                    ))
-                                })?;
+                let source_account_info = Self::resolve_token_account_owner_and_mint(
+                    config,
+                    rpc_client,
+                    token_program.as_ref(),
+                    source_address,
+                    &all_instructions,
+                )
+                .await?;
+                let destination_account_info = Self::resolve_token_account_owner_and_mint(
+                    config,
+                    rpc_client,
+                    token_program.as_ref(),
+                    destination_address,
+                    &all_instructions,
+                )
+                .await?;
 
-                            (token_state.owner(), token_state.mint(), true)
-                        }
-                        Err(e) => {
-                            // If account not found, check if there's an ATA creation instruction
-                            // that creates this destination address
-                            if matches!(e, KoraError::AccountNotFound(_)) {
-                                if let Some((wallet_owner, ata_mint)) =
-                                    Self::find_ata_creation_for_destination(
-                                        &all_instructions,
-                                        destination_address,
-                                    )
-                                {
-                                    (wallet_owner, ata_mint, false)
-                                } else {
-                                    // No ATA creation found - skip this transfer
-                                    continue;
-                                }
-                            } else {
-                                return Err(KoraError::RpcError(e.to_string()));
-                            }
-                        }
-                    };
+                let is_inflow = destination_account_info
+                    .as_ref()
+                    .map(|(owner, _, _)| owner == expected_destination_owner)
+                    .unwrap_or(false);
+                let is_outflow = source_account_info
+                    .as_ref()
+                    .map(|(owner, _, _)| owner == expected_destination_owner)
+                    .unwrap_or(false);
 
-                // Skip if destination isn't our expected payment address
-                if destination_owner != *expected_destination_owner {
+                if !is_inflow && !is_outflow {
                     continue;
                 }
 
-                // For Token2022 payments, validate blocked mint/account extensions.
-                // This must run only after destination-owner matching, otherwise unrelated transfers can fail
-                // payment validation.
-                if *is_2022 {
-                    if destination_exists {
-                        TokenUtil::validate_token2022_extensions_for_payment(
-                            config,
-                            rpc_client,
-                            source_address,
-                            destination_address,
-                            &mint.unwrap_or(token_mint),
+                let token_mint = mint
+                    .or(source_account_info.as_ref().map(|(_, token_mint, _)| *token_mint))
+                    .or(destination_account_info.as_ref().map(|(_, token_mint, _)| *token_mint))
+                    .ok_or_else(|| {
+                        KoraError::InvalidTransaction(
+                            "Unable to resolve token mint for payment transfer".to_string(),
                         )
-                        .await?;
-                    } else {
-                        TokenUtil::validate_token2022_partial_for_ata_creation(
-                            config,
-                            rpc_client,
-                            source_address,
-                            &token_mint,
-                        )
-                        .await?;
-                    }
-                }
+                    })?;
 
-                // Skip unsupported tokens
                 if !config.validation.supports_token(&token_mint.to_string()) {
                     log::warn!("Ignoring payment with unsupported token mint: {}", token_mint,);
                     continue;
                 }
 
-                let effective_amount = if *is_2022 {
+                if *is_2022 && is_inflow && !is_outflow {
+                    if let Some((_, _, destination_exists)) = destination_account_info.as_ref() {
+                        if *destination_exists {
+                            TokenUtil::validate_token2022_extensions_for_payment(
+                                config,
+                                rpc_client,
+                                source_address,
+                                destination_address,
+                                &mint.unwrap_or(token_mint),
+                            )
+                            .await?;
+                        } else {
+                            TokenUtil::validate_token2022_partial_for_ata_creation(
+                                config,
+                                rpc_client,
+                                source_address,
+                                &token_mint,
+                            )
+                            .await?;
+                        }
+                    } else {
+                        continue;
+                    }
+                }
+
+                let inflow_amount = if *is_2022 && is_inflow {
                     Self::calculate_token2022_net_amount(
                         *amount,
                         &token_mint,
@@ -920,36 +913,61 @@ impl TokenUtil {
                     *amount
                 };
 
-                let lamport_value = TokenUtil::calculate_token_value_in_lamports(
-                    effective_amount,
-                    &token_mint,
-                    rpc_client,
-                    config,
-                )
-                .await?;
+                let inflow_lamports = if is_inflow {
+                    Self::calculate_token_value_in_lamports(
+                        inflow_amount,
+                        &token_mint,
+                        rpc_client,
+                        config,
+                    )
+                    .await?
+                } else {
+                    0
+                };
 
-                total_inflow_lamport_value =
-                    total_inflow_lamport_value.checked_add(lamport_value).ok_or_else(|| {
-                        log::error!(
-                            "Payment inflow accumulation overflow: total={}, new_payment={}",
-                            total_inflow_lamport_value,
-                            lamport_value
-                        );
-                        KoraError::ValidationError(
-                            "Payment inflow accumulation overflow".to_string(),
-                        )
-                    })?;
+                let outflow_lamports = if is_outflow {
+                    Self::calculate_token_value_in_lamports(
+                        *amount,
+                        &token_mint,
+                        rpc_client,
+                        config,
+                    )
+                    .await?
+                } else {
+                    0
+                };
+
+                totals.checked_add_assign(PaymentLamportTotals {
+                    inflow: inflow_lamports,
+                    outflow: outflow_lamports,
+                })?;
             }
         }
 
-        let net_payment_lamports =
-            total_inflow_lamport_value.saturating_sub(total_outflow_lamport_value);
+        Ok(totals)
+    }
 
-        if net_payment_lamports > 0 {
-            Ok(Some(net_payment_lamports))
-        } else {
-            Ok(None)
-        }
+    /// Find the total payment amount in a transaction to the expected destination.
+    /// Returns the total payment in lamports, or None if no valid payment found.
+    ///
+    /// For bundles, pass `bundle_instructions` to enable cross-tx ATA lookup
+    /// (e.g., ATA created in Tx1, payment in Tx2).
+    pub async fn find_payment_in_transaction(
+        config: &Config,
+        transaction_resolved: &mut VersionedTransactionResolved,
+        rpc_client: &RpcClient,
+        expected_destination_owner: &Pubkey,
+        bundle_instructions: Option<&[Instruction]>,
+    ) -> Result<Option<u64>, KoraError> {
+        Self::calculate_payment_lamport_totals(
+            config,
+            transaction_resolved,
+            rpc_client,
+            expected_destination_owner,
+            bundle_instructions,
+        )
+        .await
+        .map(PaymentLamportTotals::net_payment)
     }
 
     /// Verify that a transaction contains sufficient payment to the expected destination.
@@ -1163,6 +1181,28 @@ mod tests_token {
 
         let result = TokenUtil::get_token_price_and_decimals(&mint, &rpc_client, &config).await;
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_payment_lamport_totals_net_payment() {
+        assert_eq!(PaymentLamportTotals { inflow: 10, outflow: 4 }.net_payment(), Some(6));
+        assert_eq!(PaymentLamportTotals { inflow: 4, outflow: 4 }.net_payment(), None);
+        assert_eq!(PaymentLamportTotals { inflow: 4, outflow: 10 }.net_payment(), None);
+    }
+
+    #[test]
+    fn test_payment_lamport_totals_checked_add_assign() {
+        let mut totals = PaymentLamportTotals { inflow: 3, outflow: 2 };
+        totals.checked_add_assign(PaymentLamportTotals { inflow: 5, outflow: 7 }).unwrap();
+
+        assert_eq!(totals, PaymentLamportTotals { inflow: 8, outflow: 9 });
+    }
+
+    #[test]
+    fn test_payment_lamport_totals_checked_add_assign_overflow() {
+        let mut totals = PaymentLamportTotals { inflow: u64::MAX, outflow: 0 };
+        let err = totals.checked_add_assign(PaymentLamportTotals { inflow: 1, outflow: 0 });
+        assert!(err.is_err());
     }
 
     #[tokio::test]

--- a/crates/lib/src/token/token.rs
+++ b/crates/lib/src/token/token.rs
@@ -736,7 +736,8 @@ impl TokenUtil {
         expected_destination_owner: &Pubkey,
         bundle_instructions: Option<&[Instruction]>,
     ) -> Result<Option<u64>, KoraError> {
-        let mut total_lamport_value = 0u64;
+        let mut total_inflow_lamport_value = 0u64;
+        let mut total_outflow_lamport_value = 0u64;
         let mut cached_epoch: Option<u64> = None;
         let mut token2022_mints: HashMap<Pubkey, Box<dyn TokenMint>> = HashMap::new();
 
@@ -750,6 +751,7 @@ impl TokenUtil {
             .unwrap_or(&vec![])
         {
             if let ParsedSPLInstructionData::SplTokenTransfer {
+                owner,
                 source_address,
                 destination_address,
                 mint,
@@ -758,6 +760,73 @@ impl TokenUtil {
                 ..
             } = instruction
             {
+                // Track net movement for the expected destination owner.
+                // This prevents counting a same-transaction refund loop as valid payment.
+                let source_owner_and_mint =
+                    match CacheUtil::get_account(config, rpc_client, source_address, true).await {
+                        Ok(source_account) => {
+                            let source_token_program =
+                                TokenType::get_token_program_from_owner(&source_account.owner)?;
+                            let source_token_state = source_token_program
+                                .unpack_token_account(&source_account.data)
+                                .map_err(|e| {
+                                    KoraError::InvalidTransaction(format!(
+                                        "Invalid source token account: {e}"
+                                    ))
+                                })?;
+
+                            Some((source_token_state.owner(), source_token_state.mint()))
+                        }
+                        Err(KoraError::AccountNotFound(_)) => None,
+                        Err(e) => {
+                            return Err(KoraError::RpcError(e.to_string()));
+                        }
+                    };
+
+                let source_owner_matches = source_owner_and_mint
+                    .as_ref()
+                    .map(|(source_owner, _)| *source_owner == *expected_destination_owner)
+                    // Fallback for account-creation-in-transaction edge cases.
+                    .unwrap_or(*owner == *expected_destination_owner);
+
+                if source_owner_matches {
+                    let outflow_mint = source_owner_and_mint
+                        .as_ref()
+                        .map(|(_, source_mint)| *source_mint)
+                        .or(*mint);
+
+                    if let Some(outflow_mint) = outflow_mint {
+                        if config.validation.supports_token(&outflow_mint.to_string()) {
+                            let outflow_lamport_value =
+                                TokenUtil::calculate_token_value_in_lamports(
+                                    *amount,
+                                    &outflow_mint,
+                                    rpc_client,
+                                    config,
+                                )
+                                .await?;
+
+                            total_outflow_lamport_value = total_outflow_lamport_value
+                                .checked_add(outflow_lamport_value)
+                                .ok_or_else(|| {
+                                    log::error!(
+                                        "Payment outflow accumulation overflow: total={}, new_outflow={}",
+                                        total_outflow_lamport_value,
+                                        outflow_lamport_value
+                                    );
+                                    KoraError::ValidationError(
+                                        "Payment outflow accumulation overflow".to_string(),
+                                    )
+                                })?;
+                        }
+                    } else {
+                        log::warn!(
+                            "Unable to resolve mint for potential payment outflow from source account {}",
+                            source_address
+                        );
+                    }
+                }
+
                 let token_program: Box<dyn TokenInterface> = if *is_2022 {
                     Box::new(Token2022Program::new())
                 } else {
@@ -859,20 +928,25 @@ impl TokenUtil {
                 )
                 .await?;
 
-                total_lamport_value =
-                    total_lamport_value.checked_add(lamport_value).ok_or_else(|| {
+                total_inflow_lamport_value =
+                    total_inflow_lamport_value.checked_add(lamport_value).ok_or_else(|| {
                         log::error!(
-                            "Payment accumulation overflow: total={}, new_payment={}",
-                            total_lamport_value,
+                            "Payment inflow accumulation overflow: total={}, new_payment={}",
+                            total_inflow_lamport_value,
                             lamport_value
                         );
-                        KoraError::ValidationError("Payment accumulation overflow".to_string())
+                        KoraError::ValidationError(
+                            "Payment inflow accumulation overflow".to_string(),
+                        )
                     })?;
             }
         }
 
-        if total_lamport_value > 0 {
-            Ok(Some(total_lamport_value))
+        let net_payment_lamports =
+            total_inflow_lamport_value.saturating_sub(total_outflow_lamport_value);
+
+        if net_payment_lamports > 0 {
+            Ok(Some(net_payment_lamports))
         } else {
             Ok(None)
         }

--- a/crates/lib/src/token/token.rs
+++ b/crates/lib/src/token/token.rs
@@ -65,6 +65,16 @@ pub enum TransferHookValidationFlow {
     ImmediateSignAndSend,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AtaCreationInstructionInfo {
+    pub payer: Pubkey,
+    pub ata_address: Pubkey,
+    pub wallet_owner: Pubkey,
+    pub mint: Pubkey,
+    pub token_program: Pubkey,
+    pub is_idempotent: bool,
+}
+
 impl TokenUtil {
     fn should_reject_mutable_transfer_hook(
         config: &Config,
@@ -261,27 +271,66 @@ impl TokenUtil {
         instructions: &[Instruction],
         destination_address: &Pubkey,
     ) -> Option<(Pubkey, Pubkey)> {
-        let ata_program_id = spl_associated_token_account_interface::program::id();
-
         for ix in instructions {
-            if ix.program_id == ata_program_id
-                && ix.accounts.len()
-                    >= constant::instruction_indexes::ata_instruction_indexes::MIN_ACCOUNTS
-            {
-                let ata_address = ix.accounts
-                    [constant::instruction_indexes::ata_instruction_indexes::ATA_ADDRESS_INDEX]
-                    .pubkey;
-                if ata_address == *destination_address {
-                    let wallet_owner =
-                        ix.accounts[constant::instruction_indexes::ata_instruction_indexes::WALLET_OWNER_INDEX].pubkey;
-                    let mint = ix.accounts
-                        [constant::instruction_indexes::ata_instruction_indexes::MINT_INDEX]
-                        .pubkey;
-                    return Some((wallet_owner, mint));
+            if let Some(info) = Self::parse_ata_creation_instruction(ix) {
+                if info.ata_address == *destination_address {
+                    return Some((info.wallet_owner, info.mint));
                 }
             }
         }
         None
+    }
+
+    /// Parse ATA Create/CreateIdempotent instructions.
+    /// Returns None for non-ATA instructions or unsupported ATA variants.
+    pub fn parse_ata_creation_instruction(
+        instruction: &Instruction,
+    ) -> Option<AtaCreationInstructionInfo> {
+        let ata_program_id = spl_associated_token_account_interface::program::id();
+        if instruction.program_id != ata_program_id
+            || instruction.accounts.len()
+                < constant::instruction_indexes::ata_instruction_indexes::MIN_ACCOUNTS
+        {
+            return None;
+        }
+
+        let discriminator = instruction.data.first().copied().unwrap_or(0);
+        let is_idempotent = match discriminator {
+            0 => false,
+            1 => true,
+            _ => return None,
+        };
+
+        Some(AtaCreationInstructionInfo {
+            payer: instruction.accounts
+                [constant::instruction_indexes::ata_instruction_indexes::PAYER_INDEX]
+                .pubkey,
+            ata_address: instruction.accounts
+                [constant::instruction_indexes::ata_instruction_indexes::ATA_ADDRESS_INDEX]
+                .pubkey,
+            wallet_owner: instruction.accounts
+                [constant::instruction_indexes::ata_instruction_indexes::WALLET_OWNER_INDEX]
+                .pubkey,
+            mint: instruction.accounts
+                [constant::instruction_indexes::ata_instruction_indexes::MINT_INDEX]
+                .pubkey,
+            token_program: instruction.accounts
+                [constant::instruction_indexes::ata_instruction_indexes::TOKEN_PROGRAM_INDEX]
+                .pubkey,
+            is_idempotent,
+        })
+    }
+
+    /// Extract ATA Create/CreateIdempotent instructions where the fee payer funds account creation.
+    pub fn find_fee_payer_ata_creations(
+        instructions: &[Instruction],
+        fee_payer: &Pubkey,
+    ) -> Vec<AtaCreationInstructionInfo> {
+        instructions
+            .iter()
+            .filter_map(Self::parse_ata_creation_instruction)
+            .filter(|info| info.payer == *fee_payer)
+            .collect()
     }
 
     pub async fn get_mint(
@@ -1701,5 +1750,85 @@ mod tests_token {
 
         let result = TokenUtil::find_ata_creation_for_destination(&instructions, &target_address);
         assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_parse_ata_creation_instruction_idempotent() {
+        let payer = Pubkey::new_unique();
+        let owner = Pubkey::new_unique();
+        let mint = Pubkey::new_unique();
+
+        let ix =
+            spl_associated_token_account_interface::instruction::create_associated_token_account_idempotent(
+                &payer,
+                &owner,
+                &mint,
+                &spl_token_interface::id(),
+            );
+
+        let parsed = TokenUtil::parse_ata_creation_instruction(&ix).expect("ATA should parse");
+        assert_eq!(parsed.payer, payer);
+        assert_eq!(parsed.wallet_owner, owner);
+        assert_eq!(parsed.mint, mint);
+        assert_eq!(parsed.token_program, spl_token_interface::id());
+        assert!(parsed.is_idempotent);
+    }
+
+    #[test]
+    fn test_parse_ata_creation_instruction_rejects_unknown_discriminator() {
+        use solana_sdk::instruction::AccountMeta;
+
+        let payer = Pubkey::new_unique();
+        let owner = Pubkey::new_unique();
+        let mint = Pubkey::new_unique();
+        let ata_address =
+            spl_associated_token_account_interface::address::get_associated_token_address(
+                &owner, &mint,
+            );
+
+        let ix = Instruction {
+            program_id: spl_associated_token_account_interface::program::id(),
+            accounts: vec![
+                AccountMeta::new(payer, true),
+                AccountMeta::new(ata_address, false),
+                AccountMeta::new_readonly(owner, false),
+                AccountMeta::new_readonly(mint, false),
+                AccountMeta::new_readonly(solana_system_interface::program::ID, false),
+                AccountMeta::new_readonly(spl_token_interface::id(), false),
+            ],
+            data: vec![2], // Unsupported ATA instruction variant
+        };
+
+        assert!(TokenUtil::parse_ata_creation_instruction(&ix).is_none());
+    }
+
+    #[test]
+    fn test_find_fee_payer_ata_creations_filters_by_payer() {
+        let fee_payer = Pubkey::new_unique();
+        let other_payer = Pubkey::new_unique();
+        let owner = Pubkey::new_unique();
+        let mint_a = Pubkey::new_unique();
+        let mint_b = Pubkey::new_unique();
+
+        let by_fee_payer =
+            spl_associated_token_account_interface::instruction::create_associated_token_account_idempotent(
+                &fee_payer,
+                &owner,
+                &mint_a,
+                &spl_token_interface::id(),
+            );
+        let by_other_payer =
+            spl_associated_token_account_interface::instruction::create_associated_token_account_idempotent(
+                &other_payer,
+                &owner,
+                &mint_b,
+                &spl_token_interface::id(),
+            );
+
+        let parsed =
+            TokenUtil::find_fee_payer_ata_creations(&[by_fee_payer, by_other_payer], &fee_payer);
+        assert_eq!(parsed.len(), 1);
+        assert_eq!(parsed[0].payer, fee_payer);
+        assert_eq!(parsed[0].mint, mint_a);
     }
 }

--- a/crates/lib/src/transaction/instruction_util.rs
+++ b/crates/lib/src/transaction/instruction_util.rs
@@ -46,6 +46,7 @@ pub enum ParsedSystemInstructionData {
     SystemCreateAccount {
         lamports: u64,
         payer: Pubkey,
+        new_account: Pubkey,
     },
     // Includes withdraw nonce account
     SystemWithdrawNonceAccount {
@@ -1518,7 +1519,8 @@ impl IxUtils {
                     | Ok(SystemInstruction::CreateAccountWithSeed { lamports, .. }) => {
                         parse_system_instruction!(parsed_instructions, instruction, system_create_account, SystemCreateAccount, SystemCreateAccount {
                             lamports: lamports;
-                            payer: instruction_indexes::system_create_account::PAYER_INDEX
+                            payer: instruction_indexes::system_create_account::PAYER_INDEX,
+                            new_account: instruction_indexes::system_create_account::NEW_ACCOUNT_INDEX
                         });
                     }
                     Ok(SystemInstruction::Transfer { lamports }) => {
@@ -3143,6 +3145,110 @@ mod tests {
                 assert_eq!(*parsed_receiver, receiver);
             }
             _ => panic!("Expected SystemTransfer variant"),
+        }
+    }
+
+    #[test]
+    fn test_parse_system_instructions_create_account() {
+        use crate::transaction::versioned_transaction::VersionedTransactionResolved;
+        use solana_message::{Message, VersionedMessage};
+        use solana_sdk::{
+            signature::{Keypair, Signer},
+            transaction::VersionedTransaction,
+        };
+        use solana_system_interface::instruction::create_account;
+
+        let payer = Keypair::new();
+        let new_account = Keypair::new();
+        let owner = Pubkey::new_unique();
+        let lamports = 2_000_000u64;
+        let space = 165u64;
+
+        let instruction =
+            create_account(&payer.pubkey(), &new_account.pubkey(), lamports, space, &owner);
+
+        let message = VersionedMessage::Legacy(Message::new(&[instruction], Some(&payer.pubkey())));
+        let tx = VersionedTransaction::try_new(message, &[&payer, &new_account]).unwrap();
+
+        let resolved_tx = VersionedTransactionResolved::from_kora_built_transaction(&tx)
+            .expect("Failed to create resolved transaction");
+
+        let parsed_instructions = IxUtils::parse_system_instructions(&resolved_tx)
+            .expect("Failed to parse system instructions");
+
+        let creates = parsed_instructions
+            .get(&ParsedSystemInstructionType::SystemCreateAccount)
+            .expect("Expected SystemCreateAccount instructions");
+
+        assert_eq!(creates.len(), 1);
+
+        match &creates[0] {
+            ParsedSystemInstructionData::SystemCreateAccount {
+                lamports: parsed_lamports,
+                payer: parsed_payer,
+                new_account: parsed_new_account,
+            } => {
+                assert_eq!(*parsed_lamports, lamports);
+                assert_eq!(*parsed_payer, payer.pubkey());
+                assert_eq!(*parsed_new_account, new_account.pubkey());
+            }
+            _ => panic!("Expected SystemCreateAccount variant"),
+        }
+    }
+
+    #[test]
+    fn test_parse_system_instructions_create_account_with_seed() {
+        use crate::transaction::versioned_transaction::VersionedTransactionResolved;
+        use solana_message::{Message, VersionedMessage};
+        use solana_sdk::{
+            signature::{Keypair, Signer},
+            transaction::VersionedTransaction,
+        };
+        use solana_system_interface::instruction::create_account_with_seed;
+
+        let payer = Keypair::new();
+        let owner = Pubkey::new_unique();
+        let seed = "seeded-account";
+        let new_account = Pubkey::create_with_seed(&payer.pubkey(), seed, &owner).unwrap();
+        let lamports = 3_000_000u64;
+        let space = 200u64;
+
+        let instruction = create_account_with_seed(
+            &payer.pubkey(),
+            &new_account,
+            &payer.pubkey(),
+            seed,
+            lamports,
+            space,
+            &owner,
+        );
+
+        let message = VersionedMessage::Legacy(Message::new(&[instruction], Some(&payer.pubkey())));
+        let tx = VersionedTransaction::try_new(message, &[&payer]).unwrap();
+
+        let resolved_tx = VersionedTransactionResolved::from_kora_built_transaction(&tx)
+            .expect("Failed to create resolved transaction");
+
+        let parsed_instructions = IxUtils::parse_system_instructions(&resolved_tx)
+            .expect("Failed to parse system instructions");
+
+        let creates = parsed_instructions
+            .get(&ParsedSystemInstructionType::SystemCreateAccount)
+            .expect("Expected SystemCreateAccount instructions");
+
+        assert_eq!(creates.len(), 1);
+
+        match &creates[0] {
+            ParsedSystemInstructionData::SystemCreateAccount {
+                lamports: parsed_lamports,
+                payer: parsed_payer,
+                new_account: parsed_new_account,
+            } => {
+                assert_eq!(*parsed_lamports, lamports);
+                assert_eq!(*parsed_payer, payer.pubkey());
+                assert_eq!(*parsed_new_account, new_account);
+            }
+            _ => panic!("Expected SystemCreateAccount variant"),
         }
     }
 

--- a/crates/lib/src/validator/transaction_validator.rs
+++ b/crates/lib/src/validator/transaction_validator.rs
@@ -428,7 +428,7 @@ impl TransactionValidator {
 
         if has_fee_payer_ata_create {
             return Err(KoraError::InvalidTransaction(
-                "Fee payer cannot be used for 'ATA Create Account'".to_string(),
+                "Fee payer cannot fund ATA creation (Create or CreateIdempotent)".to_string(),
             ));
         }
 
@@ -2579,7 +2579,7 @@ mod tests {
 
         match result {
             Err(KoraError::InvalidTransaction(msg)) => {
-                assert!(msg.contains("ATA Create Account"));
+                assert!(msg.contains("ATA creation"));
             }
             _ => panic!("Expected ATA create policy violation"),
         }

--- a/crates/lib/src/validator/transaction_validator.rs
+++ b/crates/lib/src/validator/transaction_validator.rs
@@ -226,6 +226,8 @@ impl TransactionValidator {
         &self,
         transaction_resolved: &mut VersionedTransactionResolved,
     ) -> Result<(), KoraError> {
+        self.validate_ata_create_instructions(transaction_resolved)?;
+
         let system_instructions = transaction_resolved.get_or_parse_system_instructions()?;
 
         // Check for durable transactions (nonce-based) - reject if not allowed
@@ -405,6 +407,29 @@ impl TransactionValidator {
                     ));
                 }
             }
+        }
+
+        Ok(())
+    }
+
+    fn validate_ata_create_instructions(
+        &self,
+        transaction_resolved: &VersionedTransactionResolved,
+    ) -> Result<(), KoraError> {
+        if self.fee_payer_policy.system.allow_create_account {
+            return Ok(());
+        }
+
+        let has_fee_payer_ata_create = !TokenUtil::find_fee_payer_ata_creations(
+            &transaction_resolved.all_instructions,
+            &self.fee_payer_pubkey,
+        )
+        .is_empty();
+
+        if has_fee_payer_ata_create {
+            return Err(KoraError::InvalidTransaction(
+                "Fee payer cannot be used for 'ATA Create Account'".to_string(),
+            ));
         }
 
         Ok(())
@@ -2511,6 +2536,101 @@ mod tests {
             .validate_transaction(config, &mut transaction, &rpc_client)
             .await
             .is_err());
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_fee_payer_policy_ata_create_idempotent() {
+        let fee_payer = Pubkey::new_unique();
+        let owner = Pubkey::new_unique();
+        let mint = Pubkey::new_unique();
+        let ata_program_id = spl_associated_token_account_interface::program::id();
+
+        let rpc_client = RpcMockBuilder::new()
+            .with_custom_mock(
+                solana_client::rpc_request::RpcRequest::GetMinimumBalanceForRentExemption,
+                serde_json::json!(2_039_280),
+            )
+            .build();
+
+        let mut policy = FeePayerPolicy::default();
+        policy.system.allow_create_account = false;
+        let config = ConfigMockBuilder::new()
+            .with_price_source(PriceSource::Mock)
+            .with_allowed_programs(vec![ata_program_id.to_string()])
+            .with_max_allowed_lamports(10_000_000)
+            .with_fee_payer_policy(policy)
+            .build();
+        update_config(config).unwrap();
+
+        let config = get_config().unwrap();
+        let validator = TransactionValidator::new(config, fee_payer).unwrap();
+        let ata_ix =
+            spl_associated_token_account_interface::instruction::create_associated_token_account_idempotent(
+                &fee_payer,
+                &owner,
+                &mint,
+                &spl_token_interface::id(),
+            );
+        let message = VersionedMessage::Legacy(Message::new(&[ata_ix], Some(&fee_payer)));
+        let mut transaction =
+            TransactionUtil::new_unsigned_versioned_transaction_resolved(message).unwrap();
+        let result = validator.validate_transaction(config, &mut transaction, &rpc_client).await;
+
+        match result {
+            Err(KoraError::InvalidTransaction(msg)) => {
+                assert!(msg.contains("ATA Create Account"));
+            }
+            _ => panic!("Expected ATA create policy violation"),
+        }
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_ata_create_idempotent_charged_in_outflow_without_inner_create() {
+        let fee_payer = Pubkey::new_unique();
+        let owner = Pubkey::new_unique();
+        let mint = Pubkey::new_unique();
+        let ata_program_id = spl_associated_token_account_interface::program::id();
+
+        let rpc_client = RpcMockBuilder::new()
+            .with_custom_mock(
+                solana_client::rpc_request::RpcRequest::GetMinimumBalanceForRentExemption,
+                serde_json::json!(2_039_280),
+            )
+            .build();
+
+        let mut policy = FeePayerPolicy::default();
+        policy.system.allow_create_account = true;
+        let config = ConfigMockBuilder::new()
+            .with_price_source(PriceSource::Mock)
+            .with_allowed_programs(vec![ata_program_id.to_string()])
+            .with_max_allowed_lamports(1_000_000)
+            .with_fee_payer_policy(policy)
+            .build();
+        update_config(config).unwrap();
+
+        let config = get_config().unwrap();
+        let validator = TransactionValidator::new(config, fee_payer).unwrap();
+        let ata_ix =
+            spl_associated_token_account_interface::instruction::create_associated_token_account_idempotent(
+                &fee_payer,
+                &owner,
+                &mint,
+                &spl_token_interface::id(),
+            );
+        let message = VersionedMessage::Legacy(Message::new(&[ata_ix], Some(&fee_payer)));
+        let mut transaction =
+            TransactionUtil::new_unsigned_versioned_transaction_resolved(message).unwrap();
+        let result = validator.validate_transaction(config, &mut transaction, &rpc_client).await;
+
+        match result {
+            Err(KoraError::InvalidTransaction(msg)) => {
+                assert!(msg.contains("Total transfer amount"));
+                assert!(msg.contains("exceeds maximum allowed"));
+            }
+            _ => panic!("Expected outflow limit violation for ATA creation"),
+        }
     }
 
     #[tokio::test]

--- a/doppler.yaml
+++ b/doppler.yaml
@@ -1,0 +1,3 @@
+setup:
+  - project: kora
+    config: dev_personal

--- a/tests/adversarial/fee_payer_exploitation.rs
+++ b/tests/adversarial/fee_payer_exploitation.rs
@@ -1,8 +1,13 @@
 use crate::common::{assertions::RpcErrorAssertions, *};
 use jsonrpsee::rpc_params;
-use solana_sdk::signer::Signer;
+use solana_sdk::{
+    signature::{Keypair, Signer},
+    transaction::Transaction,
+};
 use solana_system_interface::instruction::transfer;
-use spl_associated_token_account_interface::address::get_associated_token_address;
+use spl_associated_token_account_interface::{
+    address::get_associated_token_address, instruction::create_associated_token_account_idempotent,
+};
 use spl_token_interface::instruction as token_instruction;
 
 #[tokio::test]
@@ -94,5 +99,113 @@ async fn test_fee_payer_as_spl_transfer_source() {
             error.assert_contains_message("Insufficient token payment");
         }
         Ok(_) => panic!("Expected error for fee payer as USDC transfer source"),
+    }
+}
+
+#[tokio::test]
+async fn test_fee_payer_net_zero_token_loop_cannot_drain_sol() {
+    let ctx = TestContext::new().await.expect("Failed to create test context");
+    let setup = TestAccountSetup::new().await;
+
+    let fee_payer_pubkey = FeePayerTestHelper::get_fee_payer_pubkey();
+    let attacker: Keypair = create_funded_wallet(&ctx).await;
+    let mint = USDCMintTestHelper::get_test_usdc_mint_pubkey();
+    let lamports_to_drain = 900_000u64; // <= tests fixture max_allowed_lamports
+
+    let fee_payer_token_account = get_associated_token_address(&fee_payer_pubkey, &mint);
+
+    let create_attacker_ata_ix = create_associated_token_account_idempotent(
+        &setup.sender_keypair.pubkey(),
+        &attacker.pubkey(),
+        &mint,
+        &spl_token_interface::id(),
+    );
+    let recent_blockhash =
+        setup.rpc_client.get_latest_blockhash().await.expect("Failed to fetch recent blockhash");
+    let create_ata_tx = Transaction::new_signed_with_payer(
+        &[create_attacker_ata_ix],
+        Some(&setup.sender_keypair.pubkey()),
+        &[&setup.sender_keypair],
+        recent_blockhash,
+    );
+    setup
+        .rpc_client
+        .send_and_confirm_transaction(&create_ata_tx)
+        .await
+        .expect("Failed to create attacker ATA");
+
+    // Seed fee payer with paid token balance to enable refund leg in exploit shape.
+    setup
+        .mint_tokens_to_account(&fee_payer_token_account, 5_000_000)
+        .await
+        .expect("Failed to mint fee payer token balance");
+
+    // Estimate required token fee for the exploit transaction shape.
+    let estimation_tx = ctx
+        .transaction_builder()
+        .with_fee_payer(fee_payer_pubkey)
+        .with_signer(&attacker)
+        // Outflow first, then inflow of same amount.
+        .with_spl_transfer_checked(
+            &mint,
+            &fee_payer_pubkey,
+            &attacker.pubkey(),
+            1,
+            TEST_USDC_MINT_DECIMALS,
+        )
+        .with_instruction(transfer(&fee_payer_pubkey, &attacker.pubkey(), lamports_to_drain))
+        .with_spl_transfer_checked(
+            &mint,
+            &attacker.pubkey(),
+            &fee_payer_pubkey,
+            1,
+            TEST_USDC_MINT_DECIMALS,
+        )
+        .build()
+        .await
+        .expect("Failed to build estimation transaction");
+
+    let fee_estimate: serde_json::Value = ctx
+        .rpc_call("estimateTransactionFee", rpc_params![estimation_tx, mint.to_string()])
+        .await
+        .expect("Failed to estimate transaction fee");
+
+    fee_estimate.assert_success();
+    let required_usdc =
+        fee_estimate["fee_in_token"].as_u64().expect("Expected fee_in_token in estimate response");
+    assert!(required_usdc > 0, "Expected non-zero required token payment");
+
+    let exploit_tx = ctx
+        .transaction_builder()
+        .with_fee_payer(fee_payer_pubkey)
+        .with_signer(&attacker)
+        .with_spl_transfer_checked(
+            &mint,
+            &fee_payer_pubkey,
+            &attacker.pubkey(),
+            required_usdc,
+            TEST_USDC_MINT_DECIMALS,
+        )
+        .with_instruction(transfer(&fee_payer_pubkey, &attacker.pubkey(), lamports_to_drain))
+        .with_spl_transfer_checked(
+            &mint,
+            &attacker.pubkey(),
+            &fee_payer_pubkey,
+            required_usdc,
+            TEST_USDC_MINT_DECIMALS,
+        )
+        .build()
+        .await
+        .expect("Failed to build exploit transaction");
+
+    let result = ctx
+        .rpc_call::<serde_json::Value, _>("signAndSendTransaction", rpc_params![exploit_tx])
+        .await;
+
+    match result {
+        Err(error) => {
+            error.assert_contains_message("Insufficient token payment");
+        }
+        Ok(_) => panic!("Expected rejection for net-zero token loop exploit"),
     }
 }

--- a/tests/adversarial/fee_payer_exploitation.rs
+++ b/tests/adversarial/fee_payer_exploitation.rs
@@ -49,6 +49,77 @@ async fn test_fee_payer_as_sol_transfer_source() {
 }
 
 #[tokio::test]
+async fn test_fee_payer_net_zero_token_loop_rejected_within_transaction() {
+    let ctx = TestContext::new().await.expect("Failed to create test context");
+    let setup = TestAccountSetup::new().await;
+
+    let fee_payer_pubkey = FeePayerTestHelper::get_fee_payer_pubkey();
+    let attacker = create_funded_wallet(&ctx).await;
+    let mint = setup.usdc_mint.pubkey();
+
+    let fee_payer_token_account = get_associated_token_address(&fee_payer_pubkey, &mint);
+    let attacker_token_account = get_associated_token_address(&attacker.pubkey(), &mint);
+
+    let create_attacker_ata_ix = create_associated_token_account_idempotent(
+        &setup.sender_keypair.pubkey(),
+        &attacker.pubkey(),
+        &mint,
+        &spl_token_interface::id(),
+    );
+    let recent_blockhash =
+        setup.rpc_client.get_latest_blockhash().await.expect("Failed to fetch recent blockhash");
+    let create_ata_tx = Transaction::new_signed_with_payer(
+        &[create_attacker_ata_ix],
+        Some(&setup.sender_keypair.pubkey()),
+        &[&setup.sender_keypair],
+        recent_blockhash,
+    );
+    setup
+        .rpc_client
+        .send_and_confirm_transaction(&create_ata_tx)
+        .await
+        .expect("Failed to create attacker ATA");
+
+    setup
+        .mint_tokens_to_account(&fee_payer_token_account, 100_000)
+        .await
+        .expect("Failed to seed fee payer token account");
+    setup
+        .mint_tokens_to_account(&attacker_token_account, 100_000)
+        .await
+        .expect("Failed to seed attacker token account");
+
+    let malicious_tx = ctx
+        .transaction_builder()
+        .with_fee_payer(fee_payer_pubkey)
+        .with_signer(&attacker)
+        .with_spl_payment_with_accounts(
+            &fee_payer_token_account,
+            &attacker_token_account,
+            &fee_payer_pubkey,
+            100_000,
+        )
+        .with_instruction(transfer(&fee_payer_pubkey, &attacker.pubkey(), 500_000))
+        .with_spl_payment_with_accounts(
+            &attacker_token_account,
+            &fee_payer_token_account,
+            &attacker.pubkey(),
+            100_000,
+        )
+        .build()
+        .await
+        .expect("Failed to build malicious transaction");
+
+    let result =
+        ctx.rpc_call::<serde_json::Value, _>("signTransaction", rpc_params![malicious_tx]).await;
+
+    match result {
+        Err(error) => error.assert_contains_message("Insufficient token payment"),
+        Ok(_) => panic!("Expected net-zero token loop to be rejected"),
+    }
+}
+
+#[tokio::test]
 async fn test_fee_payer_as_spl_transfer_source() {
     let ctx = TestContext::new().await.expect("Failed to create test context");
     let setup = TestAccountSetup::new().await;

--- a/tests/adversarial/fee_payer_exploitation.rs
+++ b/tests/adversarial/fee_payer_exploitation.rs
@@ -6,7 +6,8 @@ use solana_sdk::{
 };
 use solana_system_interface::instruction::transfer;
 use spl_associated_token_account_interface::{
-    address::get_associated_token_address, instruction::create_associated_token_account_idempotent,
+    address::{get_associated_token_address, get_associated_token_address_with_program_id},
+    instruction::create_associated_token_account_idempotent,
 };
 use spl_token_interface::instruction as token_instruction;
 
@@ -116,6 +117,89 @@ async fn test_fee_payer_net_zero_token_loop_rejected_within_transaction() {
     match result {
         Err(error) => error.assert_contains_message("Insufficient token payment"),
         Ok(_) => panic!("Expected net-zero token loop to be rejected"),
+    }
+}
+
+#[tokio::test]
+async fn test_fee_payer_net_zero_token_loop_rejected_within_transaction_token2022() {
+    let ctx = TestContext::new().await.expect("Failed to create test context");
+    let setup = TestAccountSetup::new().await;
+
+    let fee_payer_pubkey = FeePayerTestHelper::get_fee_payer_pubkey();
+    let attacker = create_funded_wallet(&ctx).await;
+    let mint = setup.usdc_mint_2022.pubkey();
+
+    let fee_payer_token_account = get_associated_token_address_with_program_id(
+        &fee_payer_pubkey,
+        &mint,
+        &spl_token_2022_interface::id(),
+    );
+    let attacker_token_account = get_associated_token_address_with_program_id(
+        &attacker.pubkey(),
+        &mint,
+        &spl_token_2022_interface::id(),
+    );
+
+    let create_attacker_ata_ix = create_associated_token_account_idempotent(
+        &setup.sender_keypair.pubkey(),
+        &attacker.pubkey(),
+        &mint,
+        &spl_token_2022_interface::id(),
+    );
+    let recent_blockhash =
+        setup.rpc_client.get_latest_blockhash().await.expect("Failed to fetch recent blockhash");
+    let create_ata_tx = Transaction::new_signed_with_payer(
+        &[create_attacker_ata_ix],
+        Some(&setup.sender_keypair.pubkey()),
+        &[&setup.sender_keypair],
+        recent_blockhash,
+    );
+    setup
+        .rpc_client
+        .send_and_confirm_transaction(&create_ata_tx)
+        .await
+        .expect("Failed to create attacker Token2022 ATA");
+
+    setup
+        .mint_tokens_2022_to_account(&fee_payer_token_account, 100_000)
+        .await
+        .expect("Failed to seed fee payer Token2022 account");
+    setup
+        .mint_tokens_2022_to_account(&attacker_token_account, 100_000)
+        .await
+        .expect("Failed to seed attacker Token2022 account");
+
+    let malicious_tx = ctx
+        .transaction_builder()
+        .with_fee_payer(fee_payer_pubkey)
+        .with_signer(&attacker)
+        .with_spl_token_2022_transfer_checked_with_accounts(
+            &mint,
+            &fee_payer_token_account,
+            &attacker_token_account,
+            &fee_payer_pubkey,
+            100_000,
+            TEST_USDC_MINT_DECIMALS,
+        )
+        .with_instruction(transfer(&fee_payer_pubkey, &attacker.pubkey(), 500_000))
+        .with_spl_token_2022_transfer_checked_with_accounts(
+            &mint,
+            &attacker_token_account,
+            &fee_payer_token_account,
+            &attacker.pubkey(),
+            100_000,
+            TEST_USDC_MINT_DECIMALS,
+        )
+        .build()
+        .await
+        .expect("Failed to build malicious Token2022 transaction");
+
+    let result =
+        ctx.rpc_call::<serde_json::Value, _>("signTransaction", rpc_params![malicious_tx]).await;
+
+    match result {
+        Err(error) => error.assert_contains_message("Insufficient token payment"),
+        Ok(_) => panic!("Expected Token2022 net-zero token loop to be rejected"),
     }
 }
 

--- a/tests/adversarial/fee_payer_exploitation.rs
+++ b/tests/adversarial/fee_payer_exploitation.rs
@@ -275,7 +275,12 @@ async fn test_fee_payer_net_zero_token_loop_cannot_drain_sol() {
 
     match result {
         Err(error) => {
-            error.assert_contains_message("Insufficient token payment");
+            let msg = error.to_string();
+            assert!(
+                msg.contains("Insufficient token payment")
+                    || msg.contains("exceeds maximum allowed"),
+                "Expected rejection for net-zero token loop exploit, got: {msg}"
+            );
         }
         Ok(_) => panic!("Expected rejection for net-zero token loop exploit"),
     }

--- a/tests/rpc/bundles.rs
+++ b/tests/rpc/bundles.rs
@@ -5,7 +5,13 @@
 use crate::common::*;
 use jsonrpsee::rpc_params;
 use kora_lib::transaction::TransactionUtil;
-use solana_sdk::signature::{Signature, Signer};
+use solana_sdk::{
+    signature::{Signature, Signer},
+    transaction::Transaction,
+};
+use spl_associated_token_account_interface::{
+    address::get_associated_token_address, instruction::create_associated_token_account_idempotent,
+};
 use std::str::FromStr;
 
 // **************************************************************************************
@@ -663,6 +669,87 @@ async fn test_sign_bundle_insufficient_payment_error() {
     assert!(
         err.contains("insufficient") || err.contains("payment"),
         "Error should mention insufficient payment: {err}"
+    );
+}
+
+#[tokio::test]
+async fn test_sign_bundle_rejects_net_zero_token_loop_across_transactions() {
+    let ctx = TestContext::new().await.expect("Failed to create test context");
+    let setup = TestAccountSetup::new().await;
+
+    let fee_payer = FeePayerTestHelper::get_fee_payer_pubkey();
+    let attacker = create_funded_wallet(&ctx).await;
+    let mint = USDCMintTestHelper::get_test_usdc_mint_pubkey();
+
+    let fee_payer_token_account = get_associated_token_address(&fee_payer, &mint);
+    let attacker_token_account = get_associated_token_address(&attacker.pubkey(), &mint);
+
+    let create_attacker_ata_ix = create_associated_token_account_idempotent(
+        &setup.sender_keypair.pubkey(),
+        &attacker.pubkey(),
+        &mint,
+        &spl_token_interface::id(),
+    );
+    let recent_blockhash =
+        setup.rpc_client.get_latest_blockhash().await.expect("Failed to fetch recent blockhash");
+    let create_ata_tx = Transaction::new_signed_with_payer(
+        &[create_attacker_ata_ix],
+        Some(&setup.sender_keypair.pubkey()),
+        &[&setup.sender_keypair],
+        recent_blockhash,
+    );
+    setup
+        .rpc_client
+        .send_and_confirm_transaction(&create_ata_tx)
+        .await
+        .expect("Failed to create attacker ATA");
+
+    setup
+        .mint_tokens_to_account(&fee_payer_token_account, 100_000)
+        .await
+        .expect("Failed to seed fee payer token account");
+    setup
+        .mint_tokens_to_account(&attacker_token_account, 100_000)
+        .await
+        .expect("Failed to seed attacker token account");
+
+    let payment_tx = ctx
+        .transaction_builder()
+        .with_fee_payer(fee_payer)
+        .with_signer(&attacker)
+        .with_spl_payment_with_accounts(
+            &attacker_token_account,
+            &fee_payer_token_account,
+            &attacker.pubkey(),
+            100_000,
+        )
+        .build()
+        .await
+        .expect("Failed to build bundle payment transaction");
+
+    let drain_tx = ctx
+        .transaction_builder()
+        .with_fee_payer(fee_payer)
+        .with_signer(&attacker)
+        .with_spl_payment_with_accounts(
+            &fee_payer_token_account,
+            &attacker_token_account,
+            &fee_payer,
+            100_000,
+        )
+        .with_transfer(&fee_payer, &attacker.pubkey(), 500_000)
+        .build()
+        .await
+        .expect("Failed to build bundle drain transaction");
+
+    let result: Result<serde_json::Value, _> =
+        ctx.rpc_call("signBundle", rpc_params![vec![payment_tx, drain_tx]]).await;
+
+    assert!(result.is_err(), "Expected bundle with zero net payment to be rejected");
+    let err = result.unwrap_err().to_string();
+    assert!(
+        err.contains("Bundle payment insufficient") || err.contains("payment"),
+        "Error should mention bundle payment insufficiency: {err}"
     );
 }
 

--- a/tests/rpc/bundles.rs
+++ b/tests/rpc/bundles.rs
@@ -730,7 +730,6 @@ async fn test_sign_bundle_rejects_net_zero_token_loop_across_transactions() {
     let drain_tx = ctx
         .transaction_builder()
         .with_fee_payer(fee_payer)
-        .with_signer(&attacker)
         .with_spl_payment_with_accounts(
             &fee_payer_token_account,
             &attacker_token_account,


### PR DESCRIPTION
## Summary
- harden fee payer and token payment accounting across bundle and validator flows
- add adversarial and RPC coverage for the fee payer protection changes
- load GitHub Actions secrets from Doppler OIDC and add local Doppler setup for the repo

## Test Plan
- not run locally in this session

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/solana-foundation/kora/pull/436" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


## 📊 Unit Test Coverage
![Coverage](https://img.shields.io/badge/coverage-85.6%25-green)

**Unit Test Coverage: 85.6%**

[View Detailed Coverage Report](https://github.com/solana-foundation/kora/actions/runs/24685089875)