### PR TITLE
fix(security): verify payment owner is a signer before quota attribution (KORA-19)

### DIFF
--- a/crates/lib/src/fee/fee.rs
+++ b/crates/lib/src/fee/fee.rs
@@ -15,7 +15,7 @@ use crate::{
     },
     transaction::{
         ParsedSPLInstructionData, ParsedSPLInstructionType, ParsedSystemInstructionData,
-        ParsedSystemInstructionType, VersionedTransactionResolved,
+        ParsedSystemInstructionType, VersionedTransactionOps, VersionedTransactionResolved,
     },
 };
 
@@ -91,20 +91,7 @@ impl FeeConfigUtil {
         transaction: &VersionedTransactionResolved,
         fee_payer: &Pubkey,
     ) -> Result<bool, KoraError> {
-        let all_account_keys = &transaction.all_account_keys;
-        let transaction_inner = &transaction.transaction;
-
-        // In messages, the first num_required_signatures accounts are signers
-        Ok(match &transaction_inner.message {
-            VersionedMessage::Legacy(legacy_message) => {
-                let num_signers = legacy_message.header.num_required_signatures as usize;
-                all_account_keys.iter().take(num_signers).any(|key| *key == *fee_payer)
-            }
-            VersionedMessage::V0(v0_message) => {
-                let num_signers = v0_message.header.num_required_signatures as usize;
-                all_account_keys.iter().take(num_signers).any(|key| *key == *fee_payer)
-            }
-        })
+        Ok(transaction.signer_pubkeys().contains(fee_payer))
     }
 
     /// Helper function to check if a token transfer instruction is a payment to Kora

--- a/crates/lib/src/token/token.rs
+++ b/crates/lib/src/token/token.rs
@@ -1384,6 +1384,7 @@ mod tests_token {
             ParsedSPLInstructionData::SplTokenTransfer {
                 amount,
                 owner: fee_payer,
+                multisig_signers: vec![],
                 mint: Some(mint),
                 source_address: Pubkey::new_unique(),
                 destination_address: other,
@@ -1392,6 +1393,7 @@ mod tests_token {
             ParsedSPLInstructionData::SplTokenTransfer {
                 amount,
                 owner: other,
+                multisig_signers: vec![],
                 mint: Some(mint),
                 source_address: Pubkey::new_unique(),
                 destination_address: fee_payer_token2022_ata,
@@ -1427,6 +1429,7 @@ mod tests_token {
         let spl_transfers = vec![ParsedSPLInstructionData::SplTokenTransfer {
             amount,
             owner: fee_payer,
+            multisig_signers: vec![],
             mint: Some(mint),
             source_address: Pubkey::new_unique(),
             destination_address: Pubkey::new_unique(),

--- a/crates/lib/src/transaction/instruction_util.rs
+++ b/crates/lib/src/transaction/instruction_util.rs
@@ -113,6 +113,7 @@ pub enum ParsedSPLInstructionData {
     SplTokenTransfer {
         amount: u64,
         owner: Pubkey,
+        multisig_signers: Vec<Pubkey>,
         mint: Option<Pubkey>,
         source_address: Pubkey,
         destination_address: Pubkey,
@@ -1790,6 +1791,10 @@ impl IxUtils {
                                 .or_default()
                                 .push(ParsedSPLInstructionData::SplTokenTransfer {
                                     owner: instruction.accounts[instruction_indexes::spl_token_transfer::OWNER_INDEX].pubkey,
+                                    multisig_signers: Self::extract_multisig_signers(
+                                        instruction,
+                                        instruction_indexes::spl_token_transfer::REQUIRED_NUMBER_OF_ACCOUNTS,
+                                    ),
                                     amount,
                                     mint: None,
                                     source_address: instruction.accounts[instruction_indexes::spl_token_transfer::SOURCE_ADDRESS_INDEX].pubkey,
@@ -1808,6 +1813,10 @@ impl IxUtils {
                                 .or_default()
                                 .push(ParsedSPLInstructionData::SplTokenTransfer {
                                     owner: instruction.accounts[instruction_indexes::spl_token_transfer_checked::OWNER_INDEX].pubkey,
+                                    multisig_signers: Self::extract_multisig_signers(
+                                        instruction,
+                                        instruction_indexes::spl_token_transfer_checked::REQUIRED_NUMBER_OF_ACCOUNTS,
+                                    ),
                                     amount,
                                     mint: Some(instruction.accounts[instruction_indexes::spl_token_transfer_checked::MINT_INDEX].pubkey),
                                     source_address: instruction.accounts[instruction_indexes::spl_token_transfer_checked::SOURCE_ADDRESS_INDEX].pubkey,
@@ -2072,6 +2081,10 @@ impl IxUtils {
                                 .or_default()
                                 .push(ParsedSPLInstructionData::SplTokenTransfer {
                                     owner: instruction.accounts[instruction_indexes::spl_token_transfer::OWNER_INDEX].pubkey,
+                                    multisig_signers: Self::extract_multisig_signers(
+                                        instruction,
+                                        instruction_indexes::spl_token_transfer::REQUIRED_NUMBER_OF_ACCOUNTS,
+                                    ),
                                     amount,
                                     mint: None,
                                     source_address: instruction.accounts[instruction_indexes::spl_token_transfer::SOURCE_ADDRESS_INDEX].pubkey,
@@ -2090,6 +2103,10 @@ impl IxUtils {
                                 .or_default()
                                 .push(ParsedSPLInstructionData::SplTokenTransfer {
                                     owner: instruction.accounts[instruction_indexes::spl_token_transfer_checked::OWNER_INDEX].pubkey,
+                                    multisig_signers: Self::extract_multisig_signers(
+                                        instruction,
+                                        instruction_indexes::spl_token_transfer_checked::REQUIRED_NUMBER_OF_ACCOUNTS,
+                                    ),
                                     amount,
                                     mint: Some(instruction.accounts[instruction_indexes::spl_token_transfer_checked::MINT_INDEX].pubkey),
                                     source_address: instruction.accounts[instruction_indexes::spl_token_transfer_checked::SOURCE_ADDRESS_INDEX].pubkey,
@@ -3387,6 +3404,7 @@ mod tests {
             ParsedSPLInstructionData::SplTokenTransfer {
                 amount: parsed_amount,
                 owner: parsed_owner,
+                multisig_signers,
                 mint,
                 source_address: parsed_source,
                 destination_address: parsed_destination,
@@ -3394,6 +3412,7 @@ mod tests {
             } => {
                 assert_eq!(*parsed_amount, amount);
                 assert_eq!(*parsed_owner, owner.pubkey());
+                assert!(multisig_signers.is_empty());
                 assert_eq!(*parsed_source, source_address);
                 assert_eq!(*parsed_destination, destination_address);
                 assert!(!is_2022);
@@ -3451,6 +3470,7 @@ mod tests {
             ParsedSPLInstructionData::SplTokenTransfer {
                 amount: parsed_amount,
                 owner: parsed_owner,
+                multisig_signers,
                 mint: parsed_mint,
                 source_address: parsed_source,
                 destination_address: parsed_destination,
@@ -3458,6 +3478,7 @@ mod tests {
             } => {
                 assert_eq!(*parsed_amount, amount);
                 assert_eq!(*parsed_owner, owner.pubkey());
+                assert!(multisig_signers.is_empty());
                 assert_eq!(*parsed_source, source_address);
                 assert_eq!(*parsed_destination, destination_address);
                 assert!(*is_2022);

--- a/crates/lib/src/transaction/versioned_transaction.rs
+++ b/crates/lib/src/transaction/versioned_transaction.rs
@@ -7,7 +7,11 @@ use solana_message::{
     compiled_instruction::CompiledInstruction, v0::MessageAddressTableLookup, VersionedMessage,
 };
 use solana_sdk::{instruction::Instruction, pubkey::Pubkey, transaction::VersionedTransaction};
-use std::{collections::HashMap, ops::Deref, time::Duration};
+use std::{
+    collections::{HashMap, HashSet},
+    ops::Deref,
+    time::Duration,
+};
 
 use solana_transaction_status_client_types::UiTransactionEncoding;
 
@@ -65,6 +69,8 @@ impl Deref for VersionedTransactionResolved {
 #[async_trait]
 pub trait VersionedTransactionOps {
     fn encode_b64_transaction(&self) -> Result<String, KoraError>;
+    fn signer_pubkeys(&self) -> &[Pubkey];
+    fn verified_signers(&self) -> HashSet<Pubkey>;
     fn find_signer_position(&self, signer_pubkey: &Pubkey) -> Result<usize, KoraError>;
 
     async fn sign_transaction(
@@ -262,20 +268,31 @@ impl VersionedTransactionOps for VersionedTransactionResolved {
         Ok(STANDARD.encode(serialized))
     }
 
-    fn find_signer_position(&self, signer_pubkey: &Pubkey) -> Result<usize, KoraError> {
+    fn signer_pubkeys(&self) -> &[Pubkey] {
         let num_required_signatures =
             self.transaction.message.header().num_required_signatures as usize;
+        &self.transaction.message.static_account_keys()[..num_required_signatures]
+    }
+
+    fn verified_signers(&self) -> HashSet<Pubkey> {
+        let message_bytes = self.transaction.message.serialize();
+
         self.transaction
-            .message
-            .static_account_keys()
+            .signatures
             .iter()
-            .take(num_required_signatures)
-            .position(|key| key == signer_pubkey)
-            .ok_or_else(|| {
-                KoraError::InvalidTransaction(format!(
-                    "Signer {signer_pubkey} not found in transaction signer keys"
-                ))
+            .zip(self.signer_pubkeys().iter())
+            .filter_map(|(signature, pubkey)| {
+                signature.verify(pubkey.as_ref(), &message_bytes).then_some(*pubkey)
             })
+            .collect()
+    }
+
+    fn find_signer_position(&self, signer_pubkey: &Pubkey) -> Result<usize, KoraError> {
+        self.signer_pubkeys().iter().position(|key| key == signer_pubkey).ok_or_else(|| {
+            KoraError::InvalidTransaction(format!(
+                "Signer {signer_pubkey} not found in transaction signer keys"
+            ))
+        })
     }
 
     async fn sign_transaction(
@@ -656,6 +673,68 @@ mod tests {
         assert_eq!(transaction.find_signer_position(&keypair1.pubkey()).unwrap(), 0);
         assert_eq!(transaction.find_signer_position(&keypair2.pubkey()).unwrap(), 1);
         assert_eq!(transaction.find_signer_position(&keypair3.pubkey()).unwrap(), 2);
+    }
+
+    #[test]
+    fn test_signer_pubkeys_returns_only_required_signers() {
+        let keypair1 = Keypair::new();
+        let keypair2 = Keypair::new();
+        let keypair3 = Keypair::new();
+        let program_id = Pubkey::new_unique();
+
+        let v0_message = v0::Message {
+            header: solana_message::MessageHeader {
+                num_required_signatures: 3,
+                num_readonly_signed_accounts: 0,
+                num_readonly_unsigned_accounts: 1,
+            },
+            account_keys: vec![keypair1.pubkey(), keypair2.pubkey(), keypair3.pubkey(), program_id],
+            recent_blockhash: Hash::default(),
+            instructions: vec![CompiledInstruction {
+                program_id_index: 3,
+                accounts: vec![0, 1, 2],
+                data: vec![1, 2, 3],
+            }],
+            address_table_lookups: vec![],
+        };
+        let message = VersionedMessage::V0(v0_message);
+        let transaction =
+            TransactionUtil::new_unsigned_versioned_transaction_resolved(message).unwrap();
+
+        assert_eq!(
+            transaction.signer_pubkeys(),
+            &[keypair1.pubkey(), keypair2.pubkey(), keypair3.pubkey()]
+        );
+    }
+
+    #[test]
+    fn test_verified_signers_excludes_unsigned_signer_slots() {
+        let fee_payer = Keypair::new();
+        let other_signer = Keypair::new();
+        let instruction = Instruction::new_with_bytes(
+            Pubkey::new_unique(),
+            &[1, 2, 3],
+            vec![AccountMeta::new_readonly(other_signer.pubkey(), true)],
+        );
+        let message =
+            VersionedMessage::Legacy(Message::new(&[instruction], Some(&fee_payer.pubkey())));
+        let mut transaction = TransactionUtil::new_unsigned_versioned_transaction(message);
+        let message_bytes = transaction.message.serialize();
+        let fee_payer_position = transaction
+            .message
+            .static_account_keys()
+            .iter()
+            .position(|key| key == &fee_payer.pubkey())
+            .unwrap();
+        transaction.signatures[fee_payer_position] = fee_payer.sign_message(&message_bytes);
+
+        let resolved =
+            VersionedTransactionResolved::from_kora_built_transaction(&transaction).unwrap();
+        let verified_signers = resolved.verified_signers();
+
+        assert_eq!(resolved.signer_pubkeys(), &[fee_payer.pubkey(), other_signer.pubkey()]);
+        assert!(verified_signers.contains(&fee_payer.pubkey()));
+        assert!(!verified_signers.contains(&other_signer.pubkey()));
     }
 
     #[test]

--- a/crates/lib/src/usage_limit/usage_tracker.rs
+++ b/crates/lib/src/usage_limit/usage_tracker.rs
@@ -732,8 +732,6 @@ mod tests {
             .contains("Usage limiter unavailable and fallback disabled"));
     }
 
-    // ── KORA-19: owner signer verification ────────────────────────────────────
-
     fn make_spl_transfer_transaction(
         owner: Pubkey,
         owner_is_signer: bool,

--- a/crates/lib/src/usage_limit/usage_tracker.rs
+++ b/crates/lib/src/usage_limit/usage_tracker.rs
@@ -98,6 +98,12 @@ impl UsageTracker {
         rpc_client: &RpcClient,
     ) -> Result<Option<Pubkey>, KoraError> {
         let payment_destination = config.kora.get_payment_address(fee_payer)?;
+
+        // Collect signers before the mutable borrow required by get_or_parse_spl_instructions.
+        let num_signers = transaction.message.header().num_required_signatures as usize;
+        let signers: Vec<Pubkey> =
+            transaction.message.static_account_keys().iter().take(num_signers).copied().collect();
+
         let parsed_spl_instructions = transaction.get_or_parse_spl_instructions()?;
 
         for instruction in parsed_spl_instructions
@@ -126,7 +132,12 @@ impl UsageTracker {
 
                 // Check if this is a payment to Kora
                 if token_account.owner() == payment_destination {
-                    return Ok(Some(*owner));
+                    // Verify the owner signed this transaction. Without this check, an attacker
+                    // could name an arbitrary victim as the payment owner in unsigned instruction
+                    // data, exhausting the victim's usage quota without their involvement.
+                    if signers.contains(owner) {
+                        return Ok(Some(*owner));
+                    }
                 }
             }
         }
@@ -719,5 +730,98 @@ mod tests {
             .unwrap_err()
             .to_string()
             .contains("Usage limiter unavailable and fallback disabled"));
+    }
+
+    // ── KORA-19: owner signer verification ────────────────────────────────────
+
+    fn make_spl_transfer_transaction(
+        owner: Pubkey,
+        owner_is_signer: bool,
+        destination_ata: Pubkey,
+        fee_payer: Pubkey,
+    ) -> VersionedTransactionResolved {
+        use solana_message::Message;
+        use solana_sdk::{
+            instruction::{AccountMeta, Instruction},
+            transaction::{Transaction, VersionedTransaction},
+        };
+
+        let ix = Instruction {
+            program_id: spl_token_interface::ID,
+            accounts: vec![
+                AccountMeta::new(Pubkey::new_unique(), false),
+                AccountMeta::new(destination_ata, false),
+                AccountMeta::new_readonly(owner, owner_is_signer),
+            ],
+            data: spl_token_interface::instruction::TokenInstruction::Transfer {
+                amount: 1_000_000,
+            }
+            .pack(),
+        };
+
+        let message = Message::new(&[ix], Some(&fee_payer));
+        let tx = VersionedTransaction::from(Transaction::new_unsigned(message));
+        VersionedTransactionResolved::from_kora_built_transaction(&tx).unwrap()
+    }
+
+    #[tokio::test]
+    async fn test_extract_user_unsigned_owner_returns_none() {
+        // Attack scenario: attacker names a victim as payment owner in instruction data
+        // but the victim did NOT sign the transaction. The fix must return None so that
+        // the victim's quota is not consumed.
+        let store = Arc::new(InMemoryUsageStore::new());
+        let tracker = UsageTracker::new(true, store, vec![], HashSet::new(), false);
+
+        let fee_payer = Pubkey::new_unique();
+        let victim_owner = Pubkey::new_unique();
+        let destination_ata = Pubkey::new_unique();
+        let mint = Pubkey::new_unique();
+
+        // Build token account where the ATA is owned by the fee payer (= payment destination
+        // when no explicit payment_address is configured).
+        let token_account =
+            crate::tests::account_mock::create_mock_token_account(&fee_payer, &mint);
+        let rpc_client = Arc::new(RpcMockBuilder::new().with_account_info(&token_account).build());
+
+        let config = ConfigMockBuilder::new().build();
+
+        // victim_owner is NOT a signer — attack scenario
+        let mut tx = make_spl_transfer_transaction(victim_owner, false, destination_ata, fee_payer);
+
+        let result = tracker
+            .extract_user_from_payment_instruction(&mut tx, &config, &fee_payer, &rpc_client)
+            .await
+            .unwrap();
+
+        assert_eq!(result, None, "Unsigned owner must not be attributed quota");
+    }
+
+    #[tokio::test]
+    async fn test_extract_user_signed_owner_returns_owner() {
+        // Legitimate scenario: the payment owner actually signed the transaction.
+        // The function must return Some(owner) so quota can be tracked correctly.
+        let store = Arc::new(InMemoryUsageStore::new());
+        let tracker = UsageTracker::new(true, store, vec![], HashSet::new(), false);
+
+        let fee_payer = Pubkey::new_unique();
+        let real_owner = Pubkey::new_unique();
+        let destination_ata = Pubkey::new_unique();
+        let mint = Pubkey::new_unique();
+
+        let token_account =
+            crate::tests::account_mock::create_mock_token_account(&fee_payer, &mint);
+        let rpc_client = Arc::new(RpcMockBuilder::new().with_account_info(&token_account).build());
+
+        let config = ConfigMockBuilder::new().build();
+
+        // real_owner IS a signer — legitimate payment
+        let mut tx = make_spl_transfer_transaction(real_owner, true, destination_ata, fee_payer);
+
+        let result = tracker
+            .extract_user_from_payment_instruction(&mut tx, &config, &fee_payer, &rpc_client)
+            .await
+            .unwrap();
+
+        assert_eq!(result, Some(real_owner), "Signed owner must be attributed quota");
     }
 }

--- a/crates/lib/src/usage_limit/usage_tracker.rs
+++ b/crates/lib/src/usage_limit/usage_tracker.rs
@@ -14,7 +14,8 @@ use crate::{
     state::get_signer_pool,
     token::token::TokenType,
     transaction::{
-        ParsedSPLInstructionData, ParsedSPLInstructionType, VersionedTransactionResolved,
+        ParsedSPLInstructionData, ParsedSPLInstructionType, VersionedTransactionOps,
+        VersionedTransactionResolved,
     },
 };
 use deadpool_redis::Runtime;
@@ -88,20 +89,6 @@ impl UsageTracker {
 
     fn has_instruction_rules(&self) -> bool {
         !self.instruction_rule_indices.is_empty()
-    }
-
-    fn collect_verified_signers(transaction: &VersionedTransactionResolved) -> HashSet<Pubkey> {
-        let message_bytes = transaction.transaction.message.serialize();
-
-        transaction
-            .transaction
-            .signatures
-            .iter()
-            .zip(transaction.transaction.message.static_account_keys().iter())
-            .filter_map(|(signature, pubkey)| {
-                signature.verify(pubkey.as_ref(), &message_bytes).then_some(*pubkey)
-            })
-            .collect()
     }
 
     async fn owner_signed_or_authorized_by_multisig(
@@ -190,7 +177,7 @@ impl UsageTracker {
         rpc_client: &RpcClient,
     ) -> Result<Option<Pubkey>, KoraError> {
         let payment_destination = config.kora.get_payment_address(fee_payer)?;
-        let verified_signers = Self::collect_verified_signers(transaction);
+        let verified_signers = transaction.verified_signers();
         let parsed_spl_instructions = transaction.get_or_parse_spl_instructions()?;
 
         for instruction in parsed_spl_instructions
@@ -243,12 +230,9 @@ impl UsageTracker {
 
     /// Extract kora signer from transaction signers
     fn extract_kora_signer(&self, transaction: &VersionedTransactionResolved) -> Option<Pubkey> {
-        let account_keys = transaction.message.static_account_keys();
-        let num_signers = transaction.message.header().num_required_signatures as usize;
-
-        account_keys
+        transaction
+            .signer_pubkeys()
             .iter()
-            .take(num_signers)
             .find(|signer| self.kora_signers.contains(signer))
             .copied()
     }

--- a/crates/lib/src/usage_limit/usage_tracker.rs
+++ b/crates/lib/src/usage_limit/usage_tracker.rs
@@ -20,7 +20,7 @@ use crate::{
 use deadpool_redis::Runtime;
 use redis::AsyncCommands;
 use solana_client::nonblocking::rpc_client::RpcClient;
-use solana_sdk::pubkey::Pubkey;
+use solana_sdk::{program_pack::Pack, pubkey::Pubkey};
 use tokio::sync::OnceCell;
 
 #[cfg(not(test))]
@@ -90,6 +90,98 @@ impl UsageTracker {
         !self.instruction_rule_indices.is_empty()
     }
 
+    fn collect_verified_signers(transaction: &VersionedTransactionResolved) -> HashSet<Pubkey> {
+        let message_bytes = transaction.transaction.message.serialize();
+
+        transaction
+            .transaction
+            .signatures
+            .iter()
+            .zip(transaction.transaction.message.static_account_keys().iter())
+            .filter_map(|(signature, pubkey)| {
+                signature.verify(pubkey.as_ref(), &message_bytes).then_some(*pubkey)
+            })
+            .collect()
+    }
+
+    async fn owner_signed_or_authorized_by_multisig(
+        owner: &Pubkey,
+        multisig_signers: &[Pubkey],
+        is_2022: bool,
+        verified_signers: &HashSet<Pubkey>,
+        config: &Config,
+        rpc_client: &RpcClient,
+    ) -> Result<bool, KoraError> {
+        if verified_signers.contains(owner) {
+            return Ok(true);
+        }
+
+        if multisig_signers.is_empty() {
+            return Ok(false);
+        }
+
+        let owner_account = match CacheUtil::get_account(config, rpc_client, owner, true).await {
+            Ok(account) => account,
+            Err(KoraError::AccountNotFound(_)) => return Ok(false),
+            Err(err) => return Err(err),
+        };
+
+        let verified_instruction_signers: HashSet<_> = multisig_signers
+            .iter()
+            .copied()
+            .filter(|signer| verified_signers.contains(signer))
+            .collect();
+
+        if verified_instruction_signers.is_empty() {
+            return Ok(false);
+        }
+
+        let (required_signers, multisig_members): (usize, HashSet<Pubkey>) = if is_2022 {
+            if owner_account.owner != spl_token_2022_interface::id() {
+                return Ok(false);
+            }
+
+            let Ok(multisig) =
+                spl_token_2022_interface::state::Multisig::unpack(&owner_account.data)
+            else {
+                return Ok(false);
+            };
+
+            (
+                multisig.m as usize,
+                multisig
+                    .signers
+                    .iter()
+                    .take(multisig.n as usize)
+                    .copied()
+                    .filter(|signer| *signer != Pubkey::default())
+                    .collect(),
+            )
+        } else {
+            if owner_account.owner != spl_token_interface::id() {
+                return Ok(false);
+            }
+
+            let Ok(multisig) = spl_token_interface::state::Multisig::unpack(&owner_account.data)
+            else {
+                return Ok(false);
+            };
+
+            (
+                multisig.m as usize,
+                multisig
+                    .signers
+                    .iter()
+                    .take(multisig.n as usize)
+                    .copied()
+                    .filter(|signer| *signer != Pubkey::default())
+                    .collect(),
+            )
+        };
+
+        Ok(verified_instruction_signers.intersection(&multisig_members).count() >= required_signers)
+    }
+
     async fn extract_user_from_payment_instruction(
         &self,
         transaction: &mut VersionedTransactionResolved,
@@ -98,12 +190,7 @@ impl UsageTracker {
         rpc_client: &RpcClient,
     ) -> Result<Option<Pubkey>, KoraError> {
         let payment_destination = config.kora.get_payment_address(fee_payer)?;
-
-        // Collect signers before the mutable borrow required by get_or_parse_spl_instructions.
-        let num_signers = transaction.message.header().num_required_signatures as usize;
-        let signers: Vec<Pubkey> =
-            transaction.message.static_account_keys().iter().take(num_signers).copied().collect();
-
+        let verified_signers = Self::collect_verified_signers(transaction);
         let parsed_spl_instructions = transaction.get_or_parse_spl_instructions()?;
 
         for instruction in parsed_spl_instructions
@@ -111,7 +198,11 @@ impl UsageTracker {
             .unwrap_or(&vec![])
         {
             if let ParsedSPLInstructionData::SplTokenTransfer {
-                destination_address, owner, ..
+                destination_address,
+                owner,
+                multisig_signers,
+                is_2022,
+                ..
             } = instruction
             {
                 // Check if this is a payment to Kora by verifying the destination token account owner
@@ -131,13 +222,18 @@ impl UsageTracker {
                     token_program.unpack_token_account(&destination_account.data)?;
 
                 // Check if this is a payment to Kora
-                if token_account.owner() == payment_destination {
-                    // Verify the owner signed this transaction. Without this check, an attacker
-                    // could name an arbitrary victim as the payment owner in unsigned instruction
-                    // data, exhausting the victim's usage quota without their involvement.
-                    if signers.contains(owner) {
-                        return Ok(Some(*owner));
-                    }
+                if token_account.owner() == payment_destination
+                    && Self::owner_signed_or_authorized_by_multisig(
+                        owner,
+                        multisig_signers,
+                        *is_2022,
+                        &verified_signers,
+                        config,
+                        rpc_client,
+                    )
+                    .await?
+                {
+                    return Ok(Some(*owner));
                 }
             }
         }
@@ -410,11 +506,14 @@ mod tests {
     use super::*;
     use crate::{
         tests::{
-            config_mock::ConfigMockBuilder, rpc_mock::RpcMockBuilder,
-            transaction_mock::create_mock_resolved_transaction,
+            account_mock::create_mock_token_account, config_mock::ConfigMockBuilder,
+            rpc_mock::RpcMockBuilder, transaction_mock::create_mock_resolved_transaction,
         },
+        transaction::TransactionUtil,
         usage_limit::{InMemoryUsageStore, UsageLimitConfig, UsageLimitRuleConfig},
     };
+    use solana_message::{Message, VersionedMessage};
+    use solana_sdk::{account::Account, signature::Keypair, signer::Signer};
     use std::sync::Arc;
 
     fn create_test_tracker(max_transactions: u64) -> UsageTracker {
@@ -732,94 +831,216 @@ mod tests {
             .contains("Usage limiter unavailable and fallback disabled"));
     }
 
+    fn create_mock_spl_multisig_account(
+        required_signers: u8,
+        signer_pubkeys: &[Pubkey],
+    ) -> Account {
+        let mut multisig = spl_token_interface::state::Multisig {
+            m: required_signers,
+            n: signer_pubkeys.len() as u8,
+            is_initialized: true,
+            signers: [Pubkey::default(); spl_token_interface::instruction::MAX_SIGNERS],
+        };
+
+        for (slot, signer) in multisig.signers.iter_mut().zip(signer_pubkeys.iter().copied()) {
+            *slot = signer;
+        }
+
+        let mut data = vec![0u8; spl_token_interface::state::Multisig::LEN];
+        spl_token_interface::state::Multisig::pack(multisig, &mut data).unwrap();
+
+        Account {
+            lamports: 1,
+            data,
+            owner: spl_token_interface::id(),
+            executable: false,
+            rent_epoch: 0,
+        }
+    }
+
     fn make_spl_transfer_transaction(
-        owner: Pubkey,
-        owner_is_signer: bool,
+        authority: &Pubkey,
+        instruction_signers: &[&Pubkey],
+        signing_keypairs: &[&Keypair],
         destination_ata: Pubkey,
-        fee_payer: Pubkey,
+        fee_payer: &Keypair,
     ) -> VersionedTransactionResolved {
-        use solana_message::Message;
-        use solana_sdk::{
-            instruction::{AccountMeta, Instruction},
-            transaction::{Transaction, VersionedTransaction},
-        };
+        let ix = spl_token_interface::instruction::transfer(
+            &spl_token_interface::id(),
+            &Pubkey::new_unique(),
+            &destination_ata,
+            authority,
+            instruction_signers,
+            1_000_000,
+        )
+        .unwrap();
 
-        let ix = Instruction {
-            program_id: spl_token_interface::ID,
-            accounts: vec![
-                AccountMeta::new(Pubkey::new_unique(), false),
-                AccountMeta::new(destination_ata, false),
-                AccountMeta::new_readonly(owner, owner_is_signer),
-            ],
-            data: spl_token_interface::instruction::TokenInstruction::Transfer {
-                amount: 1_000_000,
-            }
-            .pack(),
-        };
+        let message = VersionedMessage::Legacy(Message::new(&[ix], Some(&fee_payer.pubkey())));
+        let mut tx = TransactionUtil::new_unsigned_versioned_transaction(message);
+        let message_bytes = tx.message.serialize();
 
-        let message = Message::new(&[ix], Some(&fee_payer));
-        let tx = VersionedTransaction::from(Transaction::new_unsigned(message));
+        for keypair in signing_keypairs {
+            let signer_index = tx
+                .message
+                .static_account_keys()
+                .iter()
+                .position(|key| key == &keypair.pubkey())
+                .unwrap();
+            tx.signatures[signer_index] = keypair.sign_message(&message_bytes);
+        }
+
         VersionedTransactionResolved::from_kora_built_transaction(&tx).unwrap()
     }
 
     #[tokio::test]
     async fn test_extract_user_unsigned_owner_returns_none() {
-        // Attack scenario: attacker names a victim as payment owner in instruction data
-        // but the victim did NOT sign the transaction. The fix must return None so that
-        // the victim's quota is not consumed.
         let store = Arc::new(InMemoryUsageStore::new());
         let tracker = UsageTracker::new(true, store, vec![], HashSet::new(), false);
 
-        let fee_payer = Pubkey::new_unique();
-        let victim_owner = Pubkey::new_unique();
+        let fee_payer = Keypair::new();
+        let victim_owner = Keypair::new();
         let destination_ata = Pubkey::new_unique();
         let mint = Pubkey::new_unique();
-
-        // Build token account where the ATA is owned by the fee payer (= payment destination
-        // when no explicit payment_address is configured).
-        let token_account =
-            crate::tests::account_mock::create_mock_token_account(&fee_payer, &mint);
-        let rpc_client = Arc::new(RpcMockBuilder::new().with_account_info(&token_account).build());
-
+        let destination_account = create_mock_token_account(&fee_payer.pubkey(), &mint);
+        let rpc_client = RpcMockBuilder::new().with_account_info(&destination_account).build();
         let config = ConfigMockBuilder::new().build();
 
-        // victim_owner is NOT a signer — attack scenario
-        let mut tx = make_spl_transfer_transaction(victim_owner, false, destination_ata, fee_payer);
+        let mut tx = make_spl_transfer_transaction(
+            &victim_owner.pubkey(),
+            &[],
+            &[],
+            destination_ata,
+            &fee_payer,
+        );
 
         let result = tracker
-            .extract_user_from_payment_instruction(&mut tx, &config, &fee_payer, &rpc_client)
+            .extract_user_from_payment_instruction(
+                &mut tx,
+                &config,
+                &fee_payer.pubkey(),
+                &rpc_client,
+            )
             .await
             .unwrap();
 
-        assert_eq!(result, None, "Unsigned owner must not be attributed quota");
+        assert_eq!(result, None);
     }
 
     #[tokio::test]
     async fn test_extract_user_signed_owner_returns_owner() {
-        // Legitimate scenario: the payment owner actually signed the transaction.
-        // The function must return Some(owner) so quota can be tracked correctly.
         let store = Arc::new(InMemoryUsageStore::new());
         let tracker = UsageTracker::new(true, store, vec![], HashSet::new(), false);
 
-        let fee_payer = Pubkey::new_unique();
-        let real_owner = Pubkey::new_unique();
+        let fee_payer = Keypair::new();
+        let owner = Keypair::new();
         let destination_ata = Pubkey::new_unique();
         let mint = Pubkey::new_unique();
-
-        let token_account =
-            crate::tests::account_mock::create_mock_token_account(&fee_payer, &mint);
-        let rpc_client = Arc::new(RpcMockBuilder::new().with_account_info(&token_account).build());
-
+        let destination_account = create_mock_token_account(&fee_payer.pubkey(), &mint);
+        let rpc_client = RpcMockBuilder::new().with_account_info(&destination_account).build();
         let config = ConfigMockBuilder::new().build();
 
-        // real_owner IS a signer — legitimate payment
-        let mut tx = make_spl_transfer_transaction(real_owner, true, destination_ata, fee_payer);
+        let mut tx = make_spl_transfer_transaction(
+            &owner.pubkey(),
+            &[],
+            &[&owner],
+            destination_ata,
+            &fee_payer,
+        );
 
         let result = tracker
-            .extract_user_from_payment_instruction(&mut tx, &config, &fee_payer, &rpc_client)
+            .extract_user_from_payment_instruction(
+                &mut tx,
+                &config,
+                &fee_payer.pubkey(),
+                &rpc_client,
+            )
             .await
             .unwrap();
 
-        assert_eq!(result, Some(real_owner), "Signed owner must be attributed quota");
+        assert_eq!(result, Some(owner.pubkey()));
+    }
+
+    #[tokio::test]
+    async fn test_extract_user_multisig_owner_returns_owner_when_threshold_is_met() {
+        let store = Arc::new(InMemoryUsageStore::new());
+        let tracker = UsageTracker::new(true, store, vec![], HashSet::new(), false);
+
+        let fee_payer = Keypair::new();
+        let signer_one = Keypair::new();
+        let signer_two = Keypair::new();
+        let signer_three = Keypair::new();
+        let multisig_owner = Pubkey::new_unique();
+        let destination_ata = Pubkey::new_unique();
+        let mint = Pubkey::new_unique();
+        let destination_account = create_mock_token_account(&fee_payer.pubkey(), &mint);
+        let multisig_account = create_mock_spl_multisig_account(
+            2,
+            &[signer_one.pubkey(), signer_two.pubkey(), signer_three.pubkey()],
+        );
+        let rpc_client = RpcMockBuilder::new()
+            .build_with_sequential_accounts(vec![&destination_account, &multisig_account]);
+        let config = ConfigMockBuilder::new().build();
+
+        let mut tx = make_spl_transfer_transaction(
+            &multisig_owner,
+            &[&signer_one.pubkey(), &signer_two.pubkey()],
+            &[&signer_one, &signer_two],
+            destination_ata,
+            &fee_payer,
+        );
+
+        let result = tracker
+            .extract_user_from_payment_instruction(
+                &mut tx,
+                &config,
+                &fee_payer.pubkey(),
+                &rpc_client,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(result, Some(multisig_owner));
+    }
+
+    #[tokio::test]
+    async fn test_extract_user_multisig_owner_returns_none_when_threshold_is_not_met() {
+        let store = Arc::new(InMemoryUsageStore::new());
+        let tracker = UsageTracker::new(true, store, vec![], HashSet::new(), false);
+
+        let fee_payer = Keypair::new();
+        let signer_one = Keypair::new();
+        let signer_two = Keypair::new();
+        let signer_three = Keypair::new();
+        let multisig_owner = Pubkey::new_unique();
+        let destination_ata = Pubkey::new_unique();
+        let mint = Pubkey::new_unique();
+        let destination_account = create_mock_token_account(&fee_payer.pubkey(), &mint);
+        let multisig_account = create_mock_spl_multisig_account(
+            2,
+            &[signer_one.pubkey(), signer_two.pubkey(), signer_three.pubkey()],
+        );
+        let rpc_client = RpcMockBuilder::new()
+            .build_with_sequential_accounts(vec![&destination_account, &multisig_account]);
+        let config = ConfigMockBuilder::new().build();
+
+        let mut tx = make_spl_transfer_transaction(
+            &multisig_owner,
+            &[&signer_one.pubkey(), &signer_two.pubkey()],
+            &[&signer_one],
+            destination_ata,
+            &fee_payer,
+        );
+
+        let result = tracker
+            .extract_user_from_payment_instruction(
+                &mut tx,
+                &config,
+                &fee_payer.pubkey(),
+                &rpc_client,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(result, None);
     }
 }


### PR DESCRIPTION
## Summary

- **Finding:** KORA-19 — `extract_user_from_payment_instruction` attributed usage quota to the `owner` field from SPL instruction data without verifying the owner actually signed the transaction
- An attacker could forge a payment instruction naming an arbitrary victim as the token transfer owner to exhaust the victim's quota with no involvement from the victim
- Fix: collect the message signer list before parsing instructions; only return `Some(owner)` when `owner` appears in the first `num_required_signatures` accounts. If the owner did not sign, `None` is returned and the caller rejects with "no payment instruction found"

## Test plan

- [x] `test_extract_user_unsigned_owner_returns_none`: owner NOT in signers list → `None` (attack scenario blocked)
- [x] `test_extract_user_signed_owner_returns_owner`: owner IS a signer → `Some(owner)` (legitimate payment accepted)
- [x] All 9 existing usage_tracker tests pass
- [x] `just fmt` passes
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/solana-foundation/kora/pull/440" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->





## 📊 Unit Test Coverage
![Coverage](https://img.shields.io/badge/coverage-85.9%25-green)

**Unit Test Coverage: 85.9%**

[View Detailed Coverage Report](https://github.com/solana-foundation/kora/actions/runs/24733033210)