### PR TITLE
ci: load github actions secrets from doppler

### DIFF
--- a/.github/workflows/fork-external-live-manual.yml
+++ b/.github/workflows/fork-external-live-manual.yml
@@ -11,6 +11,7 @@ on:
 permissions:
   actions: write
   contents: read
+  id-token: write
   issues: write
   pull-requests: write
 
@@ -75,9 +76,15 @@ jobs:
       - name: Setup Solana CLI
         uses: ./.github/actions/setup-solana
 
+      - uses: dopplerhq/secrets-fetch-action@v2.0.0
+        with:
+          auth-method: oidc
+          doppler-identity-id: ${{ vars.DOPPLER_SERVICE_IDENTITY_ID }}
+          doppler-project: ${{ vars.DOPPLER_PROJECT || 'kora' }}
+          doppler-config: ${{ vars.DOPPLER_CONFIG_EXTERNAL_LIVE || vars.DOPPLER_CONFIG_CI || 'stg_github' }}
+          inject-env-vars: true
+
       - name: Ensure Jupiter API key is configured
-        env:
-          JUPITER_API_KEY: ${{ secrets.JUPITER_API_KEY }}
         run: |
           if [ -z "${JUPITER_API_KEY}" ]; then
             echo "JUPITER_API_KEY is required for fork external live tests." >&2
@@ -88,8 +95,6 @@ jobs:
         uses: ./.github/actions/run-test-runner
         with:
           filters: "--filter external_live"
-        env:
-          JUPITER_API_KEY: ${{ secrets.JUPITER_API_KEY }}
 
       - name: Cleanup test environment
         if: always()

--- a/.github/workflows/rust-unit.yml
+++ b/.github/workflows/rust-unit.yml
@@ -28,6 +28,7 @@ jobs:
     timeout-minutes: 15
     permissions:
       contents: read
+      id-token: write
       pull-requests: write
     steps:
       - uses: actions/checkout@v4
@@ -47,12 +48,18 @@ jobs:
       - name: Setup Solana CLI
         uses: ./.github/actions/setup-solana
 
+      - uses: dopplerhq/secrets-fetch-action@v2.0.0
+        with:
+          auth-method: oidc
+          doppler-identity-id: ${{ vars.DOPPLER_SERVICE_IDENTITY_ID }}
+          doppler-project: ${{ vars.DOPPLER_PROJECT || 'kora' }}
+          doppler-config: ${{ vars.DOPPLER_CONFIG_CI || 'stg_github' }}
+          inject-env-vars: true
+
       - name: Install cargo-llvm-cov for coverage
         run: cargo install cargo-llvm-cov
 
       - name: Run unit tests with coverage
-        env:
-          JUPITER_API_KEY: ${{ secrets.JUPITER_API_KEY }}
         run: |
           echo "🧪 Running unit tests with coverage instrumentation..."
           cargo llvm-cov clean --workspace

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -40,6 +40,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     timeout-minutes: 25
+    permissions:
+      contents: read
+      id-token: write
     strategy:
       fail-fast: false
       matrix:
@@ -65,12 +68,18 @@ jobs:
       - name: Setup Solana CLI
         uses: ./.github/actions/setup-solana
 
+      - uses: dopplerhq/secrets-fetch-action@v2.0.0
+        with:
+          auth-method: oidc
+          doppler-identity-id: ${{ vars.DOPPLER_SERVICE_IDENTITY_ID }}
+          doppler-project: ${{ vars.DOPPLER_PROJECT || 'kora' }}
+          doppler-config: ${{ vars.DOPPLER_CONFIG_CI || 'stg_github' }}
+          inject-env-vars: true
+
       - name: Run integration tests
         uses: ./.github/actions/run-test-runner
         with:
           filters: "--filter ${{ matrix.test-group }}"
-        env:
-          JUPITER_API_KEY: ${{ secrets.JUPITER_API_KEY }}
 
       - name: Cleanup test environment
         if: always()

--- a/doppler.yaml
+++ b/doppler.yaml
@@ -1,0 +1,3 @@
+setup:
+  - project: kora
+    config: dev_personal


### PR DESCRIPTION
## Summary
- load kora GitHub Actions secrets from Doppler using OIDC service account identities
- remove direct GitHub secret reads for JUPITER_API_KEY in Rust CI and fork external live workflows
- add doppler.yaml with dev_personal as the local default config

## Test Plan
- not run locally in this session

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/solana-foundation/kora/pull/437" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


## 📊 Unit Test Coverage
![Coverage](https://img.shields.io/badge/coverage-85.6%25-green)

**Unit Test Coverage: 85.6%**

[View Detailed Coverage Report](https://github.com/solana-foundation/kora/actions/runs/24685178829)