### PR TITLE
fix(signer): separate probe reservation from selection

### DIFF
--- a/crates/lib/src/rpc_server/method/estimate_bundle_fee.rs
+++ b/crates/lib/src/rpc_server/method/estimate_bundle_fee.rs
@@ -3,7 +3,7 @@ use crate::{
     error::KoraError,
     fee::fee::FeeConfigUtil,
     rpc_server::middleware_utils::default_sig_verify,
-    state::get_request_signer_with_signer_key,
+    state::select_request_signer_with_signer_key,
     validator::bundle_validator::BundleValidator,
 };
 use serde::{Deserialize, Serialize};
@@ -69,7 +69,7 @@ pub async fn estimate_bundle_fee(
     let (transactions_to_process, _index_to_position) =
         BundleProcessor::extract_transactions_to_process(&transactions, sign_only_indices.clone())?;
 
-    let signer = get_request_signer_with_signer_key(signer_key.as_deref())?;
+    let signer = select_request_signer_with_signer_key(signer_key.as_deref())?;
     let fee_payer = signer.pubkey();
     let payment_destination = config.kora.get_payment_address(&fee_payer)?;
 

--- a/crates/lib/src/rpc_server/method/estimate_transaction_fee.rs
+++ b/crates/lib/src/rpc_server/method/estimate_transaction_fee.rs
@@ -6,7 +6,7 @@ use crate::{
     error::KoraError,
     fee::fee::FeeConfigUtil,
     rpc_server::middleware_utils::default_sig_verify,
-    state::get_request_signer_with_signer_key,
+    state::select_request_signer_with_signer_key,
     token::token::TransferHookValidationFlow,
     transaction::{TransactionUtil, VersionedTransactionResolved},
 };
@@ -59,7 +59,7 @@ pub async fn estimate_transaction_fee(
 ) -> Result<EstimateTransactionFeeResponse, KoraError> {
     let transaction = TransactionUtil::decode_b64_transaction(&request.transaction)?;
 
-    let signer = get_request_signer_with_signer_key(request.signer_key.as_deref())?;
+    let signer = select_request_signer_with_signer_key(request.signer_key.as_deref())?;
     let config = &get_config()?;
     let payment_destination = config.kora.get_payment_address(&signer.pubkey())?;
 

--- a/crates/lib/src/rpc_server/method/get_payer_signer.rs
+++ b/crates/lib/src/rpc_server/method/get_payer_signer.rs
@@ -1,6 +1,6 @@
 use crate::{
     error::KoraError,
-    state::{get_config, get_request_signer_with_signer_key},
+    state::{get_config, select_request_signer_with_signer_key},
 };
 use serde::{Deserialize, Serialize};
 use solana_keychain::SolanaSigner;
@@ -17,7 +17,7 @@ pub struct GetPayerSignerResponse {
 pub async fn get_payer_signer() -> Result<GetPayerSignerResponse, KoraError> {
     let config = get_config()?;
 
-    let signer = get_request_signer_with_signer_key(None)?;
+    let signer = select_request_signer_with_signer_key(None)?;
     let signer_pubkey = signer.pubkey();
     // Get the payment destination address (falls back to signer if no payment address is configured)
     let payment_destination = config.kora.get_payment_address(&signer_pubkey)?;

--- a/crates/lib/src/rpc_server/method/sign_and_send_bundle.rs
+++ b/crates/lib/src/rpc_server/method/sign_and_send_bundle.rs
@@ -13,10 +13,10 @@ use std::sync::Arc;
 use utoipa::ToSchema;
 
 #[cfg(not(test))]
-use crate::state::{get_config, get_request_signer_with_signer_key};
+use crate::state::{get_config, select_request_signer_with_signer_key};
 
 #[cfg(test)]
-use crate::state::get_request_signer_with_signer_key;
+use crate::state::select_request_signer_with_signer_key;
 #[cfg(test)]
 use crate::tests::config_mock::mock_state::get_config;
 
@@ -72,7 +72,7 @@ pub async fn sign_and_send_bundle(
     let (transactions_to_process, index_to_position) =
         BundleProcessor::extract_transactions_to_process(&transactions, sign_only_indices.clone())?;
 
-    let signer = get_request_signer_with_signer_key(signer_key.as_deref())?;
+    let signer = select_request_signer_with_signer_key(signer_key.as_deref())?;
     let fee_payer = signer.pubkey();
     let payment_destination = config.kora.get_payment_address(&fee_payer)?;
 

--- a/crates/lib/src/rpc_server/method/sign_and_send_transaction.rs
+++ b/crates/lib/src/rpc_server/method/sign_and_send_transaction.rs
@@ -11,10 +11,10 @@ use std::sync::Arc;
 use utoipa::ToSchema;
 
 #[cfg(not(test))]
-use crate::state::{get_config, get_request_signer_with_signer_key};
+use crate::state::{get_config, select_request_signer_with_signer_key};
 
 #[cfg(test)]
-use crate::state::get_request_signer_with_signer_key;
+use crate::state::select_request_signer_with_signer_key;
 #[cfg(test)]
 use crate::tests::config_mock::mock_state::get_config;
 
@@ -49,7 +49,7 @@ pub async fn sign_and_send_transaction(
 
     let config = &get_config()?;
 
-    let signer = get_request_signer_with_signer_key(request.signer_key.as_deref())?;
+    let signer = select_request_signer_with_signer_key(request.signer_key.as_deref())?;
     let fee_payer = signer.pubkey();
 
     let sig_verify = request.sig_verify || config.kora.force_sig_verify;

--- a/crates/lib/src/rpc_server/method/sign_bundle.rs
+++ b/crates/lib/src/rpc_server/method/sign_bundle.rs
@@ -13,10 +13,10 @@ use std::sync::Arc;
 use utoipa::ToSchema;
 
 #[cfg(not(test))]
-use crate::state::{get_config, get_request_signer_with_signer_key};
+use crate::state::{get_config, select_request_signer_with_signer_key};
 
 #[cfg(test)]
-use crate::state::get_request_signer_with_signer_key;
+use crate::state::select_request_signer_with_signer_key;
 #[cfg(test)]
 use crate::tests::config_mock::mock_state::get_config;
 
@@ -65,7 +65,7 @@ pub async fn sign_bundle(
     let (transactions_to_process, index_to_position) =
         BundleProcessor::extract_transactions_to_process(&transactions, sign_only_indices.clone())?;
 
-    let signer = get_request_signer_with_signer_key(signer_key.as_deref())?;
+    let signer = select_request_signer_with_signer_key(signer_key.as_deref())?;
     let fee_payer = signer.pubkey();
     let payment_destination = config.kora.get_payment_address(&fee_payer)?;
 

--- a/crates/lib/src/rpc_server/method/sign_transaction.rs
+++ b/crates/lib/src/rpc_server/method/sign_transaction.rs
@@ -11,10 +11,10 @@ use std::sync::Arc;
 use utoipa::ToSchema;
 
 #[cfg(not(test))]
-use crate::state::{get_config, get_request_signer_with_signer_key};
+use crate::state::{get_config, select_request_signer_with_signer_key};
 
 #[cfg(test)]
-use crate::state::get_request_signer_with_signer_key;
+use crate::state::select_request_signer_with_signer_key;
 #[cfg(test)]
 use crate::tests::config_mock::mock_state::get_config;
 
@@ -56,7 +56,7 @@ pub async fn sign_transaction(
 
     let config = &get_config()?;
 
-    let signer = get_request_signer_with_signer_key(request.signer_key.as_deref())?;
+    let signer = select_request_signer_with_signer_key(request.signer_key.as_deref())?;
     let fee_payer = signer.pubkey();
 
     let sig_verify = request.sig_verify || config.kora.force_sig_verify;
@@ -92,11 +92,33 @@ pub async fn sign_transaction(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tests::{
-        common::{setup_or_get_test_signer, setup_or_get_test_usage_limiter, RpcMockBuilder},
-        config_mock::ConfigMockBuilder,
-        transaction_mock::create_mock_encoded_transaction,
+    use crate::{
+        state::{get_signer_pool, update_config, update_signer_pool},
+        tests::{
+            common::{
+                create_probe_eligible_test_pool, setup_or_get_test_signer,
+                setup_or_get_test_usage_limiter, RpcMockBuilder,
+            },
+            config_mock::ConfigMockBuilder,
+            transaction_mock::create_mock_encoded_transaction,
+        },
+        transaction::TransactionUtil,
     };
+    use serial_test::serial;
+    use solana_compute_budget_interface::ComputeBudgetInstruction;
+    use solana_message::{Message, VersionedMessage};
+    use solana_sdk::pubkey::Pubkey;
+    use std::str::FromStr;
+
+    fn create_compute_budget_only_encoded_transaction() -> String {
+        let message = VersionedMessage::Legacy(Message::new(
+            &[ComputeBudgetInstruction::set_compute_unit_limit(200_000)],
+            Some(&Pubkey::new_unique()),
+        ));
+        let transaction = TransactionUtil::new_unsigned_versioned_transaction(message);
+
+        TransactionUtil::encode_versioned_transaction(&transaction).unwrap()
+    }
 
     #[tokio::test]
     async fn test_sign_transaction_decode_error() {
@@ -140,5 +162,36 @@ mod tests {
         assert!(result.is_err(), "Should fail with invalid signer key");
         let error = result.unwrap_err();
         assert!(matches!(error, KoraError::ValidationError(_)), "Should return ValidationError");
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_sign_transaction_pre_sign_validation_error_does_not_pin_probe_lock() {
+        let _config_guard = ConfigMockBuilder::new().build_and_setup();
+        update_config(ConfigMockBuilder::new().build()).unwrap();
+        let (pool, target_pubkey) = create_probe_eligible_test_pool();
+        update_signer_pool(pool).unwrap();
+
+        let _ = setup_or_get_test_usage_limiter().await;
+
+        let rpc_client = Arc::new(RpcMockBuilder::new().build());
+        let request = SignTransactionRequest {
+            transaction: create_compute_budget_only_encoded_transaction(),
+            signer_key: Some(target_pubkey.clone()),
+            sig_verify: true,
+            user_id: None,
+        };
+
+        let result = sign_transaction(&rpc_client, request).await;
+        assert!(matches!(
+            result,
+            Err(KoraError::InvalidTransaction(message))
+                if message.contains("only ComputeBudget instructions")
+        ));
+
+        let target_pubkey = Pubkey::from_str(&target_pubkey).unwrap();
+        let pool = get_signer_pool().unwrap();
+        assert!(!pool.probe_in_flight(&target_pubkey).unwrap());
+        assert!(pool.get_signer_by_pubkey(&target_pubkey.to_string()).is_ok());
     }
 }

--- a/crates/lib/src/rpc_server/method/transfer_transaction.rs
+++ b/crates/lib/src/rpc_server/method/transfer_transaction.rs
@@ -9,7 +9,7 @@ use utoipa::ToSchema;
 
 use crate::{
     constant::NATIVE_SOL,
-    state::get_request_signer_with_signer_key,
+    state::select_request_signer_with_signer_key,
     transaction::{TransactionUtil, VersionedMessageExt},
     validator::transaction_validator::TransactionValidator,
     CacheUtil, KoraError,
@@ -66,7 +66,7 @@ pub async fn transfer_transaction(
     rpc_client: &Arc<RpcClient>,
     request: TransferTransactionRequest,
 ) -> Result<TransferTransactionResponse, KoraError> {
-    let signer = get_request_signer_with_signer_key(request.signer_key.as_deref())?;
+    let signer = select_request_signer_with_signer_key(request.signer_key.as_deref())?;
     let config = &get_config()?;
     let signer_pubkey = signer.pubkey();
 
@@ -168,10 +168,16 @@ pub async fn transfer_transaction(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tests::{
-        common::{setup_or_get_test_signer, RpcMockBuilder},
-        config_mock::ConfigMockBuilder,
+    use crate::{
+        state::{get_signer_pool, update_config, update_signer_pool},
+        tests::{
+            common::{create_probe_eligible_test_pool, setup_or_get_test_signer, RpcMockBuilder},
+            config_mock::ConfigMockBuilder,
+        },
+        KoraError,
     };
+    use serial_test::serial;
+    use std::str::FromStr;
 
     #[tokio::test]
     #[allow(deprecated)]
@@ -294,5 +300,35 @@ mod tests {
         if let KoraError::RpcError(msg) = err {
             assert_eq!(msg, "Service Unavailable");
         }
+    }
+
+    #[tokio::test]
+    #[serial]
+    #[allow(deprecated)]
+    async fn test_transfer_transaction_does_not_pin_recovery_probe_lock() {
+        let _config_guard = ConfigMockBuilder::new().build_and_setup();
+        update_config(ConfigMockBuilder::new().build()).unwrap();
+        let (pool, target_pubkey) = create_probe_eligible_test_pool();
+        update_signer_pool(pool).unwrap();
+
+        let rpc_client = Arc::new(RpcMockBuilder::new().build());
+        let request = TransferTransactionRequest {
+            amount: 1,
+            token: crate::constant::NATIVE_SOL.to_string(),
+            source: "invalid".to_string(),
+            destination: Pubkey::new_unique().to_string(),
+            signer_key: Some(target_pubkey.clone()),
+        };
+
+        let result = transfer_transaction(&rpc_client, request).await;
+        assert!(matches!(
+            result,
+            Err(KoraError::ValidationError(message)) if message.contains("Invalid source address")
+        ));
+
+        let target_pubkey = Pubkey::from_str(&target_pubkey).unwrap();
+        let pool = get_signer_pool().unwrap();
+        assert!(!pool.probe_in_flight(&target_pubkey).unwrap());
+        assert!(pool.get_signer_by_pubkey(&target_pubkey.to_string()).is_ok());
     }
 }

--- a/crates/lib/src/signer/bundle_signer.rs
+++ b/crates/lib/src/signer/bundle_signer.rs
@@ -1,6 +1,7 @@
 use crate::{
     config::Config,
-    sanitize_error, state,
+    sanitize_error,
+    state::{get_signer_pool, reserve_request_signer_by_pubkey},
     transaction::{sign_with_retry, VersionedTransactionOps, VersionedTransactionResolved},
     KoraError,
 };
@@ -13,7 +14,7 @@ pub struct BundleSigner {}
 impl BundleSigner {
     pub async fn sign_transaction_for_bundle(
         resolved: &mut VersionedTransactionResolved,
-        signer: &Arc<solana_keychain::Signer>,
+        selected_signer: &Arc<solana_keychain::Signer>,
         fee_payer: &Pubkey,
         blockhash: &Option<solana_sdk::hash::Hash>,
         config: &Config,
@@ -27,6 +28,7 @@ impl BundleSigner {
         let message_bytes = resolved.transaction.message.serialize();
         let sign_timeout = Duration::from_secs(config.kora.sign_timeout_seconds);
         let max_retries = config.kora.sign_max_retries;
+        let signer = reserve_request_signer_by_pubkey(&selected_signer.pubkey())?;
         let signature = match sign_with_retry(
             sign_timeout,
             max_retries,
@@ -42,8 +44,8 @@ impl BundleSigner {
         .await
         {
             Ok(sig) => {
-                match state::get_signer_pool() {
-                    Ok(pool) => pool.record_signing_success(signer),
+                match get_signer_pool() {
+                    Ok(pool) => pool.record_signing_success(&signer),
                     Err(e) => log::warn!(
                         "Could not record bundle signing success to pool: {}",
                         sanitize_error!(e)
@@ -52,8 +54,8 @@ impl BundleSigner {
                 sig
             }
             Err(err) => {
-                match state::get_signer_pool() {
-                    Ok(pool) => pool.record_signing_failure(signer),
+                match get_signer_pool() {
+                    Ok(pool) => pool.record_signing_failure(&signer),
                     Err(pool_err) => log::error!(
                         "Bundle signing failed AND pool health tracking unavailable: {}; \
                          signer failure will not be recorded, automatic failover is disabled",
@@ -83,13 +85,36 @@ impl BundleSigner {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::tests::config_mock::ConfigMockBuilder;
+    use crate::{
+        signer::{pool::SignerWithMetadata, SignerPool},
+        state::{update_config, update_signer_pool},
+        tests::config_mock::ConfigMockBuilder,
+    };
+    use serial_test::serial;
     use solana_keychain::Signer;
     use solana_message::Message;
     use solana_sdk::{
         hash::Hash, signature::Keypair, signer::Signer as SdkSigner, transaction::Transaction,
     };
     use solana_system_interface::instruction::transfer;
+
+    fn setup_bundle_signer_state(
+        fee_payer_keypair: &Keypair,
+        config: &Config,
+    ) -> Arc<solana_keychain::Signer> {
+        let external_signer = Signer::from_memory(&fee_payer_keypair.to_base58_string()).unwrap();
+        let signer = Arc::new(external_signer);
+        let pool = SignerPool::new(vec![SignerWithMetadata::new(
+            "bundle_test_signer".to_string(),
+            Arc::clone(&signer),
+            1,
+        )]);
+
+        update_config(config.clone()).unwrap();
+        update_signer_pool(pool).unwrap();
+
+        signer
+    }
 
     fn create_test_resolved_with_fee_payer(fee_payer: &Keypair) -> VersionedTransactionResolved {
         let instruction = transfer(&fee_payer.pubkey(), &Pubkey::new_unique(), 1000);
@@ -113,15 +138,14 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn test_sign_transaction_for_bundle_success() {
         let fee_payer_keypair = Keypair::new();
         let fee_payer = fee_payer_keypair.pubkey();
 
-        let external_signer = Signer::from_memory(&fee_payer_keypair.to_base58_string()).unwrap();
-        let signer = Arc::new(external_signer);
-
         let blockhash = Some(Hash::new_unique());
         let config = ConfigMockBuilder::new().build();
+        let signer = setup_bundle_signer_state(&fee_payer_keypair, &config);
 
         let mut resolved = create_test_resolved_with_fee_payer(&fee_payer_keypair);
 
@@ -139,15 +163,14 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn test_sign_transaction_for_bundle_invalid_fee_payer() {
         let fee_payer_keypair = Keypair::new();
         let wrong_fee_payer = Pubkey::new_unique();
 
-        let external_signer = Signer::from_memory(&fee_payer_keypair.to_base58_string()).unwrap();
-        let signer = Arc::new(external_signer);
-
         let blockhash = Some(Hash::new_unique());
         let config = ConfigMockBuilder::new().build();
+        let signer = setup_bundle_signer_state(&fee_payer_keypair, &config);
 
         let mut resolved = create_test_resolved_with_fee_payer(&fee_payer_keypair);
 
@@ -165,15 +188,14 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn test_sign_transaction_for_bundle_rejects_unsigned_fee_payer_occurrence() {
         let fee_payer_keypair = Keypair::new();
         let fee_payer = fee_payer_keypair.pubkey();
 
-        let external_signer = Signer::from_memory(&fee_payer_keypair.to_base58_string()).unwrap();
-        let signer = Arc::new(external_signer);
-
         let blockhash = Some(Hash::new_unique());
         let config = ConfigMockBuilder::new().build();
+        let signer = setup_bundle_signer_state(&fee_payer_keypair, &config);
 
         let mut resolved = create_test_resolved_with_unsigned_fee_payer_occurrence(&fee_payer);
         let result = BundleSigner::sign_transaction_for_bundle(
@@ -190,15 +212,14 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn test_sign_transaction_for_bundle_signature_position() {
         let fee_payer_keypair = Keypair::new();
         let fee_payer = fee_payer_keypair.pubkey();
 
-        let external_signer = Signer::from_memory(&fee_payer_keypair.to_base58_string()).unwrap();
-        let signer = Arc::new(external_signer);
-
         let blockhash = Some(Hash::new_unique());
         let config = ConfigMockBuilder::new().build();
+        let signer = setup_bundle_signer_state(&fee_payer_keypair, &config);
 
         let mut resolved = create_test_resolved_with_fee_payer(&fee_payer_keypair);
 
@@ -220,15 +241,14 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial]
     async fn test_sign_transaction_for_bundle_verifies_signature() {
         let fee_payer_keypair = Keypair::new();
         let fee_payer = fee_payer_keypair.pubkey();
 
-        let external_signer = Signer::from_memory(&fee_payer_keypair.to_base58_string()).unwrap();
-        let signer = Arc::new(external_signer);
-
         let blockhash = Some(Hash::new_unique());
         let config = ConfigMockBuilder::new().build();
+        let signer = setup_bundle_signer_state(&fee_payer_keypair, &config);
 
         let mut resolved = create_test_resolved_with_fee_payer(&fee_payer_keypair);
 

--- a/crates/lib/src/signer/pool.rs
+++ b/crates/lib/src/signer/pool.rs
@@ -156,6 +156,29 @@ impl SignerWithMetadata {
         }
     }
 
+    fn is_probe_lock_stale(&self, health: &HealthState, probe_lease: Duration) -> bool {
+        match health.probe_started_at {
+            Some(started_at) => started_at.elapsed() >= probe_lease,
+            None => true,
+        }
+    }
+
+    fn is_probe_eligible_without_lock(&self, health: &HealthState, probe_lease: Duration) -> bool {
+        if health.is_healthy {
+            return true;
+        }
+
+        let Some(last_failed) = health.last_failed_at else {
+            return false;
+        };
+
+        if last_failed.elapsed().as_secs() < Self::RECOVERY_PROBE_SECS {
+            return false;
+        }
+
+        !health.probe_in_flight || self.is_probe_lock_stale(health, probe_lease)
+    }
+
     fn is_probe_eligible_with_lock(&self, health: &mut HealthState, probe_lease: Duration) -> bool {
         if health.is_healthy {
             return true;
@@ -174,8 +197,8 @@ impl SignerWithMetadata {
     }
 
     fn is_eligible_for_selection(&self, probe_lease: Duration) -> bool {
-        let mut health = self.health.lock();
-        self.is_probe_eligible_with_lock(&mut health, probe_lease)
+        let health = self.health.lock();
+        self.is_probe_eligible_without_lock(&health, probe_lease)
     }
 
     fn try_acquire_probe_lock_if_needed(&self, probe_lease: Duration) -> bool {
@@ -324,8 +347,8 @@ impl SignerPool {
     }
 
     /// Filters the active signers down to healthy signers plus unhealthy signers whose
-    /// recovery probe cooldown has elapsed and no probe lock is currently held.
-    fn healthy_signers(&self) -> Result<Vec<&SignerWithMetadata>, KoraError> {
+    /// recovery probe cooldown has elapsed and whose probe lock is not actively in-flight.
+    fn eligible_signers(&self) -> Result<Vec<&SignerWithMetadata>, KoraError> {
         let probe_lease = self.probe_lease();
         let healthy: Vec<_> =
             self.signers.iter().filter(|s| s.is_eligible_for_selection(probe_lease)).collect();
@@ -344,6 +367,23 @@ impl SignerPool {
         Ok(healthy)
     }
 
+    /// Select the next eligible signer without mutating recovery probe state.
+    pub fn select_next_signer(&self) -> Result<Arc<Signer>, KoraError> {
+        if self.signers.is_empty() {
+            return Err(KoraError::InternalServerError("Signer pool is empty".to_string()));
+        }
+
+        let eligible = self.eligible_signers()?;
+        let signer_meta = match self.strategy {
+            SelectionStrategy::RoundRobin => self.round_robin_select_from(&eligible),
+            SelectionStrategy::Random => self.random_select_from(&eligible),
+            SelectionStrategy::Weighted => self.weighted_select_from(&eligible),
+        }?;
+
+        signer_meta.update_last_used();
+        Ok(Arc::clone(&signer_meta.signer))
+    }
+
     /// Get the next signer according to the configured strategy
     pub fn get_next_signer(&self) -> Result<Arc<Signer>, KoraError> {
         if self.signers.is_empty() {
@@ -353,13 +393,13 @@ impl SignerPool {
         // Retry selection a small bounded number of times to avoid transient
         // races where a signer becomes ineligible between filtering and probe lock acquisition.
         for _ in 0..self.signers.len().max(1) {
-            let healthy = self.healthy_signers()?;
+            let eligible = self.eligible_signers()?;
             let probe_lease = self.probe_lease();
 
             let signer_meta = match self.strategy {
-                SelectionStrategy::RoundRobin => self.round_robin_select_from(&healthy),
-                SelectionStrategy::Random => self.random_select_from(&healthy),
-                SelectionStrategy::Weighted => self.weighted_select_from(&healthy),
+                SelectionStrategy::RoundRobin => self.round_robin_select_from(&eligible),
+                SelectionStrategy::Random => self.random_select_from(&eligible),
+                SelectionStrategy::Weighted => self.weighted_select_from(&eligible),
             }?;
 
             if !signer_meta.try_acquire_probe_lock_if_needed(probe_lease) {
@@ -434,6 +474,60 @@ impl SignerPool {
     /// Get the configured strategy
     pub fn strategy(&self) -> &SelectionStrategy {
         &self.strategy
+    }
+
+    #[cfg(test)]
+    pub(crate) fn make_signer_probe_eligible(&self, pubkey: &Pubkey) -> Result<(), KoraError> {
+        let signer_meta =
+            self.signers.iter().find(|s| s.signer.pubkey() == *pubkey).ok_or_else(|| {
+                KoraError::ValidationError(format!(
+                    "Signer with pubkey {} not found in pool",
+                    pubkey
+                ))
+            })?;
+
+        signer_meta.record_failure();
+        signer_meta.record_failure();
+        signer_meta.record_failure();
+        signer_meta.health.lock().last_failed_at = Some(
+            std::time::Instant::now()
+                - std::time::Duration::from_secs(SignerWithMetadata::RECOVERY_PROBE_SECS + 1),
+        );
+        Ok(())
+    }
+
+    #[cfg(test)]
+    pub(crate) fn probe_in_flight(&self, pubkey: &Pubkey) -> Result<bool, KoraError> {
+        let signer_meta =
+            self.signers.iter().find(|s| s.signer.pubkey() == *pubkey).ok_or_else(|| {
+                KoraError::ValidationError(format!(
+                    "Signer with pubkey {} not found in pool",
+                    pubkey
+                ))
+            })?;
+        Ok(signer_meta.health.lock().probe_in_flight)
+    }
+
+    /// Select a signer by public key without mutating recovery probe state.
+    pub fn select_signer_by_pubkey(&self, pubkey: &str) -> Result<Arc<Signer>, KoraError> {
+        let target_pubkey = Pubkey::from_str(pubkey).map_err(|_| {
+            KoraError::ValidationError(format!("Invalid signer signer key pubkey: {pubkey}"))
+        })?;
+
+        let signer_meta =
+            self.signers.iter().find(|s| s.signer.pubkey() == target_pubkey).ok_or_else(|| {
+                KoraError::ValidationError(format!("Signer with pubkey {pubkey} not found in pool"))
+            })?;
+
+        if !signer_meta.is_eligible_for_selection(self.probe_lease()) {
+            return Err(KoraError::ValidationError(format!(
+                "Pinned signer {} is unhealthy or currently unavailable for recovery probe",
+                pubkey
+            )));
+        }
+
+        signer_meta.update_last_used();
+        Ok(Arc::clone(&signer_meta.signer))
     }
 
     /// Get a signer by public key (for client consistency signer keys)
@@ -589,7 +683,7 @@ mod tests {
         pool.signers[0].record_failure();
         pool.signers[0].record_failure();
 
-        let healthy = pool.healthy_signers().unwrap();
+        let healthy = pool.eligible_signers().unwrap();
         assert_eq!(healthy.len(), 1);
         assert_eq!(healthy[0].name(), "signer_2");
     }
@@ -605,7 +699,7 @@ mod tests {
             signer.record_failure();
         }
 
-        let healthy = pool.healthy_signers();
+        let healthy = pool.eligible_signers();
         assert!(healthy.is_err());
 
         // get_next_signer should now fail-fast instead of routing to unhealthy signers.
@@ -641,7 +735,7 @@ mod tests {
         assert!(!meta.is_healthy());
 
         // Immediately checking healthy signers should exclude signer_1
-        let healthy_before_time = pool.healthy_signers().unwrap();
+        let healthy_before_time = pool.eligible_signers().unwrap();
         assert_eq!(healthy_before_time.len(), 1);
         assert_eq!(healthy_before_time[0].name(), "signer_2");
 
@@ -651,8 +745,12 @@ mod tests {
 
         // Now healthy_signers() should tentatively ALLOW signer_1 back into the rotation
         // to probe for recovery, even though is_healthy() is strictly still false.
-        let healthy_after_time = pool.healthy_signers().unwrap();
+        let healthy_after_time = pool.eligible_signers().unwrap();
         assert_eq!(healthy_after_time.len(), 2); // Both signers included!
+
+        let selected_signer = pool.select_signer_by_pubkey(&meta.signer.pubkey().to_string());
+        assert!(selected_signer.is_ok());
+        assert!(!meta.health.lock().probe_in_flight);
 
         // Verify pinned path also allows after 30s mock
         let pinned_signer = pool.get_signer_by_pubkey(&meta.signer.pubkey().to_string());
@@ -691,7 +789,7 @@ mod tests {
         pool.record_signing_failure(&signer);
 
         assert!(!pool.signers[0].is_healthy());
-        let healthy = pool.healthy_signers().unwrap();
+        let healthy = pool.eligible_signers().unwrap();
         assert_eq!(healthy.len(), 1);
         assert_eq!(healthy[0].name(), "signer_2");
     }
@@ -721,6 +819,25 @@ mod tests {
     }
 
     #[test]
+    fn test_select_signer_by_pubkey_does_not_acquire_probe_lock() {
+        let pool = create_test_pool();
+        let meta = &pool.signers[0];
+        let pubkey = meta.signer.pubkey().to_string();
+
+        meta.record_failure();
+        meta.record_failure();
+        meta.record_failure();
+        assert!(!meta.is_healthy());
+
+        meta.health.lock().last_failed_at =
+            Some(std::time::Instant::now() - std::time::Duration::from_secs(31));
+
+        assert!(pool.select_signer_by_pubkey(&pubkey).is_ok());
+        assert!(!meta.health.lock().probe_in_flight);
+        assert!(pool.get_signer_by_pubkey(&pubkey).is_ok());
+    }
+
+    #[test]
     fn test_stale_probe_lock_is_released_after_lease_timeout() {
         let pool = create_test_pool();
         let meta = &pool.signers[0];
@@ -736,7 +853,7 @@ mod tests {
             Some(std::time::Instant::now() - std::time::Duration::from_secs(31));
 
         // Acquire a probe lock, then simulate a stuck request by backdating probe_started_at.
-        let healthy = pool.healthy_signers().unwrap();
+        let healthy = pool.eligible_signers().unwrap();
         assert_eq!(healthy.len(), 2);
         assert!(pool.signers[0].try_acquire_probe_lock_if_needed(pool.probe_lease()));
         {
@@ -746,8 +863,10 @@ mod tests {
         }
 
         // Stale lock should be cleared automatically and signer should become selectable again.
-        let healthy_after_lease = pool.healthy_signers().unwrap();
+        let healthy_after_lease = pool.eligible_signers().unwrap();
         assert_eq!(healthy_after_lease.len(), 2);
+        assert!(meta.health.lock().probe_in_flight);
+        assert!(pool.get_signer_by_pubkey(&meta.signer.pubkey().to_string()).is_ok());
     }
 
     #[test]
@@ -772,7 +891,7 @@ mod tests {
             health.probe_started_at = Some(std::time::Instant::now() - Duration::from_secs(61));
         }
 
-        let healthy = pool.healthy_signers().unwrap();
+        let healthy = pool.eligible_signers().unwrap();
         assert_eq!(healthy.len(), 1);
         assert_eq!(healthy[0].name(), "signer_2");
 
@@ -782,7 +901,7 @@ mod tests {
                 Some(std::time::Instant::now() - signing_budget - Duration::from_secs(1));
         }
 
-        let healthy_after_full_budget = pool.healthy_signers().unwrap();
+        let healthy_after_full_budget = pool.eligible_signers().unwrap();
         assert_eq!(healthy_after_full_budget.len(), 2);
     }
 }

--- a/crates/lib/src/signer/pool.rs
+++ b/crates/lib/src/signer/pool.rs
@@ -163,7 +163,7 @@ impl SignerWithMetadata {
         }
     }
 
-    fn is_probe_eligible_without_lock(&self, health: &HealthState, probe_lease: Duration) -> bool {
+    fn is_recovery_probe_ready(health: &HealthState) -> bool {
         if health.is_healthy {
             return true;
         }
@@ -172,24 +172,26 @@ impl SignerWithMetadata {
             return false;
         };
 
-        if last_failed.elapsed().as_secs() < Self::RECOVERY_PROBE_SECS {
+        last_failed.elapsed().as_secs() >= Self::RECOVERY_PROBE_SECS
+    }
+
+    fn is_probe_eligible_without_lock(&self, health: &HealthState, probe_lease: Duration) -> bool {
+        if !Self::is_recovery_probe_ready(health) {
             return false;
         }
 
-        !health.probe_in_flight || self.is_probe_lock_stale(health, probe_lease)
+        health.is_healthy
+            || !health.probe_in_flight
+            || self.is_probe_lock_stale(health, probe_lease)
     }
 
     fn is_probe_eligible_with_lock(&self, health: &mut HealthState, probe_lease: Duration) -> bool {
-        if health.is_healthy {
-            return true;
+        if !Self::is_recovery_probe_ready(health) {
+            return false;
         }
 
-        let Some(last_failed) = health.last_failed_at else {
-            return false;
-        };
-
-        if last_failed.elapsed().as_secs() < Self::RECOVERY_PROBE_SECS {
-            return false;
+        if health.is_healthy {
+            return true;
         }
 
         self.release_stale_probe_lock_if_needed(health, probe_lease);
@@ -228,6 +230,12 @@ pub struct SignerPool {
     current_index: AtomicUsize,
     /// Stale probe lease derived from the signing timeout/retry budget.
     probe_lease_ms: AtomicU64,
+}
+
+#[derive(Clone, Copy)]
+enum ProbeReservationMode {
+    ReadOnly,
+    Reserve,
 }
 
 /// Information about a signer for monitoring/debugging
@@ -350,10 +358,10 @@ impl SignerPool {
     /// recovery probe cooldown has elapsed and whose probe lock is not actively in-flight.
     fn eligible_signers(&self) -> Result<Vec<&SignerWithMetadata>, KoraError> {
         let probe_lease = self.probe_lease();
-        let healthy: Vec<_> =
+        let eligible: Vec<_> =
             self.signers.iter().filter(|s| s.is_eligible_for_selection(probe_lease)).collect();
 
-        if healthy.is_empty() {
+        if eligible.is_empty() {
             log::error!(
                 "No signer is currently eligible (all unhealthy and recovery cooldown/probe lock active) across {} signers",
                 self.signers.len()
@@ -364,55 +372,101 @@ impl SignerPool {
             ));
         }
 
-        Ok(healthy)
+        Ok(eligible)
     }
 
-    /// Select the next eligible signer without mutating recovery probe state.
-    pub fn select_next_signer(&self) -> Result<Arc<Signer>, KoraError> {
+    fn select_from_eligible<'a>(
+        &self,
+        signers: &[&'a SignerWithMetadata],
+    ) -> Result<&'a SignerWithMetadata, KoraError> {
+        match self.strategy {
+            SelectionStrategy::RoundRobin => self.round_robin_select_from(signers),
+            SelectionStrategy::Random => self.random_select_from(signers),
+            SelectionStrategy::Weighted => self.weighted_select_from(signers),
+        }
+    }
+
+    fn select_next_signer_internal(
+        &self,
+        mode: ProbeReservationMode,
+    ) -> Result<Arc<Signer>, KoraError> {
         if self.signers.is_empty() {
             return Err(KoraError::InternalServerError("Signer pool is empty".to_string()));
         }
 
-        let eligible = self.eligible_signers()?;
-        let signer_meta = match self.strategy {
-            SelectionStrategy::RoundRobin => self.round_robin_select_from(&eligible),
-            SelectionStrategy::Random => self.random_select_from(&eligible),
-            SelectionStrategy::Weighted => self.weighted_select_from(&eligible),
-        }?;
+        match mode {
+            ProbeReservationMode::ReadOnly => {
+                let eligible = self.eligible_signers()?;
+                let signer_meta = self.select_from_eligible(&eligible)?;
+                signer_meta.update_last_used();
+                Ok(Arc::clone(&signer_meta.signer))
+            }
+            ProbeReservationMode::Reserve => {
+                for _ in 0..self.signers.len().max(1) {
+                    let eligible = self.eligible_signers()?;
+                    let probe_lease = self.probe_lease();
+                    let signer_meta = self.select_from_eligible(&eligible)?;
+
+                    if !signer_meta.try_acquire_probe_lock_if_needed(probe_lease) {
+                        continue;
+                    }
+
+                    signer_meta.update_last_used();
+                    return Ok(Arc::clone(&signer_meta.signer));
+                }
+
+                Err(KoraError::InternalServerError(
+                    "No healthy signers available after probe lock contention".to_string(),
+                ))
+            }
+        }
+    }
+
+    fn find_signer_by_pubkey(&self, pubkey: &str) -> Result<&SignerWithMetadata, KoraError> {
+        let target_pubkey = Pubkey::from_str(pubkey).map_err(|_| {
+            KoraError::ValidationError(format!("Invalid signer signer key pubkey: {pubkey}"))
+        })?;
+
+        self.signers.iter().find(|s| s.signer.pubkey() == target_pubkey).ok_or_else(|| {
+            KoraError::ValidationError(format!("Signer with pubkey {pubkey} not found in pool"))
+        })
+    }
+
+    fn signer_by_pubkey_internal(
+        &self,
+        pubkey: &str,
+        mode: ProbeReservationMode,
+    ) -> Result<Arc<Signer>, KoraError> {
+        let signer_meta = self.find_signer_by_pubkey(pubkey)?;
+
+        let signer_available = match mode {
+            ProbeReservationMode::ReadOnly => {
+                signer_meta.is_eligible_for_selection(self.probe_lease())
+            }
+            ProbeReservationMode::Reserve => {
+                signer_meta.try_acquire_probe_lock_if_needed(self.probe_lease())
+            }
+        };
+
+        if !signer_available {
+            return Err(KoraError::ValidationError(format!(
+                "Pinned signer {} is unhealthy or currently unavailable for recovery probe",
+                pubkey
+            )));
+        }
 
         signer_meta.update_last_used();
         Ok(Arc::clone(&signer_meta.signer))
     }
 
+    /// Select the next eligible signer without mutating recovery probe state.
+    pub fn select_next_signer(&self) -> Result<Arc<Signer>, KoraError> {
+        self.select_next_signer_internal(ProbeReservationMode::ReadOnly)
+    }
+
     /// Get the next signer according to the configured strategy
     pub fn get_next_signer(&self) -> Result<Arc<Signer>, KoraError> {
-        if self.signers.is_empty() {
-            return Err(KoraError::InternalServerError("Signer pool is empty".to_string()));
-        }
-
-        // Retry selection a small bounded number of times to avoid transient
-        // races where a signer becomes ineligible between filtering and probe lock acquisition.
-        for _ in 0..self.signers.len().max(1) {
-            let eligible = self.eligible_signers()?;
-            let probe_lease = self.probe_lease();
-
-            let signer_meta = match self.strategy {
-                SelectionStrategy::RoundRobin => self.round_robin_select_from(&eligible),
-                SelectionStrategy::Random => self.random_select_from(&eligible),
-                SelectionStrategy::Weighted => self.weighted_select_from(&eligible),
-            }?;
-
-            if !signer_meta.try_acquire_probe_lock_if_needed(probe_lease) {
-                continue;
-            }
-
-            signer_meta.update_last_used();
-            return Ok(Arc::clone(&signer_meta.signer));
-        }
-
-        Err(KoraError::InternalServerError(
-            "No healthy signers available after probe lock contention".to_string(),
-        ))
+        self.select_next_signer_internal(ProbeReservationMode::Reserve)
     }
 
     fn round_robin_select_from<'a>(
@@ -510,48 +564,12 @@ impl SignerPool {
 
     /// Select a signer by public key without mutating recovery probe state.
     pub fn select_signer_by_pubkey(&self, pubkey: &str) -> Result<Arc<Signer>, KoraError> {
-        let target_pubkey = Pubkey::from_str(pubkey).map_err(|_| {
-            KoraError::ValidationError(format!("Invalid signer signer key pubkey: {pubkey}"))
-        })?;
-
-        let signer_meta =
-            self.signers.iter().find(|s| s.signer.pubkey() == target_pubkey).ok_or_else(|| {
-                KoraError::ValidationError(format!("Signer with pubkey {pubkey} not found in pool"))
-            })?;
-
-        if !signer_meta.is_eligible_for_selection(self.probe_lease()) {
-            return Err(KoraError::ValidationError(format!(
-                "Pinned signer {} is unhealthy or currently unavailable for recovery probe",
-                pubkey
-            )));
-        }
-
-        signer_meta.update_last_used();
-        Ok(Arc::clone(&signer_meta.signer))
+        self.signer_by_pubkey_internal(pubkey, ProbeReservationMode::ReadOnly)
     }
 
     /// Get a signer by public key (for client consistency signer keys)
     pub fn get_signer_by_pubkey(&self, pubkey: &str) -> Result<Arc<Signer>, KoraError> {
-        // Try to parse as Pubkey to validate format
-        let target_pubkey = Pubkey::from_str(pubkey).map_err(|_| {
-            KoraError::ValidationError(format!("Invalid signer signer key pubkey: {pubkey}"))
-        })?;
-
-        // Find signer with matching public key
-        let signer_meta =
-            self.signers.iter().find(|s| s.signer.pubkey() == target_pubkey).ok_or_else(|| {
-                KoraError::ValidationError(format!("Signer with pubkey {pubkey} not found in pool"))
-            })?;
-
-        if !signer_meta.try_acquire_probe_lock_if_needed(self.probe_lease()) {
-            return Err(KoraError::ValidationError(format!(
-                "Pinned signer {} is unhealthy or currently unavailable for recovery probe",
-                pubkey
-            )));
-        }
-
-        signer_meta.update_last_used();
-        Ok(Arc::clone(&signer_meta.signer))
+        self.signer_by_pubkey_internal(pubkey, ProbeReservationMode::Reserve)
     }
 }
 

--- a/crates/lib/src/state.rs
+++ b/crates/lib/src/state.rs
@@ -16,14 +16,34 @@ static GLOBAL_SIGNER_POOL: Lazy<RwLock<Option<Arc<SignerPool>>>> = Lazy::new(|| 
 // Global config with zero-cost reads and hot-reload capability
 static GLOBAL_CONFIG: AtomicPtr<Config> = AtomicPtr::new(std::ptr::null_mut());
 
-/// Get a request-scoped signer with optional signer_key for consistency across related calls
+fn sync_probe_lease_from_config(pool: &SignerPool, config: &Config) {
+    let sign_timeout = Duration::from_secs(config.kora.sign_timeout_seconds);
+    pool.set_probe_lease(signing_retry_window(sign_timeout, config.kora.sign_max_retries));
+}
+
+/// Select a request-scoped signer without mutating recovery probe state.
+pub fn select_request_signer_with_signer_key(
+    signer_key: Option<&str>,
+) -> Result<Arc<solana_keychain::Signer>, KoraError> {
+    let config = get_config()?;
+    let pool = get_signer_pool()?;
+    sync_probe_lease_from_config(&pool, config);
+
+    if let Some(signer_key) = signer_key {
+        return pool.select_signer_by_pubkey(signer_key);
+    }
+
+    pool.select_next_signer()
+        .map_err(|e| KoraError::InternalServerError(format!("Failed to get signer from pool: {e}")))
+}
+
+/// Reserve a request-scoped signer, acquiring a recovery probe lock if needed.
 pub fn get_request_signer_with_signer_key(
     signer_key: Option<&str>,
 ) -> Result<Arc<solana_keychain::Signer>, KoraError> {
     let config = get_config()?;
     let pool = get_signer_pool()?;
-    let sign_timeout = Duration::from_secs(config.kora.sign_timeout_seconds);
-    pool.set_probe_lease(signing_retry_window(sign_timeout, config.kora.sign_max_retries));
+    sync_probe_lease_from_config(&pool, config);
 
     // If client provided a signer signer_key, try to use that specific signer
     if let Some(signer_key) = signer_key {
@@ -33,6 +53,12 @@ pub fn get_request_signer_with_signer_key(
     // Use configured selection strategy (defaults to round-robin if not specified)
     pool.get_next_signer()
         .map_err(|e| KoraError::InternalServerError(format!("Failed to get signer from pool: {e}")))
+}
+
+pub fn reserve_request_signer_by_pubkey(
+    signer_pubkey: &solana_sdk::pubkey::Pubkey,
+) -> Result<Arc<solana_keychain::Signer>, KoraError> {
+    get_request_signer_with_signer_key(Some(&signer_pubkey.to_string()))
 }
 
 /// Initialize the global signer pool with a SignerPool instance
@@ -126,7 +152,7 @@ mod tests {
     use solana_sdk::signature::Keypair;
 
     #[test]
-    fn test_get_request_signer_updates_probe_lease_from_config() {
+    fn test_select_request_signer_updates_probe_lease_from_config() {
         let mut config = ConfigMockBuilder::new().build();
         config.kora.sign_timeout_seconds = 15;
         config.kora.sign_max_retries = 5;
@@ -141,7 +167,7 @@ mod tests {
         )]);
         update_signer_pool(pool).unwrap();
 
-        let _ = get_request_signer_with_signer_key(None).unwrap();
+        let _ = select_request_signer_with_signer_key(None).unwrap();
 
         let pool = get_signer_pool().unwrap();
         assert_eq!(pool.probe_lease(), signing_retry_window(Duration::from_secs(15), 5));

--- a/crates/lib/src/tests/common/mod.rs
+++ b/crates/lib/src/tests/common/mod.rs
@@ -6,9 +6,8 @@ use std::sync::Arc;
 /// 1. Setup functions for test environment initialization (signer & config)
 /// 2. Centralized re-exports of commonly used mock utilities
 use crate::{
-    get_request_signer_with_signer_key,
     signer::{pool::SignerWithMetadata, SignerPool},
-    state::{get_config, update_config, update_signer_pool},
+    state::{get_config, select_request_signer_with_signer_key, update_config, update_signer_pool},
     tests::{account_mock, config_mock::ConfigMockBuilder, rpc_mock},
     usage_limit::UsageTracker,
     Config, KoraError,
@@ -26,7 +25,7 @@ use solana_keychain::{Signer, SolanaSigner};
 pub fn setup_or_get_test_signer() -> Pubkey {
     let _ = setup_or_get_test_config();
 
-    if let Ok(signer) = get_request_signer_with_signer_key(None) {
+    if let Ok(signer) = select_request_signer_with_signer_key(None) {
         return signer.pubkey();
     }
 
@@ -49,6 +48,24 @@ pub fn setup_or_get_test_signer() -> Pubkey {
     }
 
     solana_sdk::signer::Signer::pubkey(&test_keypair)
+}
+
+pub fn create_probe_eligible_test_pool() -> (SignerPool, String) {
+    let keypair_1 = Keypair::new();
+    let keypair_2 = Keypair::new();
+
+    let signer_1 = Signer::from_memory(&keypair_1.to_base58_string()).unwrap();
+    let signer_2 = Signer::from_memory(&keypair_2.to_base58_string()).unwrap();
+    let target_pubkey = signer_1.pubkey();
+
+    let pool = SignerPool::new(vec![
+        SignerWithMetadata::new("signer_1".to_string(), Arc::new(signer_1), 1),
+        SignerWithMetadata::new("signer_2".to_string(), Arc::new(signer_2), 1),
+    ]);
+
+    pool.make_signer_probe_eligible(&target_pubkey).unwrap();
+
+    (pool, target_pubkey.to_string())
 }
 
 /// Setup or retrieve test config for global state initialization

--- a/crates/lib/src/transaction/versioned_transaction.rs
+++ b/crates/lib/src/transaction/versioned_transaction.rs
@@ -22,6 +22,7 @@ use crate::{
     lighthouse::LighthouseUtil,
     plugin::{PluginExecutionContext, TransactionPluginRunner},
     sanitize_error,
+    state::{get_signer_pool, reserve_request_signer_by_pubkey},
     token::token::TransferHookValidationFlow,
     transaction::{
         instruction_util::IxUtils, ParsedALTInstructionData, ParsedALTInstructionType,
@@ -298,11 +299,11 @@ impl VersionedTransactionOps for VersionedTransactionResolved {
     async fn sign_transaction(
         &mut self,
         config: &Config,
-        signer: &std::sync::Arc<Signer>,
+        selected_signer: &std::sync::Arc<Signer>,
         rpc_client: &RpcClient,
         will_send: bool,
     ) -> Result<(VersionedTransaction, String), KoraError> {
-        let fee_payer = signer.pubkey();
+        let fee_payer = selected_signer.pubkey();
         let validator = TransactionValidator::new(config, fee_payer)?;
 
         // Validate transaction and accounts (already resolved)
@@ -384,6 +385,7 @@ impl VersionedTransactionOps for VersionedTransactionResolved {
         let message_bytes = transaction.message.serialize();
         let sign_timeout = Duration::from_secs(config.kora.sign_timeout_seconds);
         let max_retries = config.kora.sign_max_retries;
+        let signer = reserve_request_signer_by_pubkey(&fee_payer)?;
         let signature =
             match sign_with_retry(sign_timeout, max_retries, "signing", "Signing", || async {
                 signer
@@ -395,8 +397,8 @@ impl VersionedTransactionOps for VersionedTransactionResolved {
             {
                 Ok(sig) => {
                     // Report success to the pool for health tracking
-                    match crate::state::get_signer_pool() {
-                        Ok(pool) => pool.record_signing_success(signer),
+                    match get_signer_pool() {
+                        Ok(pool) => pool.record_signing_success(&signer),
                         Err(e) => log::warn!(
                             "Could not record signing success to pool: {}",
                             sanitize_error!(e)
@@ -407,8 +409,8 @@ impl VersionedTransactionOps for VersionedTransactionResolved {
                 Err(err) => {
                     // Report failure to the pool to track signer health only after all retries are exhausted.
                     // This prevents a single failing request from immediately blacklisting a signer.
-                    match crate::state::get_signer_pool() {
-                        Ok(pool) => pool.record_signing_failure(signer),
+                    match get_signer_pool() {
+                        Ok(pool) => pool.record_signing_failure(&signer),
                         Err(pool_err) => log::error!(
                             "Signing failed AND pool health tracking unavailable: {}; \
                          signer failure will not be recorded, automatic failover is disabled",


### PR DESCRIPTION
## Summary
- split signer selection into read-only and reserving paths so helper RPCs no longer acquire recovery probe locks
- move probe reservation to the actual signing boundary for transaction and bundle signing flows
- add regression coverage proving helper and pre-sign validation failures do not pin `probe_in_flight`

## Test Plan
- cargo test -p kora-lib signer::bundle_signer::tests -- --nocapture
- cargo test -p kora-lib sign_transaction_ -- --nocapture
- cargo test -p kora-lib transfer_transaction_ -- --nocapture
- cargo test -p kora-lib estimate_transaction_fee_ -- --nocapture
- cargo test -p kora-lib estimate_bundle_fee_ -- --nocapture
- cargo test -p kora-lib sign_bundle_ -- --nocapture
- cargo test -p kora-lib sign_and_send_transaction_ -- --nocapture
- cargo test -p kora-lib sign_and_send_bundle_ -- --nocapture
- cargo test -p kora-lib select_request_signer_updates_probe_lease_from_config -- --nocapture
- cargo clippy -p kora-lib --tests -- -D warnings
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/solana-foundation/kora/pull/442" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->



## 📊 Unit Test Coverage
![Coverage](https://img.shields.io/badge/coverage-86.1%25-green)

**Unit Test Coverage: 86.1%**

[View Detailed Coverage Report](https://github.com/solana-foundation/kora/actions/runs/24736833981)