### PR TITLE
fix(security): simulate bundle sequentially before signing when sig_verify=false (KORA-21)

### DIFF
--- a/crates/lib/src/rpc_server/method/sign_and_send_bundle.rs
+++ b/crates/lib/src/rpc_server/method/sign_and_send_bundle.rs
@@ -89,6 +89,26 @@ pub async fn sign_and_send_bundle(
     )
     .await?;
 
+    let signed_indices = BundleValidator::signed_indices_for_bundle(
+        transactions.len(),
+        sign_only_indices.as_deref(),
+    );
+
+    // When sig_verify = false (default), simulation accepts unsigned transactions
+    // (skipSigVerify = true). Validate the bundle sequentially before calling the
+    // signer so that invalid bundles are rejected before consuming signer resources.
+    if !sig_verify {
+        BundleValidator::simulate_and_validate_sequential_bundle(
+            rpc_client,
+            config,
+            &transactions,
+            &signed_indices,
+            &fee_payer,
+            true,
+        )
+        .await?;
+    }
+
     let signed_resolved = processor.sign_all(&signer, &fee_payer, rpc_client, config, true).await?;
 
     // Encode signed transactions
@@ -104,19 +124,18 @@ pub async fn sign_and_send_bundle(
         &index_to_position,
     );
 
-    let signed_indices = BundleValidator::signed_indices_for_bundle(
-        transactions.len(),
-        sign_only_indices.as_deref(),
-    );
-    BundleValidator::simulate_and_validate_sequential_bundle(
-        rpc_client,
-        config,
-        &signed_transactions,
-        &signed_indices,
-        &fee_payer,
-        !sig_verify,
-    )
-    .await?;
+    // When sig_verify = true, simulation needs real signatures: validate after signing.
+    if sig_verify {
+        BundleValidator::simulate_and_validate_sequential_bundle(
+            rpc_client,
+            config,
+            &signed_transactions,
+            &signed_indices,
+            &fee_payer,
+            false,
+        )
+        .await?;
+    }
 
     // Send the full merged bundle to Jito for atomic execution.
     let jito_client = JitoBundleClient::new(&config.kora.bundle.jito);
@@ -457,5 +476,67 @@ mod tests {
         assert!(json.contains("signer_pubkey"));
         assert!(json.contains("bundle_uuid"));
         assert!(json.contains("bundle-uuid-12345"));
+    }
+
+    #[tokio::test]
+    async fn test_sign_and_send_bundle_rejects_outflow_violation_before_signing_when_sig_verify_false(
+    ) {
+        // When sig_verify = false (default), simulation runs BEFORE signing.
+        // A bundle with sequential outflow violation must be rejected without calling the signer.
+        let mut server = Server::new_async().await;
+        let simulate_mock = server
+            .mock("POST", "/")
+            .match_header("content-type", "application/json")
+            .match_body(Matcher::PartialJson(json!({"method": "simulateBundle"})))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"{"jsonrpc":"2.0","id":1,"result":{"context":{"slot":123},"value":{"summary":"succeeded","transactionResults":[{"err":null,"logs":["Program 11111111111111111111111111111111 invoke [1]"],"preExecutionAccounts":[{"lamports":2500000,"owner":"11111111111111111111111111111111","data":["","base64"],"executable":false,"rentEpoch":0}],"postExecutionAccounts":[{"lamports":1000000,"owner":"11111111111111111111111111111111","data":["","base64"],"executable":false,"rentEpoch":0}]}]}}}"#,
+            )
+            .create();
+
+        let mut config = ConfigMockBuilder::new()
+            .with_bundle_enabled(true)
+            .with_usage_limit_enabled(false)
+            .with_max_allowed_lamports(1_000_000)
+            .build();
+        config.validation.price = PriceConfig { model: PriceModel::Free };
+        config.kora.bundle.jito.block_engine_url = server.url();
+        config.kora.bundle.jito.simulate_bundle_url = Some(server.url());
+        let _m = setup_config_mock(config);
+        let _ = setup_or_get_test_usage_limiter().await;
+
+        let signer_pubkey = setup_or_get_test_signer();
+        let rpc_client = Arc::new(
+            RpcMockBuilder::new()
+                .with_fee_estimate(5000)
+                .with_blockhash()
+                .with_simulation()
+                .build(),
+        );
+
+        // Fee payer is signer_pubkey, but is NOT the transfer sender.
+        // process_bundle passes; the Jito simulation mock returns a large lamport drop
+        // for the fee payer account, which exceeds max_allowed_lamports.
+        let ix = transfer(&Pubkey::new_unique(), &Pubkey::new_unique(), 1_000_000_000);
+        let message = VersionedMessage::Legacy(Message::new(&[ix], Some(&signer_pubkey)));
+        let transaction = TransactionUtil::new_unsigned_versioned_transaction(message);
+        let encoded = TransactionUtil::encode_versioned_transaction(&transaction).unwrap();
+
+        let request = SignAndSendBundleRequest {
+            transactions: vec![encoded],
+            signer_key: Some(signer_pubkey.to_string()),
+            sig_verify: false,
+            user_id: None,
+            sign_only_indices: None,
+        };
+
+        let result = sign_and_send_bundle(&rpc_client, request).await;
+
+        simulate_mock.assert();
+        assert!(result.is_err(), "Expected sequential outflow validation error");
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("Total transfer amount"), "Unexpected error: {err}");
+        assert!(err.contains("exceeds maximum allowed"), "Unexpected error: {err}");
     }
 }

--- a/crates/lib/src/rpc_server/method/sign_bundle.rs
+++ b/crates/lib/src/rpc_server/method/sign_bundle.rs
@@ -82,6 +82,26 @@ pub async fn sign_bundle(
     )
     .await?;
 
+    let signed_indices = BundleValidator::signed_indices_for_bundle(
+        transactions.len(),
+        sign_only_indices.as_deref(),
+    );
+
+    // When sig_verify = false (default), simulation accepts unsigned transactions
+    // (skipSigVerify = true). Validate the bundle sequentially before calling the
+    // signer so that invalid bundles are rejected before consuming signer resources.
+    if !sig_verify {
+        BundleValidator::simulate_and_validate_sequential_bundle(
+            rpc_client,
+            config,
+            &transactions,
+            &signed_indices,
+            &fee_payer,
+            true,
+        )
+        .await?;
+    }
+
     let signed_resolved =
         processor.sign_all(&signer, &fee_payer, rpc_client, config, false).await?;
 
@@ -98,19 +118,18 @@ pub async fn sign_bundle(
         &index_to_position,
     );
 
-    let signed_indices = BundleValidator::signed_indices_for_bundle(
-        transactions.len(),
-        sign_only_indices.as_deref(),
-    );
-    BundleValidator::simulate_and_validate_sequential_bundle(
-        rpc_client,
-        config,
-        &signed_transactions,
-        &signed_indices,
-        &fee_payer,
-        !sig_verify,
-    )
-    .await?;
+    // When sig_verify = true, simulation needs real signatures: validate after signing.
+    if sig_verify {
+        BundleValidator::simulate_and_validate_sequential_bundle(
+            rpc_client,
+            config,
+            &signed_transactions,
+            &signed_indices,
+            &fee_payer,
+            false,
+        )
+        .await?;
+    }
 
     Ok(SignBundleResponse { signed_transactions, signer_pubkey: fee_payer.to_string() })
 }
@@ -423,6 +442,67 @@ mod tests {
             sig_verify: true,
             user_id: None,
             sign_only_indices: Some(vec![1]),
+        };
+
+        let result = sign_bundle(&rpc_client, request).await;
+
+        simulate_mock.assert();
+        assert!(result.is_err(), "Expected sequential outflow validation error");
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("Total transfer amount"), "Unexpected error: {err}");
+        assert!(err.contains("exceeds maximum allowed"), "Unexpected error: {err}");
+    }
+
+    #[tokio::test]
+    async fn test_sign_bundle_rejects_outflow_violation_before_signing_when_sig_verify_false() {
+        // When sig_verify = false (default), simulation runs BEFORE signing.
+        // A bundle with sequential outflow violation must be rejected without calling the signer.
+        let mut server = Server::new_async().await;
+        let simulate_mock = server
+            .mock("POST", "/")
+            .match_header("content-type", "application/json")
+            .match_body(Matcher::PartialJson(json!({"method": "simulateBundle"})))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                r#"{"jsonrpc":"2.0","id":1,"result":{"context":{"slot":123},"value":{"summary":"succeeded","transactionResults":[{"err":null,"logs":["Program 11111111111111111111111111111111 invoke [1]"],"preExecutionAccounts":[{"lamports":2500000,"owner":"11111111111111111111111111111111","data":["","base64"],"executable":false,"rentEpoch":0}],"postExecutionAccounts":[{"lamports":1000000,"owner":"11111111111111111111111111111111","data":["","base64"],"executable":false,"rentEpoch":0}]}]}}}"#,
+            )
+            .create();
+
+        let mut config = ConfigMockBuilder::new()
+            .with_bundle_enabled(true)
+            .with_usage_limit_enabled(false)
+            .with_max_allowed_lamports(1_000_000)
+            .build();
+        config.validation.price = PriceConfig { model: PriceModel::Free };
+        config.kora.bundle.jito.block_engine_url = server.url();
+        config.kora.bundle.jito.simulate_bundle_url = Some(server.url());
+        let _m = setup_config_mock(config);
+        let _ = setup_or_get_test_usage_limiter().await;
+
+        let signer_pubkey = setup_or_get_test_signer();
+        let rpc_client = Arc::new(
+            RpcMockBuilder::new()
+                .with_fee_estimate(5000)
+                .with_blockhash()
+                .with_simulation()
+                .build(),
+        );
+
+        // Fee payer is signer_pubkey, but is NOT the transfer sender.
+        // process_bundle passes; the Jito simulation mock returns a large lamport drop
+        // for the fee payer account, which exceeds max_allowed_lamports.
+        let ix = transfer(&Pubkey::new_unique(), &Pubkey::new_unique(), 1_000_000_000);
+        let message = VersionedMessage::Legacy(Message::new(&[ix], Some(&signer_pubkey)));
+        let transaction = TransactionUtil::new_unsigned_versioned_transaction(message);
+        let encoded = TransactionUtil::encode_versioned_transaction(&transaction).unwrap();
+
+        let request = SignBundleRequest {
+            transactions: vec![encoded],
+            signer_key: Some(signer_pubkey.to_string()),
+            sig_verify: false,
+            user_id: None,
+            sign_only_indices: None,
         };
 
         let result = sign_bundle(&rpc_client, request).await;


### PR DESCRIPTION
## Summary

- **Finding:** KORA-21 — Bundle signing happens before sequential simulation, wasting signer resources on bundles that will be immediately rejected
- When `sig_verify = false` (the default), Jito simulation uses `skipSigVerify = true` and accepts unsigned transactions. There's no need to call the signer before knowing whether the bundle passes the sequential outflow and program-allowlist checks.
- Fix: for both `signBundle` and `signAndSendBundle`, call `simulate_and_validate_sequential_bundle` **before** `sign_all` when `sig_verify = false`. When `sig_verify = true` the simulation needs actual signatures, so the existing sign-then-simulate order is preserved.

## Test plan

- [x] New test `test_sign_bundle_rejects_outflow_violation_before_signing_when_sig_verify_false`: mockito simulation returns outflow violation, `simulate_mock.assert()` confirms simulation was called, result is the expected outflow error
- [x] New test `test_sign_and_send_bundle_rejects_outflow_violation_before_signing_when_sig_verify_false`: same pattern for `signAndSendBundle`
- [x] All existing `sign_bundle` tests pass (11/11) — `sig_verify = true` path is unchanged
- [x] All existing `sign_and_send_bundle` tests pass (11/11)
- [x] `just fmt` passes
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/solana-foundation/kora/pull/439" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


## 📊 Unit Test Coverage
![Coverage](https://img.shields.io/badge/coverage-85.7%25-green)

**Unit Test Coverage: 85.7%**

[View Detailed Coverage Report](https://github.com/solana-foundation/kora/actions/runs/24685880541)