### PR TITLE
fix(security): enforce strict fixed pricing when token quote floors to zero

### DIFF
--- a/crates/lib/src/transaction/versioned_transaction.rs
+++ b/crates/lib/src/transaction/versioned_transaction.rs
@@ -335,6 +335,10 @@ impl VersionedTransactionOps for VersionedTransactionResolved {
 
         let required_lamports = fee_calculation.total_fee_lamports;
 
+        // Strict fixed pricing must run even when the fixed quote floors to 0 lamports,
+        // otherwise a sub-lamport quote would skip the strictness check and sign for free.
+        TransactionValidator::validate_strict_pricing_with_fee(config, &fee_calculation)?;
+
         // Validate payment if price model is not Free
         if required_lamports > 0 {
             log::info!("Payment validation: required_lamports={}", required_lamports);
@@ -350,9 +354,6 @@ impl VersionedTransactionOps for VersionedTransactionResolved {
                 &payment_destination,
             )
             .await?;
-
-            // Validate strict pricing if enabled
-            TransactionValidator::validate_strict_pricing_with_fee(config, &fee_calculation)?;
         }
 
         // Get latest blockhash and update transaction

--- a/crates/lib/src/validator/transaction_validator.rs
+++ b/crates/lib/src/validator/transaction_validator.rs
@@ -3121,6 +3121,31 @@ mod tests {
         assert!(result.is_ok(), "Should pass when total equals fixed price");
     }
 
+    #[test]
+    #[serial]
+    fn test_strict_pricing_sub_lamport_quote_rejected() {
+        let mut config = ConfigMockBuilder::new().build();
+        config.validation.price.model = PriceModel::Fixed {
+            amount: 1,
+            token: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v".to_string(),
+            strict: true,
+        };
+        let _ = update_config(config);
+
+        // Sub-lamport configured price floors to 0 but real cost is positive (base_fee = 5000).
+        let fee_calc = TotalFeeCalculation::new(0, 5000, 0, 0, 0, 0);
+
+        let config = get_config().unwrap();
+        let result = TransactionValidator::validate_strict_pricing_with_fee(config, &fee_calc);
+
+        assert!(result.is_err(), "Strict mode must reject a zero quote with positive real cost");
+        if let Err(KoraError::ValidationError(msg)) = result {
+            assert!(msg.contains("Strict pricing violation"));
+        } else {
+            panic!("Expected ValidationError");
+        }
+    }
+
     #[tokio::test]
     #[serial]
     async fn test_durable_transaction_rejected_by_default() {


### PR DESCRIPTION
## Summary
- Move `validate_strict_pricing_with_fee()` out of the `required_lamports > 0` guard in `sign_transaction` so strict mode always enforces the fixed-price invariant.
- Previously, when a configured fixed token amount converted to `< 1` lamport (floored to `0`), strict checking was skipped entirely — Kora would sign and subsidize the transaction despite positive real fee-payer cost (base fee, signature fee, fee-payer outflow, or transfer-fee components).
- Added regression test `test_strict_pricing_sub_lamport_quote_rejected` covering the sub-lamport quote case.

## Test Plan
- [x] `cargo test -p kora-lib --lib strict_pricing` — all 6 tests pass, including the new regression
- [x] `cargo test -p kora-lib --lib transaction::versioned_transaction` — 22/22 pass
- [x] `cargo test -p kora-lib --lib fee::price` — 6/6 pass
- [x] `cargo build -p kora-lib` clean

## Notes
- The existing `validate_strict_pricing_with_fee` already early-returns for non-strict and non-Fixed models, so always calling it is safe and preserves behavior for all other price models.
- The comparison uses `TotalFeeCalculation::get_total_fee_lamports()` (sum of all real cost components), which correctly surfaces the violation when the fixed quote is `0` but real cost is positive.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/solana-foundation/kora/pull/444" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


## 📊 Unit Test Coverage
![Coverage](https://img.shields.io/badge/coverage-86.0%25-green)

**Unit Test Coverage: 86.0%**

[View Detailed Coverage Report](https://github.com/solana-foundation/kora/actions/runs/24736872882)