### PR TITLE
fix(token2022): classify transfercheckedwithfee as transfer

### DIFF
--- a/crates/lib/src/fee/fee.rs
+++ b/crates/lib/src/fee/fee.rs
@@ -770,6 +770,31 @@ mod tests {
             .expect("failed to build resolved transaction")
     }
 
+    fn create_token2022_transfer_checked_with_fee_resolved_transaction(
+        owner: &Pubkey,
+        source: &Pubkey,
+        destination: &Pubkey,
+        mint: &Pubkey,
+    ) -> crate::transaction::VersionedTransactionResolved {
+        let transfer_ix =
+            spl_token_2022_interface::extension::transfer_fee::instruction::transfer_checked_with_fee(
+                &spl_token_2022_interface::id(),
+                source,
+                mint,
+                destination,
+                owner,
+                &[],
+                1,
+                6,
+                0,
+            )
+            .unwrap();
+
+        let message = VersionedMessage::Legacy(Message::new(&[transfer_ix], Some(owner)));
+        TransactionUtil::new_unsigned_versioned_transaction_resolved(message)
+            .expect("failed to build resolved transaction")
+    }
+
     fn create_alt_close_resolved_transaction(
         fee_payer: &Pubkey,
         lookup_table_authority: &Pubkey,
@@ -789,6 +814,7 @@ mod tests {
     async fn estimate_free_fee_with_mutable_transfer_hook(
         transfer_hook_policy: TransferHookPolicy,
         transfer_hook_validation_flow: TransferHookValidationFlow,
+        use_transfer_fee_extension: bool,
     ) -> Result<TotalFeeCalculation, KoraError> {
         let mut config = ConfigMockBuilder::new().with_cache_enabled(false).build();
         config.validation.price = PriceConfig { model: PriceModel::Free };
@@ -801,12 +827,21 @@ mod tests {
         let destination = Pubkey::new_unique();
         let mint = Pubkey::new_unique();
 
-        let mut resolved_tx = create_token2022_transfer_checked_resolved_transaction(
-            &owner,
-            &source,
-            &destination,
-            &mint,
-        );
+        let mut resolved_tx = if use_transfer_fee_extension {
+            create_token2022_transfer_checked_with_fee_resolved_transaction(
+                &owner,
+                &source,
+                &destination,
+                &mint,
+            )
+        } else {
+            create_token2022_transfer_checked_resolved_transaction(
+                &owner,
+                &source,
+                &destination,
+                &mint,
+            )
+        };
 
         let mint_account = MintAccountMockBuilder::new()
             .with_decimals(6)
@@ -833,6 +868,7 @@ mod tests {
         let result = estimate_free_fee_with_mutable_transfer_hook(
             TransferHookPolicy::DenyMutableForDelayedSigning,
             TransferHookValidationFlow::DelayedSigning,
+            false,
         )
         .await;
 
@@ -847,6 +883,7 @@ mod tests {
         let result = estimate_free_fee_with_mutable_transfer_hook(
             TransferHookPolicy::DenyMutableForDelayedSigning,
             TransferHookValidationFlow::ImmediateSignAndSend,
+            false,
         )
         .await;
 
@@ -861,6 +898,7 @@ mod tests {
         let result = estimate_free_fee_with_mutable_transfer_hook(
             TransferHookPolicy::DenyAll,
             TransferHookValidationFlow::ImmediateSignAndSend,
+            false,
         )
         .await;
 
@@ -875,6 +913,7 @@ mod tests {
         let result = estimate_free_fee_with_mutable_transfer_hook(
             TransferHookPolicy::AllowAll,
             TransferHookValidationFlow::DelayedSigning,
+            false,
         )
         .await;
 
@@ -932,6 +971,21 @@ mod tests {
         assert!(result.is_ok());
         let calculation = result.unwrap();
         assert_eq!(calculation.total_fee_lamports, 0);
+    }
+
+    #[tokio::test]
+    async fn test_estimate_kora_fee_free_rejects_mutable_transfer_hook_authority_for_transfer_checked_with_fee(
+    ) {
+        let result = estimate_free_fee_with_mutable_transfer_hook(
+            TransferHookPolicy::DenyMutableForDelayedSigning,
+            TransferHookValidationFlow::DelayedSigning,
+            true,
+        )
+        .await;
+
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("Mutable transfer-hook authority found on mint account"));
     }
 
     #[test]

--- a/crates/lib/src/transaction/instruction_util.rs
+++ b/crates/lib/src/transaction/instruction_util.rs
@@ -674,7 +674,7 @@ impl IxUtils {
         );
     }
 
-    fn push_unknown_token2022_extension(
+    fn push_unhandled_token2022_extension(
         parsed_instructions: &mut HashMap<ParsedSPLInstructionType, Vec<ParsedSPLInstructionData>>,
         instruction: &Instruction,
     ) {
@@ -2363,7 +2363,7 @@ impl IxUtils {
                                     );
                                 }
                                 _ => {
-                                    Self::push_unknown_token2022_extension(
+                                    Self::push_unhandled_token2022_extension(
                                         &mut parsed_instructions,
                                         instruction,
                                     );
@@ -2785,7 +2785,7 @@ impl IxUtils {
                             ));
                         }
                         _ => {
-                            Self::push_unknown_token2022_extension(
+                            Self::push_unhandled_token2022_extension(
                                 &mut parsed_instructions,
                                 instruction,
                             );

--- a/crates/lib/src/transaction/instruction_util.rs
+++ b/crates/lib/src/transaction/instruction_util.rs
@@ -650,6 +650,43 @@ impl IxUtils {
         parsed_instructions.entry(instruction_type).or_default().push(instruction_data);
     }
 
+    fn push_parsed_token_transfer(
+        parsed_instructions: &mut HashMap<ParsedSPLInstructionType, Vec<ParsedSPLInstructionData>>,
+        instruction: &Instruction,
+        transfer_indexes: (usize, usize, usize, usize),
+        amount: u64,
+        mint: Option<Pubkey>,
+        is_2022: bool,
+    ) {
+        let (owner_index, source_index, destination_index, multisig_start_index) = transfer_indexes;
+        Self::push_parsed_spl_instruction(
+            parsed_instructions,
+            ParsedSPLInstructionType::SplTokenTransfer,
+            ParsedSPLInstructionData::SplTokenTransfer {
+                amount,
+                owner: instruction.accounts[owner_index].pubkey,
+                multisig_signers: Self::extract_multisig_signers(instruction, multisig_start_index),
+                mint,
+                source_address: instruction.accounts[source_index].pubkey,
+                destination_address: instruction.accounts[destination_index].pubkey,
+                is_2022,
+            },
+        );
+    }
+
+    fn push_unknown_token2022_extension(
+        parsed_instructions: &mut HashMap<ParsedSPLInstructionType, Vec<ParsedSPLInstructionData>>,
+        instruction: &Instruction,
+    ) {
+        Self::push_parsed_spl_instruction(
+            parsed_instructions,
+            ParsedSPLInstructionType::SplTokenUnknownExtension,
+            ParsedSPLInstructionData::SplTokenUnknownExtension {
+                accounts: instruction.accounts.iter().map(|a| a.pubkey).collect(),
+            },
+        );
+    }
+
     pub fn build_default_compiled_instruction(program_id_index: u8) -> CompiledInstruction {
         CompiledInstruction { program_id_index, accounts: vec![], data: vec![] }
     }
@@ -1945,21 +1982,19 @@ impl IxUtils {
                         spl_token_interface::instruction::TokenInstruction::Transfer { amount } => {
                             validate_number_accounts!(instruction, instruction_indexes::spl_token_transfer::REQUIRED_NUMBER_OF_ACCOUNTS);
 
-                            parsed_instructions
-                                .entry(ParsedSPLInstructionType::SplTokenTransfer)
-                                .or_default()
-                                .push(ParsedSPLInstructionData::SplTokenTransfer {
-                                    owner: instruction.accounts[instruction_indexes::spl_token_transfer::OWNER_INDEX].pubkey,
-                                    multisig_signers: Self::extract_multisig_signers(
-                                        instruction,
-                                        instruction_indexes::spl_token_transfer::REQUIRED_NUMBER_OF_ACCOUNTS,
-                                    ),
-                                    amount,
-                                    mint: None,
-                                    source_address: instruction.accounts[instruction_indexes::spl_token_transfer::SOURCE_ADDRESS_INDEX].pubkey,
-                                    destination_address: instruction.accounts[instruction_indexes::spl_token_transfer::DESTINATION_ADDRESS_INDEX].pubkey,
-                                    is_2022: false,
-                                });
+                            Self::push_parsed_token_transfer(
+                                &mut parsed_instructions,
+                                instruction,
+                                (
+                                    instruction_indexes::spl_token_transfer::OWNER_INDEX,
+                                    instruction_indexes::spl_token_transfer::SOURCE_ADDRESS_INDEX,
+                                    instruction_indexes::spl_token_transfer::DESTINATION_ADDRESS_INDEX,
+                                    instruction_indexes::spl_token_transfer::REQUIRED_NUMBER_OF_ACCOUNTS,
+                                ),
+                                amount,
+                                None,
+                                false,
+                            );
                         }
                         spl_token_interface::instruction::TokenInstruction::TransferChecked {
                             amount,
@@ -1967,21 +2002,23 @@ impl IxUtils {
                         } => {
                             validate_number_accounts!(instruction, instruction_indexes::spl_token_transfer_checked::REQUIRED_NUMBER_OF_ACCOUNTS);
 
-                            parsed_instructions
-                                .entry(ParsedSPLInstructionType::SplTokenTransfer)
-                                .or_default()
-                                .push(ParsedSPLInstructionData::SplTokenTransfer {
-                                    owner: instruction.accounts[instruction_indexes::spl_token_transfer_checked::OWNER_INDEX].pubkey,
-                                    multisig_signers: Self::extract_multisig_signers(
-                                        instruction,
-                                        instruction_indexes::spl_token_transfer_checked::REQUIRED_NUMBER_OF_ACCOUNTS,
-                                    ),
-                                    amount,
-                                    mint: Some(instruction.accounts[instruction_indexes::spl_token_transfer_checked::MINT_INDEX].pubkey),
-                                    source_address: instruction.accounts[instruction_indexes::spl_token_transfer_checked::SOURCE_ADDRESS_INDEX].pubkey,
-                                    destination_address: instruction.accounts[instruction_indexes::spl_token_transfer_checked::DESTINATION_ADDRESS_INDEX].pubkey,
-                                    is_2022: false,
-                                });
+                            Self::push_parsed_token_transfer(
+                                &mut parsed_instructions,
+                                instruction,
+                                (
+                                    instruction_indexes::spl_token_transfer_checked::OWNER_INDEX,
+                                    instruction_indexes::spl_token_transfer_checked::SOURCE_ADDRESS_INDEX,
+                                    instruction_indexes::spl_token_transfer_checked::DESTINATION_ADDRESS_INDEX,
+                                    instruction_indexes::spl_token_transfer_checked::REQUIRED_NUMBER_OF_ACCOUNTS,
+                                ),
+                                amount,
+                                Some(
+                                    instruction.accounts
+                                        [instruction_indexes::spl_token_transfer_checked::MINT_INDEX]
+                                        .pubkey,
+                                ),
+                                false,
+                            );
                         }
                         spl_token_interface::instruction::TokenInstruction::Burn { .. } => {
                             let owner = Self::parse_burn_owner_with_mint_fallback(instruction)?;
@@ -2241,21 +2278,19 @@ impl IxUtils {
                         spl_token_2022_interface::instruction::TokenInstruction::Transfer { amount } => {
                             validate_number_accounts!(instruction, instruction_indexes::spl_token_transfer::REQUIRED_NUMBER_OF_ACCOUNTS);
 
-                            parsed_instructions
-                                .entry(ParsedSPLInstructionType::SplTokenTransfer)
-                                .or_default()
-                                .push(ParsedSPLInstructionData::SplTokenTransfer {
-                                    owner: instruction.accounts[instruction_indexes::spl_token_transfer::OWNER_INDEX].pubkey,
-                                    multisig_signers: Self::extract_multisig_signers(
-                                        instruction,
-                                        instruction_indexes::spl_token_transfer::REQUIRED_NUMBER_OF_ACCOUNTS,
-                                    ),
-                                    amount,
-                                    mint: None,
-                                    source_address: instruction.accounts[instruction_indexes::spl_token_transfer::SOURCE_ADDRESS_INDEX].pubkey,
-                                    destination_address: instruction.accounts[instruction_indexes::spl_token_transfer::DESTINATION_ADDRESS_INDEX].pubkey,
-                                    is_2022: true,
-                                });
+                            Self::push_parsed_token_transfer(
+                                &mut parsed_instructions,
+                                instruction,
+                                (
+                                    instruction_indexes::spl_token_transfer::OWNER_INDEX,
+                                    instruction_indexes::spl_token_transfer::SOURCE_ADDRESS_INDEX,
+                                    instruction_indexes::spl_token_transfer::DESTINATION_ADDRESS_INDEX,
+                                    instruction_indexes::spl_token_transfer::REQUIRED_NUMBER_OF_ACCOUNTS,
+                                ),
+                                amount,
+                                None,
+                                true,
+                            );
                         }
                         spl_token_2022_interface::instruction::TokenInstruction::TransferChecked {
                             amount,
@@ -2263,21 +2298,77 @@ impl IxUtils {
                         } => {
                             validate_number_accounts!(instruction, instruction_indexes::spl_token_transfer_checked::REQUIRED_NUMBER_OF_ACCOUNTS);
 
-                            parsed_instructions
-                                .entry(ParsedSPLInstructionType::SplTokenTransfer)
-                                .or_default()
-                                .push(ParsedSPLInstructionData::SplTokenTransfer {
-                                    owner: instruction.accounts[instruction_indexes::spl_token_transfer_checked::OWNER_INDEX].pubkey,
-                                    multisig_signers: Self::extract_multisig_signers(
-                                        instruction,
-                                        instruction_indexes::spl_token_transfer_checked::REQUIRED_NUMBER_OF_ACCOUNTS,
-                                    ),
+                            Self::push_parsed_token_transfer(
+                                &mut parsed_instructions,
+                                instruction,
+                                (
+                                    instruction_indexes::spl_token_transfer_checked::OWNER_INDEX,
+                                    instruction_indexes::spl_token_transfer_checked::SOURCE_ADDRESS_INDEX,
+                                    instruction_indexes::spl_token_transfer_checked::DESTINATION_ADDRESS_INDEX,
+                                    instruction_indexes::spl_token_transfer_checked::REQUIRED_NUMBER_OF_ACCOUNTS,
+                                ),
+                                amount,
+                                Some(
+                                    instruction.accounts
+                                        [instruction_indexes::spl_token_transfer_checked::MINT_INDEX]
+                                        .pubkey,
+                                ),
+                                true,
+                            );
+                        }
+                        spl_token_2022_interface::instruction::TokenInstruction::TransferFeeExtension => {
+                            if instruction.data.len() < 2 {
+                                return Err(KoraError::InvalidTransaction(
+                                    "Failed to parse Token-2022 TransferFee instruction".to_string(),
+                                ));
+                            }
+
+                            let transfer_fee_ix =
+                                spl_token_2022_interface::extension::transfer_fee::instruction::TransferFeeInstruction::unpack(
+                                    &instruction.data[1..],
+                                )
+                                .map_err(|e| {
+                                    KoraError::InvalidTransaction(format!(
+                                        "Failed to parse Token-2022 TransferFee instruction: {}",
+                                        sanitize_error!(e)
+                                    ))
+                                })?;
+
+                            match transfer_fee_ix {
+                                spl_token_2022_interface::extension::transfer_fee::instruction::TransferFeeInstruction::TransferCheckedWithFee {
                                     amount,
-                                    mint: Some(instruction.accounts[instruction_indexes::spl_token_transfer_checked::MINT_INDEX].pubkey),
-                                    source_address: instruction.accounts[instruction_indexes::spl_token_transfer_checked::SOURCE_ADDRESS_INDEX].pubkey,
-                                    destination_address: instruction.accounts[instruction_indexes::spl_token_transfer_checked::DESTINATION_ADDRESS_INDEX].pubkey,
-                                    is_2022: true,
-                                });
+                                    ..
+                                } => {
+                                    validate_number_accounts!(
+                                        instruction,
+                                        instruction_indexes::spl_token_transfer_checked::REQUIRED_NUMBER_OF_ACCOUNTS
+                                    );
+
+                                    Self::push_parsed_token_transfer(
+                                        &mut parsed_instructions,
+                                        instruction,
+                                        (
+                                            instruction_indexes::spl_token_transfer_checked::OWNER_INDEX,
+                                            instruction_indexes::spl_token_transfer_checked::SOURCE_ADDRESS_INDEX,
+                                            instruction_indexes::spl_token_transfer_checked::DESTINATION_ADDRESS_INDEX,
+                                            instruction_indexes::spl_token_transfer_checked::REQUIRED_NUMBER_OF_ACCOUNTS,
+                                        ),
+                                        amount,
+                                        Some(
+                                            instruction.accounts
+                                                [instruction_indexes::spl_token_transfer_checked::MINT_INDEX]
+                                                .pubkey,
+                                        ),
+                                        true,
+                                    );
+                                }
+                                _ => {
+                                    Self::push_unknown_token2022_extension(
+                                        &mut parsed_instructions,
+                                        instruction,
+                                    );
+                                }
+                            }
                         }
                         spl_token_2022_interface::instruction::TokenInstruction::Burn { .. } => {
                             let owner = Self::parse_burn_owner_with_mint_fallback(instruction)?;
@@ -2694,19 +2785,9 @@ impl IxUtils {
                             ));
                         }
                         _ => {
-                            // Extension instruction with no dedicated fee-payer parser.
-                            // Record all accounts so the validator can reject if the fee
-                            // payer appears among them.
-                            Self::push_parsed_spl_instruction(
+                            Self::push_unknown_token2022_extension(
                                 &mut parsed_instructions,
-                                ParsedSPLInstructionType::SplTokenUnknownExtension,
-                                ParsedSPLInstructionData::SplTokenUnknownExtension {
-                                    accounts: instruction
-                                        .accounts
-                                        .iter()
-                                        .map(|a| a.pubkey)
-                                        .collect(),
-                                },
+                                instruction,
                             );
                         }
                     };
@@ -3777,6 +3858,73 @@ mod tests {
             decimals,
         )
         .expect("Failed to create transfer_checked instruction");
+
+        let message = VersionedMessage::Legacy(Message::new(&[instruction], Some(&owner.pubkey())));
+        let tx = VersionedTransaction::try_new(message, &[&owner]).unwrap();
+
+        let resolved_tx = VersionedTransactionResolved::from_kora_built_transaction(&tx)
+            .expect("Failed to create resolved transaction");
+
+        let parsed_instructions = IxUtils::parse_token_instructions(&resolved_tx)
+            .expect("Failed to parse token instructions");
+
+        let transfers = parsed_instructions
+            .get(&ParsedSPLInstructionType::SplTokenTransfer)
+            .expect("Expected SplTokenTransfer instructions");
+
+        assert_eq!(transfers.len(), 1);
+
+        match &transfers[0] {
+            ParsedSPLInstructionData::SplTokenTransfer {
+                amount: parsed_amount,
+                owner: parsed_owner,
+                multisig_signers,
+                mint: parsed_mint,
+                source_address: parsed_source,
+                destination_address: parsed_destination,
+                is_2022,
+            } => {
+                assert_eq!(*parsed_amount, amount);
+                assert_eq!(*parsed_owner, owner.pubkey());
+                assert!(multisig_signers.is_empty());
+                assert_eq!(*parsed_source, source_address);
+                assert_eq!(*parsed_destination, destination_address);
+                assert!(*is_2022);
+                assert_eq!(parsed_mint.unwrap(), mint);
+            }
+            _ => panic!("Expected SplTokenTransfer variant"),
+        }
+    }
+
+    #[test]
+    fn test_parse_token_2022_instructions_transfer_checked_with_fee() {
+        use crate::transaction::versioned_transaction::VersionedTransactionResolved;
+        use solana_message::{Message, VersionedMessage};
+        use solana_sdk::{
+            signature::{Keypair, Signer},
+            transaction::VersionedTransaction,
+        };
+        use spl_token_2022_interface::extension::transfer_fee::instruction::transfer_checked_with_fee;
+
+        let owner = Keypair::new();
+        let source_address = Pubkey::new_unique();
+        let mint = Pubkey::new_unique();
+        let destination_address = Pubkey::new_unique();
+        let amount = 7500u64;
+        let decimals = 6u8;
+
+        let instruction = transfer_checked_with_fee(
+            &spl_token_2022_interface::ID,
+            &source_address,
+            &mint,
+            &destination_address,
+            &owner.pubkey(),
+            &[],
+            amount,
+            decimals,
+            0,
+        )
+        .expect("Failed to create transfer_checked_with_fee instruction");
 
         let message = VersionedMessage::Legacy(Message::new(&[instruction], Some(&owner.pubkey())));
         let tx = VersionedTransaction::try_new(message, &[&owner]).unwrap();

--- a/tests/free_signing/free_signing_tests.rs
+++ b/tests/free_signing/free_signing_tests.rs
@@ -10,6 +10,7 @@ use std::str::FromStr;
 async fn build_transfer_hook_transaction_for_free_signing(
     ctx: &TestContext,
     amount: u64,
+    use_transfer_fee_extension: bool,
 ) -> anyhow::Result<String> {
     let rpc_client = ctx.rpc_client();
     let hook_program_id =
@@ -74,16 +75,30 @@ async fn build_transfer_hook_transaction_for_free_signing(
     )
     .await?;
 
-    let mut transfer_instruction = spl_token_2022_interface::instruction::transfer_checked(
-        &spl_token_2022_interface::id(),
-        &sender_ata,
-        &transfer_hook_mint_keypair.pubkey(),
-        &recipient_ata,
-        &sender.pubkey(),
-        &[],
-        amount,
-        6,
-    )?;
+    let mut transfer_instruction = if use_transfer_fee_extension {
+        spl_token_2022_interface::extension::transfer_fee::instruction::transfer_checked_with_fee(
+            &spl_token_2022_interface::id(),
+            &sender_ata,
+            &transfer_hook_mint_keypair.pubkey(),
+            &recipient_ata,
+            &sender.pubkey(),
+            &[],
+            amount,
+            6,
+            0,
+        )?
+    } else {
+        spl_token_2022_interface::instruction::transfer_checked(
+            &spl_token_2022_interface::id(),
+            &sender_ata,
+            &transfer_hook_mint_keypair.pubkey(),
+            &recipient_ata,
+            &sender.pubkey(),
+            &[],
+            amount,
+            6,
+        )?
+    };
 
     let extra_account_metas_address = spl_transfer_hook_interface::get_extra_account_metas_address(
         &transfer_hook_mint_keypair.pubkey(),
@@ -111,7 +126,7 @@ async fn build_transfer_hook_transaction_for_free_signing(
 async fn test_sign_transaction_rejects_mutable_transfer_hook_in_free_mode() {
     let ctx = TestContext::new().await.expect("Failed to create test context");
 
-    let test_tx = build_transfer_hook_transaction_for_free_signing(&ctx, 10)
+    let test_tx = build_transfer_hook_transaction_for_free_signing(&ctx, 10, false)
         .await
         .expect("Failed to create transfer-hook transaction");
 
@@ -131,7 +146,7 @@ async fn test_sign_transaction_rejects_mutable_transfer_hook_in_free_mode() {
 async fn test_sign_and_send_transaction_allows_mutable_transfer_hook_in_free_mode() {
     let ctx = TestContext::new().await.expect("Failed to create test context");
 
-    let test_tx = build_transfer_hook_transaction_for_free_signing(&ctx, 10)
+    let test_tx = build_transfer_hook_transaction_for_free_signing(&ctx, 10, false)
         .await
         .expect("Failed to create transfer-hook transaction");
 
@@ -143,6 +158,27 @@ async fn test_sign_and_send_transaction_allows_mutable_transfer_hook_in_free_mod
     assert!(
         response["signed_transaction"].as_str().is_some(),
         "Expected signed_transaction in response"
+    );
+}
+
+#[tokio::test]
+async fn test_sign_transaction_rejects_mutable_transfer_hook_transfer_checked_with_fee_in_free_mode(
+) {
+    let ctx = TestContext::new().await.expect("Failed to create test context");
+
+    let test_tx = build_transfer_hook_transaction_for_free_signing(&ctx, 10, true)
+        .await
+        .expect("Failed to create transfer-hook transaction");
+
+    let result: Result<serde_json::Value, anyhow::Error> =
+        ctx.rpc_call("signTransaction", rpc_params![test_tx]).await;
+
+    assert!(result.is_err(), "Expected delayed signing to reject mutable transfer-hook authority",);
+
+    let error = result.unwrap_err().to_string();
+    assert!(
+        error.contains("Mutable transfer-hook authority found on mint account"),
+        "Expected mutable transfer-hook authority error, got: {error}",
     );
 }
 


### PR DESCRIPTION
## Summary
- parse Token-2022 TransferCheckedWithFee into Kora's internal SplTokenTransfer representation
- route transfer-fee-encoded transfers through the existing mutable transfer-hook guard used by delayed signing
- add focused parser, fee, and free-signing regressions for the bypass path

## Test Plan
- just fmt
- cargo clippy -p kora-lib --tests -- -D warnings
- cargo test -p kora-lib test_parse_token_2022_instructions_transfer_checked_with_fee -- --nocapture
- cargo test -p kora-lib test_estimate_kora_fee_free_rejects_mutable_transfer_hook_authority_for_transfer_checked_with_fee -- --nocapture
- not run locally: cargo test -p tests --test free_signing test_sign_transaction_rejects_mutable_transfer_hook_transfer_checked_with_fee_in_free_mode -- --nocapture (KORA_PRIVATE_KEY not set in this shell)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/solana-foundation/kora/pull/446" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->



## 📊 Unit Test Coverage
![Coverage](https://img.shields.io/badge/coverage-86.2%25-green)

**Unit Test Coverage: 86.2%**

[View Detailed Coverage Report](https://github.com/solana-foundation/kora/actions/runs/24743521974)