### PR TITLE
fix(token2022): validate extension security metadata

### DIFF
--- a/crates/lib/src/config.rs
+++ b/crates/lib/src/config.rs
@@ -224,6 +224,7 @@ pub struct SplTokenInstructionPolicy {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema, Default)]
+#[serde(default)]
 pub struct Token2022InstructionPolicy {
     /// Allow fee payer to be the owner in Token2022 Transfer/TransferChecked instructions
     pub allow_transfer: bool,

--- a/crates/lib/src/config.rs
+++ b/crates/lib/src/config.rs
@@ -245,6 +245,12 @@ pub struct Token2022InstructionPolicy {
     pub allow_initialize_account: bool,
     /// Allow fee payer to be a signer in Token2022 InitializeMultisig instructions
     pub allow_initialize_multisig: bool,
+    /// Allow fee payer to be planted as a future Token2022 extension authority/delegate during
+    /// extension initialization.
+    pub allow_initialize_extension_authority: bool,
+    /// Allow fee payer to be used as the current authority for Token2022 extension update/admin
+    /// instructions.
+    pub allow_update_extension_authority: bool,
     /// Allow fee payer to be the freeze authority in Token2022 FreezeAccount instructions
     pub allow_freeze_account: bool,
     /// Allow fee payer to be the freeze authority in Token2022 ThawAccount instructions

--- a/crates/lib/src/tests/config_mock.rs
+++ b/crates/lib/src/tests/config_mock.rs
@@ -687,6 +687,8 @@ impl FeePayerPolicyBuilder {
                     allow_revoke: false,
                     allow_set_authority: false,
                     allow_mint_to: false,
+                    allow_initialize_extension_authority: false,
+                    allow_update_extension_authority: false,
                     allow_freeze_account: false,
                     allow_thaw_account: false,
                     allow_initialize_mint: false,

--- a/crates/lib/src/token/spl_token_2022_util.rs
+++ b/crates/lib/src/token/spl_token_2022_util.rs
@@ -353,6 +353,10 @@ mod tests {
             "non_transferable",
             "permanent_delegate",
             "transfer_hook",
+            "metadata_pointer",
+            "group_pointer",
+            "group_member_pointer",
+            "scaled_ui_amount",
             "pausable",
         ];
 
@@ -383,6 +387,10 @@ mod tests {
             ExtensionType::NonTransferable,
             ExtensionType::PermanentDelegate,
             ExtensionType::TransferHook,
+            ExtensionType::MetadataPointer,
+            ExtensionType::GroupPointer,
+            ExtensionType::GroupMemberPointer,
+            ExtensionType::ScaledUiAmount,
             ExtensionType::Pausable,
         ];
 
@@ -628,6 +636,10 @@ mod tests {
             ExtensionType::NonTransferable,
             ExtensionType::PermanentDelegate,
             ExtensionType::TransferHook,
+            ExtensionType::MetadataPointer,
+            ExtensionType::GroupPointer,
+            ExtensionType::GroupMemberPointer,
+            ExtensionType::ScaledUiAmount,
             ExtensionType::Pausable,
             ExtensionType::ConfidentialMintBurn,
         ];

--- a/crates/lib/src/token/spl_token_2022_util.rs
+++ b/crates/lib/src/token/spl_token_2022_util.rs
@@ -41,13 +41,17 @@ use spl_token_2022_interface::{
         confidential_transfer::{ConfidentialTransferAccount, ConfidentialTransferMint},
         cpi_guard::CpiGuard,
         default_account_state::DefaultAccountState,
+        group_member_pointer::GroupMemberPointer,
+        group_pointer::GroupPointer,
         immutable_owner::ImmutableOwner,
         interest_bearing_mint::InterestBearingConfig,
         memo_transfer::MemoTransfer,
+        metadata_pointer::MetadataPointer,
         mint_close_authority::MintCloseAuthority,
         non_transferable::{NonTransferable, NonTransferableAccount},
         pausable::{PausableAccount, PausableConfig},
         permanent_delegate::PermanentDelegate,
+        scaled_ui_amount::ScaledUiAmountConfig,
         transfer_fee::TransferFeeConfig,
         transfer_hook::{TransferHook, TransferHookAccount},
         BaseStateWithExtensions, ExtensionType, StateWithExtensions,
@@ -97,6 +101,10 @@ define_extensions!(MintExtension, [
     NonTransferable(NonTransferable) => ExtensionType::NonTransferable, "non_transferable",
     PermanentDelegate(PermanentDelegate) => ExtensionType::PermanentDelegate, "permanent_delegate",
     TransferHook(TransferHook) => ExtensionType::TransferHook, "transfer_hook",
+    MetadataPointer(MetadataPointer) => ExtensionType::MetadataPointer, "metadata_pointer",
+    GroupPointer(GroupPointer) => ExtensionType::GroupPointer, "group_pointer",
+    GroupMemberPointer(GroupMemberPointer) => ExtensionType::GroupMemberPointer, "group_member_pointer",
+    ScaledUiAmountConfig(ScaledUiAmountConfig) => ExtensionType::ScaledUiAmount, "scaled_ui_amount",
     PausableConfig(PausableConfig) => ExtensionType::Pausable, "pausable",
 ]);
 
@@ -198,6 +206,22 @@ pub fn try_parse_mint_extension(
             .get_extension::<TransferHook>()
             .ok()
             .map(|ext| ParsedExtension::Mint(MintExtension::TransferHook(*ext))),
+        ExtensionType::MetadataPointer => mint
+            .get_extension::<MetadataPointer>()
+            .ok()
+            .map(|ext| ParsedExtension::Mint(MintExtension::MetadataPointer(*ext))),
+        ExtensionType::GroupPointer => mint
+            .get_extension::<GroupPointer>()
+            .ok()
+            .map(|ext| ParsedExtension::Mint(MintExtension::GroupPointer(*ext))),
+        ExtensionType::GroupMemberPointer => mint
+            .get_extension::<GroupMemberPointer>()
+            .ok()
+            .map(|ext| ParsedExtension::Mint(MintExtension::GroupMemberPointer(*ext))),
+        ExtensionType::ScaledUiAmount => mint
+            .get_extension::<ScaledUiAmountConfig>()
+            .ok()
+            .map(|ext| ParsedExtension::Mint(MintExtension::ScaledUiAmountConfig(*ext))),
         ExtensionType::Pausable => mint
             .get_extension::<PausableConfig>()
             .ok()

--- a/crates/lib/src/transaction/mod.rs
+++ b/crates/lib/src/transaction/mod.rs
@@ -1,10 +1,12 @@
 mod instruction_util;
 mod retry_util;
+mod token2022_security;
 mod transaction;
 mod versioned_message;
 mod versioned_transaction;
 pub use instruction_util::*;
 pub(crate) use retry_util::{sign_with_retry, signing_retry_window};
+pub(crate) use token2022_security::*;
 pub use transaction::*;
 pub use versioned_message::*;
 pub use versioned_transaction::*;

--- a/crates/lib/src/transaction/token2022_security.rs
+++ b/crates/lib/src/transaction/token2022_security.rs
@@ -15,11 +15,24 @@ use spl_token_2022_interface::{
 
 use crate::{error::KoraError, sanitize_error};
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Token2022FieldRole {
+    Reference,
+    ProgramId,
+    PlantedAuthority,
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub struct Token2022SecurityField {
     pub context: &'static str,
     pub pubkey: Pubkey,
-    pub plants_extension_authority: bool,
+    pub role: Token2022FieldRole,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Token2022AccountUsagePolicy {
+    Ignore,
+    RejectIfFeePayerPresent,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -27,24 +40,24 @@ pub struct Token2022SecurityInstruction {
     pub instruction_name: &'static str,
     pub extension_type: Option<ExtensionType>,
     pub accounts: Vec<Pubkey>,
-    pub reject_if_fee_payer_in_accounts: bool,
+    pub account_usage_policy: Token2022AccountUsagePolicy,
     pub update_authority: Option<Pubkey>,
     pub multisig_signers: Vec<Pubkey>,
     pub data_pubkeys: Vec<Token2022SecurityField>,
 }
 
 impl Token2022SecurityInstruction {
-    pub fn uses_fee_payer_as_update_authority(&self, fee_payer: &Pubkey) -> bool {
+    pub fn uses_fee_payer_as_current_extension_authority(&self, fee_payer: &Pubkey) -> bool {
         self.update_authority == Some(*fee_payer) || self.multisig_signers.contains(fee_payer)
     }
 
-    pub fn planted_fee_payer_authority(
+    pub fn find_planted_fee_payer_authority(
         &self,
         fee_payer: &Pubkey,
     ) -> Option<&Token2022SecurityField> {
-        self.data_pubkeys
-            .iter()
-            .find(|field| field.plants_extension_authority && field.pubkey == *fee_payer)
+        self.data_pubkeys.iter().find(|field| {
+            matches!(field.role, Token2022FieldRole::PlantedAuthority) && field.pubkey == *fee_payer
+        })
     }
 }
 
@@ -74,13 +87,13 @@ impl Token2022SecurityParser {
                         instruction_name: "Token2022 InitializeMintCloseAuthority",
                         extension_type: Some(ExtensionType::MintCloseAuthority),
                         accounts: Self::instruction_accounts(instruction),
-                        reject_if_fee_payer_in_accounts: false,
+                        account_usage_policy: Token2022AccountUsagePolicy::Ignore,
                         update_authority: None,
                         multisig_signers: vec![],
                         data_pubkeys: Self::optional_field(
                             close_authority.into(),
                             "Token2022 InitializeMintCloseAuthority newAuthority",
-                            true,
+                            Token2022FieldRole::PlantedAuthority,
                         )
                         .into_iter()
                         .collect(),
@@ -91,13 +104,13 @@ impl Token2022SecurityParser {
                         instruction_name: "Token2022 InitializePermanentDelegate",
                         extension_type: Some(ExtensionType::PermanentDelegate),
                         accounts: Self::instruction_accounts(instruction),
-                        reject_if_fee_payer_in_accounts: false,
+                        account_usage_policy: Token2022AccountUsagePolicy::Ignore,
                         update_authority: None,
                         multisig_signers: vec![],
                         data_pubkeys: vec![Token2022SecurityField {
                             context: "Token2022 InitializePermanentDelegate delegate",
                             pubkey: delegate,
-                            plants_extension_authority: true,
+                            role: Token2022FieldRole::PlantedAuthority,
                         }],
                     });
                 }
@@ -182,19 +195,19 @@ impl Token2022SecurityParser {
                 instruction_name: "Token2022 InitializeTransferFeeConfig",
                 extension_type: Some(ExtensionType::TransferFeeConfig),
                 accounts: Self::instruction_accounts(instruction),
-                reject_if_fee_payer_in_accounts: false,
+                account_usage_policy: Token2022AccountUsagePolicy::Ignore,
                 update_authority: None,
                 multisig_signers: vec![],
                 data_pubkeys: [
                     Self::optional_field(
                         transfer_fee_config_authority.into(),
                         "Token2022 InitializeTransferFeeConfig transferFeeConfigAuthority",
-                        true,
+                        Token2022FieldRole::PlantedAuthority,
                     ),
                     Self::optional_field(
                         withdraw_withheld_authority.into(),
                         "Token2022 InitializeTransferFeeConfig withdrawWithheldAuthority",
-                        true,
+                        Token2022FieldRole::PlantedAuthority,
                     ),
                 ]
                 .into_iter()
@@ -206,7 +219,7 @@ impl Token2022SecurityParser {
                     instruction_name: "Token2022 SetTransferFee",
                     extension_type: Some(ExtensionType::TransferFeeConfig),
                     accounts: Self::instruction_accounts(instruction),
-                    reject_if_fee_payer_in_accounts: false,
+                    account_usage_policy: Token2022AccountUsagePolicy::Ignore,
                     update_authority: Some(Self::required_account(
                         instruction,
                         1,
@@ -221,7 +234,7 @@ impl Token2022SecurityParser {
                     instruction_name: "Token2022 WithdrawWithheldTokensFromMint",
                     extension_type: Some(ExtensionType::TransferFeeConfig),
                     accounts: Self::instruction_accounts(instruction),
-                    reject_if_fee_payer_in_accounts: false,
+                    account_usage_policy: Token2022AccountUsagePolicy::Ignore,
                     update_authority: Some(Self::required_account(
                         instruction,
                         2,
@@ -238,7 +251,7 @@ impl Token2022SecurityParser {
                     instruction_name: "Token2022 WithdrawWithheldTokensFromAccounts",
                     extension_type: Some(ExtensionType::TransferFeeConfig),
                     accounts: Self::instruction_accounts(instruction),
-                    reject_if_fee_payer_in_accounts: false,
+                    account_usage_policy: Token2022AccountUsagePolicy::Ignore,
                     update_authority: Some(Self::required_account(
                         instruction,
                         2,
@@ -286,13 +299,13 @@ impl Token2022SecurityParser {
                     instruction_name: "Token2022 InitializeInterestBearingConfig",
                     extension_type: Some(ExtensionType::InterestBearingConfig),
                     accounts: Self::instruction_accounts(instruction),
-                    reject_if_fee_payer_in_accounts: false,
+                    account_usage_policy: Token2022AccountUsagePolicy::Ignore,
                     update_authority: None,
                     multisig_signers: vec![],
                     data_pubkeys: Self::optional_field(
                         initialize.rate_authority.into(),
                         "Token2022 InitializeInterestBearingConfig rateAuthority",
-                        true,
+                        Token2022FieldRole::PlantedAuthority,
                     )
                     .into_iter()
                     .collect(),
@@ -302,7 +315,7 @@ impl Token2022SecurityParser {
                 instruction_name: "Token2022 UpdateInterestBearingConfigRate",
                 extension_type: Some(ExtensionType::InterestBearingConfig),
                 accounts: Self::instruction_accounts(instruction),
-                reject_if_fee_payer_in_accounts: false,
+                account_usage_policy: Token2022AccountUsagePolicy::Ignore,
                 update_authority: Some(Self::required_account(
                     instruction,
                     1,
@@ -337,19 +350,19 @@ impl Token2022SecurityParser {
                     instruction_name: "Token2022 InitializeTransferHook",
                     extension_type: Some(ExtensionType::TransferHook),
                     accounts: Self::instruction_accounts(instruction),
-                    reject_if_fee_payer_in_accounts: false,
+                    account_usage_policy: Token2022AccountUsagePolicy::Ignore,
                     update_authority: None,
                     multisig_signers: vec![],
                     data_pubkeys: [
                         Self::optional_field(
                             initialize.authority.into(),
                             "Token2022 InitializeTransferHook authority",
-                            true,
+                            Token2022FieldRole::PlantedAuthority,
                         ),
                         Self::optional_field(
                             initialize.program_id.into(),
                             "Token2022 InitializeTransferHook program_id",
-                            false,
+                            Token2022FieldRole::ProgramId,
                         ),
                     ]
                     .into_iter()
@@ -373,7 +386,7 @@ impl Token2022SecurityParser {
                     instruction_name: "Token2022 TransferHookUpdate",
                     extension_type: Some(ExtensionType::TransferHook),
                     accounts: Self::instruction_accounts(instruction),
-                    reject_if_fee_payer_in_accounts: false,
+                    account_usage_policy: Token2022AccountUsagePolicy::Ignore,
                     update_authority: Some(Self::required_account(
                         instruction,
                         1,
@@ -383,7 +396,7 @@ impl Token2022SecurityParser {
                     data_pubkeys: Self::optional_field(
                         update.program_id.into(),
                         "Token2022 TransferHookUpdate program_id",
-                        false,
+                        Token2022FieldRole::ProgramId,
                     )
                     .into_iter()
                     .collect(),
@@ -417,19 +430,19 @@ impl Token2022SecurityParser {
                     instruction_name: "Token2022 InitializeMetadataPointer",
                     extension_type: Some(ExtensionType::MetadataPointer),
                     accounts: Self::instruction_accounts(instruction),
-                    reject_if_fee_payer_in_accounts: false,
+                    account_usage_policy: Token2022AccountUsagePolicy::Ignore,
                     update_authority: None,
                     multisig_signers: vec![],
                     data_pubkeys: [
                         Self::optional_field(
                             initialize.authority.into(),
                             "Token2022 InitializeMetadataPointer authority",
-                            true,
+                            Token2022FieldRole::PlantedAuthority,
                         ),
                         Self::optional_field(
                             initialize.metadata_address.into(),
                             "Token2022 InitializeMetadataPointer metadataAddress",
-                            false,
+                            Token2022FieldRole::Reference,
                         ),
                     ]
                     .into_iter()
@@ -453,7 +466,7 @@ impl Token2022SecurityParser {
                     instruction_name: "Token2022 UpdateMetadataPointer",
                     extension_type: Some(ExtensionType::MetadataPointer),
                     accounts: Self::instruction_accounts(instruction),
-                    reject_if_fee_payer_in_accounts: false,
+                    account_usage_policy: Token2022AccountUsagePolicy::Ignore,
                     update_authority: Some(Self::required_account(
                         instruction,
                         1,
@@ -463,7 +476,7 @@ impl Token2022SecurityParser {
                     data_pubkeys: Self::optional_field(
                         update.metadata_address.into(),
                         "Token2022 UpdateMetadataPointer metadataAddress",
-                        false,
+                        Token2022FieldRole::Reference,
                     )
                     .into_iter()
                     .collect(),
@@ -495,19 +508,19 @@ impl Token2022SecurityParser {
                     instruction_name: "Token2022 InitializeGroupPointer",
                     extension_type: Some(ExtensionType::GroupPointer),
                     accounts: Self::instruction_accounts(instruction),
-                    reject_if_fee_payer_in_accounts: false,
+                    account_usage_policy: Token2022AccountUsagePolicy::Ignore,
                     update_authority: None,
                     multisig_signers: vec![],
                     data_pubkeys: [
                         Self::optional_field(
                             initialize.authority.into(),
                             "Token2022 InitializeGroupPointer authority",
-                            true,
+                            Token2022FieldRole::PlantedAuthority,
                         ),
                         Self::optional_field(
                             initialize.group_address.into(),
                             "Token2022 InitializeGroupPointer groupAddress",
-                            false,
+                            Token2022FieldRole::Reference,
                         ),
                     ]
                     .into_iter()
@@ -531,7 +544,7 @@ impl Token2022SecurityParser {
                     instruction_name: "Token2022 UpdateGroupPointer",
                     extension_type: Some(ExtensionType::GroupPointer),
                     accounts: Self::instruction_accounts(instruction),
-                    reject_if_fee_payer_in_accounts: false,
+                    account_usage_policy: Token2022AccountUsagePolicy::Ignore,
                     update_authority: Some(Self::required_account(
                         instruction,
                         1,
@@ -541,7 +554,7 @@ impl Token2022SecurityParser {
                     data_pubkeys: Self::optional_field(
                         update.group_address.into(),
                         "Token2022 UpdateGroupPointer groupAddress",
-                        false,
+                        Token2022FieldRole::Reference,
                     )
                     .into_iter()
                     .collect(),
@@ -574,19 +587,19 @@ impl Token2022SecurityParser {
                     instruction_name: "Token2022 InitializeGroupMemberPointer",
                     extension_type: Some(ExtensionType::GroupMemberPointer),
                     accounts: Self::instruction_accounts(instruction),
-                    reject_if_fee_payer_in_accounts: false,
+                    account_usage_policy: Token2022AccountUsagePolicy::Ignore,
                     update_authority: None,
                     multisig_signers: vec![],
                     data_pubkeys: [
                         Self::optional_field(
                             initialize.authority.into(),
                             "Token2022 InitializeGroupMemberPointer authority",
-                            true,
+                            Token2022FieldRole::PlantedAuthority,
                         ),
                         Self::optional_field(
                             initialize.member_address.into(),
                             "Token2022 InitializeGroupMemberPointer memberAddress",
-                            false,
+                            Token2022FieldRole::Reference,
                         ),
                     ]
                     .into_iter()
@@ -610,7 +623,7 @@ impl Token2022SecurityParser {
                     instruction_name: "Token2022 UpdateGroupMemberPointer",
                     extension_type: Some(ExtensionType::GroupMemberPointer),
                     accounts: Self::instruction_accounts(instruction),
-                    reject_if_fee_payer_in_accounts: false,
+                    account_usage_policy: Token2022AccountUsagePolicy::Ignore,
                     update_authority: Some(Self::required_account(
                         instruction,
                         1,
@@ -620,7 +633,7 @@ impl Token2022SecurityParser {
                     data_pubkeys: Self::optional_field(
                         update.member_address.into(),
                         "Token2022 UpdateGroupMemberPointer memberAddress",
-                        false,
+                        Token2022FieldRole::Reference,
                     )
                     .into_iter()
                     .collect(),
@@ -653,13 +666,13 @@ impl Token2022SecurityParser {
                     instruction_name: "Token2022 InitializeScaledUiAmountConfig",
                     extension_type: Some(ExtensionType::ScaledUiAmount),
                     accounts: Self::instruction_accounts(instruction),
-                    reject_if_fee_payer_in_accounts: false,
+                    account_usage_policy: Token2022AccountUsagePolicy::Ignore,
                     update_authority: None,
                     multisig_signers: vec![],
                     data_pubkeys: Self::optional_field(
                         initialize.authority.into(),
                         "Token2022 InitializeScaledUiAmountConfig authority",
-                        true,
+                        Token2022FieldRole::PlantedAuthority,
                     )
                     .into_iter()
                     .collect(),
@@ -669,7 +682,7 @@ impl Token2022SecurityParser {
                 instruction_name: "Token2022 UpdateScaledUiAmountConfigMultiplier",
                 extension_type: Some(ExtensionType::ScaledUiAmount),
                 accounts: Self::instruction_accounts(instruction),
-                reject_if_fee_payer_in_accounts: false,
+                account_usage_policy: Token2022AccountUsagePolicy::Ignore,
                 update_authority: Some(Self::required_account(
                     instruction,
                     1,
@@ -704,13 +717,13 @@ impl Token2022SecurityParser {
                     instruction_name: "Token2022 InitializePausable",
                     extension_type: Some(ExtensionType::Pausable),
                     accounts: Self::instruction_accounts(instruction),
-                    reject_if_fee_payer_in_accounts: false,
+                    account_usage_policy: Token2022AccountUsagePolicy::Ignore,
                     update_authority: None,
                     multisig_signers: vec![],
                     data_pubkeys: vec![Token2022SecurityField {
                         context: "Token2022 InitializePausable authority",
                         pubkey: initialize.authority,
-                        plants_extension_authority: true,
+                        role: Token2022FieldRole::PlantedAuthority,
                     }],
                 }))
             }
@@ -739,9 +752,9 @@ impl Token2022SecurityParser {
     fn optional_field(
         pubkey: Option<Pubkey>,
         context: &'static str,
-        plants_extension_authority: bool,
+        role: Token2022FieldRole,
     ) -> Option<Token2022SecurityField> {
-        pubkey.map(|pubkey| Token2022SecurityField { context, pubkey, plants_extension_authority })
+        pubkey.map(|pubkey| Token2022SecurityField { context, pubkey, role })
     }
 
     fn required_account(
@@ -781,7 +794,7 @@ impl Token2022SecurityParser {
             instruction_name,
             extension_type: None,
             accounts: Self::instruction_accounts(instruction),
-            reject_if_fee_payer_in_accounts: true,
+            account_usage_policy: Token2022AccountUsagePolicy::RejectIfFeePayerPresent,
             update_authority: None,
             multisig_signers: vec![],
             data_pubkeys: vec![],
@@ -814,7 +827,7 @@ mod tests {
         assert_eq!(parsed[0].instruction_name, "Token2022 InitializeMetadataPointer");
         assert_eq!(parsed[0].extension_type, Some(ExtensionType::MetadataPointer));
         assert_eq!(
-            parsed[0].planted_fee_payer_authority(&authority).map(|field| field.context),
+            parsed[0].find_planted_fee_payer_authority(&authority).map(|field| field.context),
             Some("Token2022 InitializeMetadataPointer authority")
         );
         assert!(parsed[0].data_pubkeys.iter().any(|field| field.pubkey == metadata_address

--- a/crates/lib/src/transaction/token2022_security.rs
+++ b/crates/lib/src/transaction/token2022_security.rs
@@ -1,0 +1,862 @@
+use solana_sdk::{instruction::Instruction, pubkey::Pubkey};
+use spl_token_2022_interface::{
+    extension::{
+        group_member_pointer::instruction::GroupMemberPointerInstruction,
+        group_pointer::instruction::GroupPointerInstruction,
+        interest_bearing_mint::instruction::InterestBearingMintInstruction,
+        metadata_pointer::instruction::MetadataPointerInstruction,
+        pausable::instruction::PausableInstruction,
+        scaled_ui_amount::instruction::ScaledUiAmountMintInstruction,
+        transfer_fee::instruction::TransferFeeInstruction,
+        transfer_hook::instruction::TransferHookInstruction, ExtensionType,
+    },
+    instruction::{decode_instruction_data, decode_instruction_type, TokenInstruction},
+};
+
+use crate::{error::KoraError, sanitize_error};
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Token2022SecurityField {
+    pub context: &'static str,
+    pub pubkey: Pubkey,
+    pub plants_extension_authority: bool,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Token2022SecurityInstruction {
+    pub instruction_name: &'static str,
+    pub extension_type: Option<ExtensionType>,
+    pub accounts: Vec<Pubkey>,
+    pub reject_if_fee_payer_in_accounts: bool,
+    pub update_authority: Option<Pubkey>,
+    pub multisig_signers: Vec<Pubkey>,
+    pub data_pubkeys: Vec<Token2022SecurityField>,
+}
+
+impl Token2022SecurityInstruction {
+    pub fn uses_fee_payer_as_update_authority(&self, fee_payer: &Pubkey) -> bool {
+        self.update_authority == Some(*fee_payer) || self.multisig_signers.contains(fee_payer)
+    }
+
+    pub fn planted_fee_payer_authority(
+        &self,
+        fee_payer: &Pubkey,
+    ) -> Option<&Token2022SecurityField> {
+        self.data_pubkeys
+            .iter()
+            .find(|field| field.plants_extension_authority && field.pubkey == *fee_payer)
+    }
+}
+
+pub(crate) struct Token2022SecurityParser;
+
+impl Token2022SecurityParser {
+    pub fn parse(
+        instructions: &[Instruction],
+    ) -> Result<Vec<Token2022SecurityInstruction>, KoraError> {
+        let mut parsed = Vec::new();
+
+        for instruction in instructions {
+            if instruction.program_id != spl_token_2022_interface::id() {
+                continue;
+            }
+
+            let token_instruction = TokenInstruction::unpack(&instruction.data).map_err(|e| {
+                KoraError::InvalidTransaction(format!(
+                    "Failed to parse Token-2022 instruction for security validation: {}",
+                    sanitize_error!(e)
+                ))
+            })?;
+
+            match token_instruction {
+                TokenInstruction::InitializeMintCloseAuthority { close_authority } => {
+                    parsed.push(Token2022SecurityInstruction {
+                        instruction_name: "Token2022 InitializeMintCloseAuthority",
+                        extension_type: Some(ExtensionType::MintCloseAuthority),
+                        accounts: Self::instruction_accounts(instruction),
+                        reject_if_fee_payer_in_accounts: false,
+                        update_authority: None,
+                        multisig_signers: vec![],
+                        data_pubkeys: Self::optional_field(
+                            close_authority.into(),
+                            "Token2022 InitializeMintCloseAuthority newAuthority",
+                            true,
+                        )
+                        .into_iter()
+                        .collect(),
+                    });
+                }
+                TokenInstruction::InitializePermanentDelegate { delegate } => {
+                    parsed.push(Token2022SecurityInstruction {
+                        instruction_name: "Token2022 InitializePermanentDelegate",
+                        extension_type: Some(ExtensionType::PermanentDelegate),
+                        accounts: Self::instruction_accounts(instruction),
+                        reject_if_fee_payer_in_accounts: false,
+                        update_authority: None,
+                        multisig_signers: vec![],
+                        data_pubkeys: vec![Token2022SecurityField {
+                            context: "Token2022 InitializePermanentDelegate delegate",
+                            pubkey: delegate,
+                            plants_extension_authority: true,
+                        }],
+                    });
+                }
+                TokenInstruction::TransferFeeExtension => {
+                    if let Some(parsed_instruction) =
+                        Self::parse_transfer_fee_extension(instruction)?
+                    {
+                        parsed.push(parsed_instruction);
+                    }
+                }
+                TokenInstruction::InterestBearingMintExtension => {
+                    if let Some(parsed_instruction) =
+                        Self::parse_interest_bearing_extension(instruction)?
+                    {
+                        parsed.push(parsed_instruction);
+                    }
+                }
+                TokenInstruction::TransferHookExtension => {
+                    if let Some(parsed_instruction) =
+                        Self::parse_transfer_hook_extension(instruction)?
+                    {
+                        parsed.push(parsed_instruction);
+                    }
+                }
+                TokenInstruction::MetadataPointerExtension => {
+                    parsed.push(Self::parse_metadata_pointer_extension(instruction)?);
+                }
+                TokenInstruction::GroupPointerExtension => {
+                    parsed.push(Self::parse_group_pointer_extension(instruction)?);
+                }
+                TokenInstruction::GroupMemberPointerExtension => {
+                    parsed.push(Self::parse_group_member_pointer_extension(instruction)?);
+                }
+                TokenInstruction::ScaledUiAmountExtension => {
+                    parsed.push(Self::parse_scaled_ui_amount_extension(instruction)?);
+                }
+                TokenInstruction::PausableExtension => {
+                    if let Some(parsed_instruction) = Self::parse_pausable_extension(instruction)? {
+                        parsed.push(parsed_instruction);
+                    }
+                }
+                TokenInstruction::DefaultAccountStateExtension
+                | TokenInstruction::MemoTransferExtension
+                | TokenInstruction::CpiGuardExtension
+                | TokenInstruction::InitializeNonTransferableMint
+                | TokenInstruction::WithdrawExcessLamports => {
+                    parsed.push(Self::unsupported_fee_payer_account_check(
+                        instruction,
+                        "unsupported Token-2022 extension instruction",
+                    ));
+                }
+                _ => {}
+            }
+        }
+
+        Ok(parsed)
+    }
+
+    fn parse_transfer_fee_extension(
+        instruction: &Instruction,
+    ) -> Result<Option<Token2022SecurityInstruction>, KoraError> {
+        if instruction.data.len() < 2 {
+            return Err(KoraError::InvalidTransaction(
+                "Failed to parse Token-2022 TransferFee instruction".to_string(),
+            ));
+        }
+
+        let transfer_fee_instruction = TransferFeeInstruction::unpack(&instruction.data[1..])
+            .map_err(|e| {
+                KoraError::InvalidTransaction(format!(
+                    "Failed to parse Token-2022 TransferFee instruction: {}",
+                    sanitize_error!(e)
+                ))
+            })?;
+
+        match transfer_fee_instruction {
+            TransferFeeInstruction::InitializeTransferFeeConfig {
+                transfer_fee_config_authority,
+                withdraw_withheld_authority,
+                ..
+            } => Ok(Some(Token2022SecurityInstruction {
+                instruction_name: "Token2022 InitializeTransferFeeConfig",
+                extension_type: Some(ExtensionType::TransferFeeConfig),
+                accounts: Self::instruction_accounts(instruction),
+                reject_if_fee_payer_in_accounts: false,
+                update_authority: None,
+                multisig_signers: vec![],
+                data_pubkeys: [
+                    Self::optional_field(
+                        transfer_fee_config_authority.into(),
+                        "Token2022 InitializeTransferFeeConfig transferFeeConfigAuthority",
+                        true,
+                    ),
+                    Self::optional_field(
+                        withdraw_withheld_authority.into(),
+                        "Token2022 InitializeTransferFeeConfig withdrawWithheldAuthority",
+                        true,
+                    ),
+                ]
+                .into_iter()
+                .flatten()
+                .collect(),
+            })),
+            TransferFeeInstruction::SetTransferFee { .. } => {
+                Ok(Some(Token2022SecurityInstruction {
+                    instruction_name: "Token2022 SetTransferFee",
+                    extension_type: Some(ExtensionType::TransferFeeConfig),
+                    accounts: Self::instruction_accounts(instruction),
+                    reject_if_fee_payer_in_accounts: false,
+                    update_authority: Some(Self::required_account(
+                        instruction,
+                        1,
+                        "Token2022 SetTransferFee authority",
+                    )?),
+                    multisig_signers: Self::extract_multisig_signers(instruction, 2, None),
+                    data_pubkeys: vec![],
+                }))
+            }
+            TransferFeeInstruction::WithdrawWithheldTokensFromMint => {
+                Ok(Some(Token2022SecurityInstruction {
+                    instruction_name: "Token2022 WithdrawWithheldTokensFromMint",
+                    extension_type: Some(ExtensionType::TransferFeeConfig),
+                    accounts: Self::instruction_accounts(instruction),
+                    reject_if_fee_payer_in_accounts: false,
+                    update_authority: Some(Self::required_account(
+                        instruction,
+                        2,
+                        "Token2022 WithdrawWithheldTokensFromMint withdrawWithheldAuthority",
+                    )?),
+                    multisig_signers: Self::extract_multisig_signers(instruction, 3, None),
+                    data_pubkeys: vec![],
+                }))
+            }
+            TransferFeeInstruction::WithdrawWithheldTokensFromAccounts { num_token_accounts } => {
+                let signer_end =
+                    instruction.accounts.len().saturating_sub(num_token_accounts as usize);
+                Ok(Some(Token2022SecurityInstruction {
+                    instruction_name: "Token2022 WithdrawWithheldTokensFromAccounts",
+                    extension_type: Some(ExtensionType::TransferFeeConfig),
+                    accounts: Self::instruction_accounts(instruction),
+                    reject_if_fee_payer_in_accounts: false,
+                    update_authority: Some(Self::required_account(
+                        instruction,
+                        2,
+                        "Token2022 WithdrawWithheldTokensFromAccounts withdrawWithheldAuthority",
+                    )?),
+                    multisig_signers: Self::extract_multisig_signers(
+                        instruction,
+                        3,
+                        Some(signer_end),
+                    ),
+                    data_pubkeys: vec![],
+                }))
+            }
+            TransferFeeInstruction::TransferCheckedWithFee { .. } => Ok(None),
+            TransferFeeInstruction::HarvestWithheldTokensToMint => {
+                Ok(Some(Self::unsupported_fee_payer_account_check(
+                    instruction,
+                    "Token2022 HarvestWithheldTokensToMint",
+                )))
+            }
+        }
+    }
+
+    fn parse_interest_bearing_extension(
+        instruction: &Instruction,
+    ) -> Result<Option<Token2022SecurityInstruction>, KoraError> {
+        let interest_bearing_instruction = Self::decode_extension_type::<
+            InterestBearingMintInstruction,
+        >(instruction, "InterestBearing")?;
+
+        match interest_bearing_instruction {
+            InterestBearingMintInstruction::Initialize => {
+                let initialize =
+                    *decode_instruction_data::<
+                        spl_token_2022_interface::extension::interest_bearing_mint::instruction::InitializeInstructionData,
+                    >(&instruction.data[1..])
+                    .map_err(|e| {
+                        KoraError::InvalidTransaction(format!(
+                            "Failed to parse Token-2022 InterestBearing initialize instruction: {}",
+                            sanitize_error!(e)
+                        ))
+                    })?;
+
+                Ok(Some(Token2022SecurityInstruction {
+                    instruction_name: "Token2022 InitializeInterestBearingConfig",
+                    extension_type: Some(ExtensionType::InterestBearingConfig),
+                    accounts: Self::instruction_accounts(instruction),
+                    reject_if_fee_payer_in_accounts: false,
+                    update_authority: None,
+                    multisig_signers: vec![],
+                    data_pubkeys: Self::optional_field(
+                        initialize.rate_authority.into(),
+                        "Token2022 InitializeInterestBearingConfig rateAuthority",
+                        true,
+                    )
+                    .into_iter()
+                    .collect(),
+                }))
+            }
+            InterestBearingMintInstruction::UpdateRate => Ok(Some(Token2022SecurityInstruction {
+                instruction_name: "Token2022 UpdateInterestBearingConfigRate",
+                extension_type: Some(ExtensionType::InterestBearingConfig),
+                accounts: Self::instruction_accounts(instruction),
+                reject_if_fee_payer_in_accounts: false,
+                update_authority: Some(Self::required_account(
+                    instruction,
+                    1,
+                    "Token2022 UpdateInterestBearingConfigRate rateAuthority",
+                )?),
+                multisig_signers: Self::extract_multisig_signers(instruction, 2, None),
+                data_pubkeys: vec![],
+            })),
+        }
+    }
+
+    fn parse_transfer_hook_extension(
+        instruction: &Instruction,
+    ) -> Result<Option<Token2022SecurityInstruction>, KoraError> {
+        let transfer_hook_instruction =
+            Self::decode_extension_type::<TransferHookInstruction>(instruction, "TransferHook")?;
+
+        match transfer_hook_instruction {
+            TransferHookInstruction::Initialize => {
+                let initialize =
+                    *decode_instruction_data::<
+                        spl_token_2022_interface::extension::transfer_hook::instruction::InitializeInstructionData,
+                    >(&instruction.data[1..])
+                    .map_err(|e| {
+                        KoraError::InvalidTransaction(format!(
+                            "Failed to parse Token-2022 TransferHook initialize instruction: {}",
+                            sanitize_error!(e)
+                        ))
+                    })?;
+
+                Ok(Some(Token2022SecurityInstruction {
+                    instruction_name: "Token2022 InitializeTransferHook",
+                    extension_type: Some(ExtensionType::TransferHook),
+                    accounts: Self::instruction_accounts(instruction),
+                    reject_if_fee_payer_in_accounts: false,
+                    update_authority: None,
+                    multisig_signers: vec![],
+                    data_pubkeys: [
+                        Self::optional_field(
+                            initialize.authority.into(),
+                            "Token2022 InitializeTransferHook authority",
+                            true,
+                        ),
+                        Self::optional_field(
+                            initialize.program_id.into(),
+                            "Token2022 InitializeTransferHook program_id",
+                            false,
+                        ),
+                    ]
+                    .into_iter()
+                    .flatten()
+                    .collect(),
+                }))
+            }
+            TransferHookInstruction::Update => {
+                let update =
+                    *decode_instruction_data::<
+                        spl_token_2022_interface::extension::transfer_hook::instruction::UpdateInstructionData,
+                    >(&instruction.data[1..])
+                    .map_err(|e| {
+                        KoraError::InvalidTransaction(format!(
+                            "Failed to parse Token-2022 TransferHook update instruction: {}",
+                            sanitize_error!(e)
+                        ))
+                    })?;
+
+                Ok(Some(Token2022SecurityInstruction {
+                    instruction_name: "Token2022 TransferHookUpdate",
+                    extension_type: Some(ExtensionType::TransferHook),
+                    accounts: Self::instruction_accounts(instruction),
+                    reject_if_fee_payer_in_accounts: false,
+                    update_authority: Some(Self::required_account(
+                        instruction,
+                        1,
+                        "Token2022 TransferHookUpdate authority",
+                    )?),
+                    multisig_signers: Self::extract_multisig_signers(instruction, 2, None),
+                    data_pubkeys: Self::optional_field(
+                        update.program_id.into(),
+                        "Token2022 TransferHookUpdate program_id",
+                        false,
+                    )
+                    .into_iter()
+                    .collect(),
+                }))
+            }
+        }
+    }
+
+    fn parse_metadata_pointer_extension(
+        instruction: &Instruction,
+    ) -> Result<Token2022SecurityInstruction, KoraError> {
+        let metadata_pointer_instruction = Self::decode_extension_type::<MetadataPointerInstruction>(
+            instruction,
+            "MetadataPointer",
+        )?;
+
+        match metadata_pointer_instruction {
+            MetadataPointerInstruction::Initialize => {
+                let initialize =
+                    *decode_instruction_data::<
+                        spl_token_2022_interface::extension::metadata_pointer::instruction::InitializeInstructionData,
+                    >(&instruction.data[1..])
+                    .map_err(|e| {
+                        KoraError::InvalidTransaction(format!(
+                            "Failed to parse Token-2022 MetadataPointer initialize instruction: {}",
+                            sanitize_error!(e)
+                        ))
+                    })?;
+
+                Ok(Token2022SecurityInstruction {
+                    instruction_name: "Token2022 InitializeMetadataPointer",
+                    extension_type: Some(ExtensionType::MetadataPointer),
+                    accounts: Self::instruction_accounts(instruction),
+                    reject_if_fee_payer_in_accounts: false,
+                    update_authority: None,
+                    multisig_signers: vec![],
+                    data_pubkeys: [
+                        Self::optional_field(
+                            initialize.authority.into(),
+                            "Token2022 InitializeMetadataPointer authority",
+                            true,
+                        ),
+                        Self::optional_field(
+                            initialize.metadata_address.into(),
+                            "Token2022 InitializeMetadataPointer metadataAddress",
+                            false,
+                        ),
+                    ]
+                    .into_iter()
+                    .flatten()
+                    .collect(),
+                })
+            }
+            MetadataPointerInstruction::Update => {
+                let update =
+                    *decode_instruction_data::<
+                        spl_token_2022_interface::extension::metadata_pointer::instruction::UpdateInstructionData,
+                    >(&instruction.data[1..])
+                    .map_err(|e| {
+                        KoraError::InvalidTransaction(format!(
+                            "Failed to parse Token-2022 MetadataPointer update instruction: {}",
+                            sanitize_error!(e)
+                        ))
+                    })?;
+
+                Ok(Token2022SecurityInstruction {
+                    instruction_name: "Token2022 UpdateMetadataPointer",
+                    extension_type: Some(ExtensionType::MetadataPointer),
+                    accounts: Self::instruction_accounts(instruction),
+                    reject_if_fee_payer_in_accounts: false,
+                    update_authority: Some(Self::required_account(
+                        instruction,
+                        1,
+                        "Token2022 UpdateMetadataPointer authority",
+                    )?),
+                    multisig_signers: Self::extract_multisig_signers(instruction, 2, None),
+                    data_pubkeys: Self::optional_field(
+                        update.metadata_address.into(),
+                        "Token2022 UpdateMetadataPointer metadataAddress",
+                        false,
+                    )
+                    .into_iter()
+                    .collect(),
+                })
+            }
+        }
+    }
+
+    fn parse_group_pointer_extension(
+        instruction: &Instruction,
+    ) -> Result<Token2022SecurityInstruction, KoraError> {
+        let group_pointer_instruction =
+            Self::decode_extension_type::<GroupPointerInstruction>(instruction, "GroupPointer")?;
+
+        match group_pointer_instruction {
+            GroupPointerInstruction::Initialize => {
+                let initialize =
+                    *decode_instruction_data::<
+                        spl_token_2022_interface::extension::group_pointer::instruction::InitializeInstructionData,
+                    >(&instruction.data[1..])
+                    .map_err(|e| {
+                        KoraError::InvalidTransaction(format!(
+                            "Failed to parse Token-2022 GroupPointer initialize instruction: {}",
+                            sanitize_error!(e)
+                        ))
+                    })?;
+
+                Ok(Token2022SecurityInstruction {
+                    instruction_name: "Token2022 InitializeGroupPointer",
+                    extension_type: Some(ExtensionType::GroupPointer),
+                    accounts: Self::instruction_accounts(instruction),
+                    reject_if_fee_payer_in_accounts: false,
+                    update_authority: None,
+                    multisig_signers: vec![],
+                    data_pubkeys: [
+                        Self::optional_field(
+                            initialize.authority.into(),
+                            "Token2022 InitializeGroupPointer authority",
+                            true,
+                        ),
+                        Self::optional_field(
+                            initialize.group_address.into(),
+                            "Token2022 InitializeGroupPointer groupAddress",
+                            false,
+                        ),
+                    ]
+                    .into_iter()
+                    .flatten()
+                    .collect(),
+                })
+            }
+            GroupPointerInstruction::Update => {
+                let update =
+                    *decode_instruction_data::<
+                        spl_token_2022_interface::extension::group_pointer::instruction::UpdateInstructionData,
+                    >(&instruction.data[1..])
+                    .map_err(|e| {
+                        KoraError::InvalidTransaction(format!(
+                            "Failed to parse Token-2022 GroupPointer update instruction: {}",
+                            sanitize_error!(e)
+                        ))
+                    })?;
+
+                Ok(Token2022SecurityInstruction {
+                    instruction_name: "Token2022 UpdateGroupPointer",
+                    extension_type: Some(ExtensionType::GroupPointer),
+                    accounts: Self::instruction_accounts(instruction),
+                    reject_if_fee_payer_in_accounts: false,
+                    update_authority: Some(Self::required_account(
+                        instruction,
+                        1,
+                        "Token2022 UpdateGroupPointer authority",
+                    )?),
+                    multisig_signers: Self::extract_multisig_signers(instruction, 2, None),
+                    data_pubkeys: Self::optional_field(
+                        update.group_address.into(),
+                        "Token2022 UpdateGroupPointer groupAddress",
+                        false,
+                    )
+                    .into_iter()
+                    .collect(),
+                })
+            }
+        }
+    }
+
+    fn parse_group_member_pointer_extension(
+        instruction: &Instruction,
+    ) -> Result<Token2022SecurityInstruction, KoraError> {
+        let group_member_pointer_instruction = Self::decode_extension_type::<
+            GroupMemberPointerInstruction,
+        >(instruction, "GroupMemberPointer")?;
+
+        match group_member_pointer_instruction {
+            GroupMemberPointerInstruction::Initialize => {
+                let initialize =
+                    *decode_instruction_data::<
+                        spl_token_2022_interface::extension::group_member_pointer::instruction::InitializeInstructionData,
+                    >(&instruction.data[1..])
+                    .map_err(|e| {
+                        KoraError::InvalidTransaction(format!(
+                            "Failed to parse Token-2022 GroupMemberPointer initialize instruction: {}",
+                            sanitize_error!(e)
+                        ))
+                    })?;
+
+                Ok(Token2022SecurityInstruction {
+                    instruction_name: "Token2022 InitializeGroupMemberPointer",
+                    extension_type: Some(ExtensionType::GroupMemberPointer),
+                    accounts: Self::instruction_accounts(instruction),
+                    reject_if_fee_payer_in_accounts: false,
+                    update_authority: None,
+                    multisig_signers: vec![],
+                    data_pubkeys: [
+                        Self::optional_field(
+                            initialize.authority.into(),
+                            "Token2022 InitializeGroupMemberPointer authority",
+                            true,
+                        ),
+                        Self::optional_field(
+                            initialize.member_address.into(),
+                            "Token2022 InitializeGroupMemberPointer memberAddress",
+                            false,
+                        ),
+                    ]
+                    .into_iter()
+                    .flatten()
+                    .collect(),
+                })
+            }
+            GroupMemberPointerInstruction::Update => {
+                let update =
+                    *decode_instruction_data::<
+                        spl_token_2022_interface::extension::group_member_pointer::instruction::UpdateInstructionData,
+                    >(&instruction.data[1..])
+                    .map_err(|e| {
+                        KoraError::InvalidTransaction(format!(
+                            "Failed to parse Token-2022 GroupMemberPointer update instruction: {}",
+                            sanitize_error!(e)
+                        ))
+                    })?;
+
+                Ok(Token2022SecurityInstruction {
+                    instruction_name: "Token2022 UpdateGroupMemberPointer",
+                    extension_type: Some(ExtensionType::GroupMemberPointer),
+                    accounts: Self::instruction_accounts(instruction),
+                    reject_if_fee_payer_in_accounts: false,
+                    update_authority: Some(Self::required_account(
+                        instruction,
+                        1,
+                        "Token2022 UpdateGroupMemberPointer authority",
+                    )?),
+                    multisig_signers: Self::extract_multisig_signers(instruction, 2, None),
+                    data_pubkeys: Self::optional_field(
+                        update.member_address.into(),
+                        "Token2022 UpdateGroupMemberPointer memberAddress",
+                        false,
+                    )
+                    .into_iter()
+                    .collect(),
+                })
+            }
+        }
+    }
+
+    fn parse_scaled_ui_amount_extension(
+        instruction: &Instruction,
+    ) -> Result<Token2022SecurityInstruction, KoraError> {
+        let scaled_ui_amount_instruction = Self::decode_extension_type::<
+            ScaledUiAmountMintInstruction,
+        >(instruction, "ScaledUiAmount")?;
+
+        match scaled_ui_amount_instruction {
+            ScaledUiAmountMintInstruction::Initialize => {
+                let initialize =
+                    *decode_instruction_data::<
+                        spl_token_2022_interface::extension::scaled_ui_amount::instruction::InitializeInstructionData,
+                    >(&instruction.data[1..])
+                    .map_err(|e| {
+                        KoraError::InvalidTransaction(format!(
+                            "Failed to parse Token-2022 ScaledUiAmount initialize instruction: {}",
+                            sanitize_error!(e)
+                        ))
+                    })?;
+
+                Ok(Token2022SecurityInstruction {
+                    instruction_name: "Token2022 InitializeScaledUiAmountConfig",
+                    extension_type: Some(ExtensionType::ScaledUiAmount),
+                    accounts: Self::instruction_accounts(instruction),
+                    reject_if_fee_payer_in_accounts: false,
+                    update_authority: None,
+                    multisig_signers: vec![],
+                    data_pubkeys: Self::optional_field(
+                        initialize.authority.into(),
+                        "Token2022 InitializeScaledUiAmountConfig authority",
+                        true,
+                    )
+                    .into_iter()
+                    .collect(),
+                })
+            }
+            ScaledUiAmountMintInstruction::UpdateMultiplier => Ok(Token2022SecurityInstruction {
+                instruction_name: "Token2022 UpdateScaledUiAmountConfigMultiplier",
+                extension_type: Some(ExtensionType::ScaledUiAmount),
+                accounts: Self::instruction_accounts(instruction),
+                reject_if_fee_payer_in_accounts: false,
+                update_authority: Some(Self::required_account(
+                    instruction,
+                    1,
+                    "Token2022 UpdateScaledUiAmountConfigMultiplier authority",
+                )?),
+                multisig_signers: Self::extract_multisig_signers(instruction, 2, None),
+                data_pubkeys: vec![],
+            }),
+        }
+    }
+
+    fn parse_pausable_extension(
+        instruction: &Instruction,
+    ) -> Result<Option<Token2022SecurityInstruction>, KoraError> {
+        let pausable_instruction =
+            Self::decode_extension_type::<PausableInstruction>(instruction, "Pausable")?;
+
+        match pausable_instruction {
+            PausableInstruction::Initialize => {
+                let initialize =
+                    *decode_instruction_data::<
+                        spl_token_2022_interface::extension::pausable::instruction::InitializeInstructionData,
+                    >(&instruction.data[1..])
+                    .map_err(|e| {
+                        KoraError::InvalidTransaction(format!(
+                            "Failed to parse Token-2022 Pausable initialize instruction: {}",
+                            sanitize_error!(e)
+                        ))
+                    })?;
+
+                Ok(Some(Token2022SecurityInstruction {
+                    instruction_name: "Token2022 InitializePausable",
+                    extension_type: Some(ExtensionType::Pausable),
+                    accounts: Self::instruction_accounts(instruction),
+                    reject_if_fee_payer_in_accounts: false,
+                    update_authority: None,
+                    multisig_signers: vec![],
+                    data_pubkeys: vec![Token2022SecurityField {
+                        context: "Token2022 InitializePausable authority",
+                        pubkey: initialize.authority,
+                        plants_extension_authority: true,
+                    }],
+                }))
+            }
+            PausableInstruction::Pause | PausableInstruction::Resume => Ok(None),
+        }
+    }
+
+    fn decode_extension_type<T>(instruction: &Instruction, name: &str) -> Result<T, KoraError>
+    where
+        T: TryFrom<u8>,
+    {
+        if instruction.data.len() < 2 {
+            return Err(KoraError::InvalidTransaction(format!(
+                "Failed to parse Token-2022 {name} instruction"
+            )));
+        }
+
+        decode_instruction_type::<T>(&instruction.data[1..]).map_err(|e| {
+            KoraError::InvalidTransaction(format!(
+                "Failed to parse Token-2022 {name} instruction: {}",
+                sanitize_error!(e)
+            ))
+        })
+    }
+
+    fn optional_field(
+        pubkey: Option<Pubkey>,
+        context: &'static str,
+        plants_extension_authority: bool,
+    ) -> Option<Token2022SecurityField> {
+        pubkey.map(|pubkey| Token2022SecurityField { context, pubkey, plants_extension_authority })
+    }
+
+    fn required_account(
+        instruction: &Instruction,
+        index: usize,
+        context: &'static str,
+    ) -> Result<Pubkey, KoraError> {
+        instruction.accounts.get(index).map(|account| account.pubkey).ok_or_else(|| {
+            KoraError::InvalidTransaction(format!("{context} is missing the required account meta"))
+        })
+    }
+
+    fn extract_multisig_signers(
+        instruction: &Instruction,
+        start: usize,
+        end: Option<usize>,
+    ) -> Vec<Pubkey> {
+        let end = end.unwrap_or(instruction.accounts.len());
+        instruction
+            .accounts
+            .iter()
+            .skip(start)
+            .take(end.saturating_sub(start))
+            .map(|account| account.pubkey)
+            .collect()
+    }
+
+    fn instruction_accounts(instruction: &Instruction) -> Vec<Pubkey> {
+        instruction.accounts.iter().map(|account| account.pubkey).collect()
+    }
+
+    fn unsupported_fee_payer_account_check(
+        instruction: &Instruction,
+        instruction_name: &'static str,
+    ) -> Token2022SecurityInstruction {
+        Token2022SecurityInstruction {
+            instruction_name,
+            extension_type: None,
+            accounts: Self::instruction_accounts(instruction),
+            reject_if_fee_payer_in_accounts: true,
+            update_authority: None,
+            multisig_signers: vec![],
+            data_pubkeys: vec![],
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use solana_sdk::instruction::AccountMeta;
+
+    #[test]
+    fn test_parse_metadata_pointer_initialize_security_fields() {
+        let mint = Pubkey::new_unique();
+        let authority = Pubkey::new_unique();
+        let metadata_address = Pubkey::new_unique();
+
+        let instruction =
+            spl_token_2022_interface::extension::metadata_pointer::instruction::initialize(
+                &spl_token_2022_interface::id(),
+                &mint,
+                Some(authority),
+                Some(metadata_address),
+            )
+            .unwrap();
+
+        let parsed = Token2022SecurityParser::parse(&[instruction]).unwrap();
+        assert_eq!(parsed.len(), 1);
+        assert_eq!(parsed[0].instruction_name, "Token2022 InitializeMetadataPointer");
+        assert_eq!(parsed[0].extension_type, Some(ExtensionType::MetadataPointer));
+        assert_eq!(
+            parsed[0].planted_fee_payer_authority(&authority).map(|field| field.context),
+            Some("Token2022 InitializeMetadataPointer authority")
+        );
+        assert!(parsed[0].data_pubkeys.iter().any(|field| field.pubkey == metadata_address
+            && field.context == "Token2022 InitializeMetadataPointer metadataAddress"));
+    }
+
+    #[test]
+    fn test_parse_transfer_fee_withdraw_from_accounts_uses_only_signer_slice() {
+        let authority = Pubkey::new_unique();
+        let signer = Pubkey::new_unique();
+        let source_1 = Pubkey::new_unique();
+        let source_2 = Pubkey::new_unique();
+        let mut data = TokenInstruction::TransferFeeExtension.pack();
+        spl_token_2022_interface::extension::transfer_fee::instruction::TransferFeeInstruction::WithdrawWithheldTokensFromAccounts {
+            num_token_accounts: 2,
+        }
+        .pack(&mut data);
+
+        let instruction = Instruction {
+            program_id: spl_token_2022_interface::id(),
+            accounts: vec![
+                AccountMeta::new(Pubkey::new_unique(), false),
+                AccountMeta::new(Pubkey::new_unique(), false),
+                AccountMeta::new_readonly(authority, false),
+                AccountMeta::new_readonly(signer, true),
+                AccountMeta::new(source_1, false),
+                AccountMeta::new(source_2, false),
+            ],
+            data,
+        };
+
+        let parsed = Token2022SecurityParser::parse(&[instruction]).unwrap();
+        assert_eq!(parsed.len(), 1);
+        assert_eq!(
+            parsed[0].update_authority,
+            Some(authority),
+            "authority should come from the dedicated authority account"
+        );
+        assert_eq!(
+            parsed[0].multisig_signers,
+            vec![signer],
+            "source accounts should not be treated as multisig signers"
+        );
+    }
+}

--- a/crates/lib/src/transaction/versioned_transaction.rs
+++ b/crates/lib/src/transaction/versioned_transaction.rs
@@ -27,7 +27,7 @@ use crate::{
     transaction::{
         instruction_util::IxUtils, ParsedALTInstructionData, ParsedALTInstructionType,
         ParsedSPLInstructionData, ParsedSPLInstructionType, ParsedSystemInstructionData,
-        ParsedSystemInstructionType,
+        ParsedSystemInstructionType, Token2022SecurityInstruction, Token2022SecurityParser,
     },
     validator::transaction_validator::TransactionValidator,
     CacheUtil,
@@ -57,6 +57,8 @@ pub struct VersionedTransactionResolved {
     // Parsed ALT instructions by type (None if not parsed yet)
     parsed_alt_instructions:
         Option<HashMap<ParsedALTInstructionType, Vec<ParsedALTInstructionData>>>,
+
+    parsed_token2022_security_instructions: Option<Vec<Token2022SecurityInstruction>>,
 }
 
 impl Deref for VersionedTransactionResolved {
@@ -103,6 +105,7 @@ impl VersionedTransactionResolved {
             parsed_system_instructions: None,
             parsed_spl_instructions: None,
             parsed_alt_instructions: None,
+            parsed_token2022_security_instructions: None,
         };
 
         // 1. Resolve lookup table addresses based on transaction type
@@ -153,6 +156,7 @@ impl VersionedTransactionResolved {
             parsed_system_instructions: None,
             parsed_spl_instructions: None,
             parsed_alt_instructions: None,
+            parsed_token2022_security_instructions: None,
         })
     }
 
@@ -252,6 +256,21 @@ impl VersionedTransactionResolved {
 
         self.parsed_alt_instructions.as_ref().ok_or_else(|| {
             KoraError::SerializationError("Parsed ALT instructions not found".to_string())
+        })
+    }
+
+    pub fn get_or_parse_token2022_security_instructions(
+        &mut self,
+    ) -> Result<&Vec<Token2022SecurityInstruction>, KoraError> {
+        if self.parsed_token2022_security_instructions.is_none() {
+            self.parsed_token2022_security_instructions =
+                Some(Token2022SecurityParser::parse(&self.all_instructions)?);
+        }
+
+        self.parsed_token2022_security_instructions.as_ref().ok_or_else(|| {
+            KoraError::SerializationError(
+                "Parsed Token-2022 security instructions not found".to_string(),
+            )
         })
     }
 }

--- a/crates/lib/src/validator/config_validator.rs
+++ b/crates/lib/src/validator/config_validator.rs
@@ -2084,6 +2084,8 @@ mod tests {
                         allow_initialize_mint: true,
                         allow_initialize_account: true,
                         allow_initialize_multisig: true,
+                        allow_initialize_extension_authority: true,
+                        allow_update_extension_authority: true,
                         allow_freeze_account: true,
                         allow_thaw_account: true,
                     },

--- a/crates/lib/src/validator/transaction_validator.rs
+++ b/crates/lib/src/validator/transaction_validator.rs
@@ -138,7 +138,7 @@ impl TransactionValidator {
         self.validate_require_one_of_programs(transaction_resolved)?;
         self.validate_transfer_amounts(config, transaction_resolved, rpc_client).await?;
         self.validate_disallowed_accounts(transaction_resolved)?;
-        self.validate_fee_payer_usage(transaction_resolved)?;
+        self.validate_fee_payer_usage(config, transaction_resolved)?;
 
         Ok(())
     }
@@ -258,6 +258,7 @@ impl TransactionValidator {
 
     fn validate_fee_payer_usage(
         &self,
+        config: &Config,
         transaction_resolved: &mut VersionedTransactionResolved,
     ) -> Result<(), KoraError> {
         self.validate_ata_create_instructions(transaction_resolved)?;
@@ -451,12 +452,6 @@ impl TransactionValidator {
                 && (*payer == self.fee_payer_pubkey || *owner == self.fee_payer_pubkey) ,
             "Token2022 Reallocate is not allowed when involving fee payer");
 
-        validate_token2022!(self, spl_instructions, SplTokenInitializePausable,
-            ParsedSPLInstructionData::SplTokenInitializePausable { authority } =>
-            *authority == self.fee_payer_pubkey,
-            self.fee_payer_policy.token_2022.allow_initialize_mint,
-            "Fee payer cannot be set as Token2022 pausable authority");
-
         validate_token2022!(self, spl_instructions, SplTokenPause,
             ParsedSPLInstructionData::SplTokenPause { authority, multisig_signers } =>
             (*authority == self.fee_payer_pubkey
@@ -471,10 +466,7 @@ impl TransactionValidator {
             self.fee_payer_policy.token_2022.allow_thaw_account,
             "Fee payer cannot be used for Token2022 Resume");
 
-        validate_token2022!(self, spl_instructions, SplTokenUnknownExtension,
-            ParsedSPLInstructionData::SplTokenUnknownExtension { accounts } =>
-            accounts.contains(&self.fee_payer_pubkey),
-            "Fee payer cannot be an account in an unsupported Token-2022 extension instruction");
+        self.validate_token2022_security_policies(config, transaction_resolved)?;
 
         Ok(())
     }
@@ -601,37 +593,13 @@ impl TransactionValidator {
                         )?;
                     }
                 }
-                ParsedSPLInstructionData::SplTokenInitializePausable { authority } => {
-                    self.validate_disallowed_instruction_data_account(
-                        authority,
-                        "Token2022 InitializePausable authority",
-                    )?;
-                }
-                ParsedSPLInstructionData::SplTokenInitializeTransferHook {
-                    authority,
-                    program_id,
-                } => {
-                    if let Some(authority) = authority {
-                        self.validate_disallowed_instruction_data_account(
-                            authority,
-                            "Token2022 InitializeTransferHook authority",
-                        )?;
-                    }
-                    if let Some(program_id) = program_id {
-                        self.validate_disallowed_instruction_data_account(
-                            program_id,
-                            "Token2022 InitializeTransferHook program_id",
-                        )?;
-                    }
-                }
-                ParsedSPLInstructionData::SplTokenTransferHookUpdate {
-                    program_id: Some(program_id),
-                    ..
-                } => self.validate_disallowed_instruction_data_account(
-                    program_id,
-                    "Token2022 TransferHookUpdate program_id",
-                )?,
                 _ => {}
+            }
+        }
+
+        for instruction in transaction_resolved.get_or_parse_token2022_security_instructions()? {
+            for field in &instruction.data_pubkeys {
+                self.validate_disallowed_instruction_data_account(&field.pubkey, field.context)?;
             }
         }
 
@@ -654,6 +622,52 @@ impl TransactionValidator {
 
     pub fn is_disallowed_account(&self, account: &Pubkey) -> bool {
         self.disallowed_accounts.contains(account)
+    }
+
+    fn validate_token2022_security_policies(
+        &self,
+        config: &Config,
+        transaction_resolved: &mut VersionedTransactionResolved,
+    ) -> Result<(), KoraError> {
+        for instruction in transaction_resolved.get_or_parse_token2022_security_instructions()? {
+            if instruction.reject_if_fee_payer_in_accounts
+                && instruction.accounts.contains(&self.fee_payer_pubkey)
+            {
+                return Err(KoraError::InvalidTransaction(format!(
+                    "Fee payer cannot be an account in {}",
+                    instruction.instruction_name
+                )));
+            }
+
+            if let Some(extension_type) = instruction.extension_type {
+                if config.validation.token_2022.is_mint_extension_blocked(extension_type) {
+                    return Err(KoraError::InvalidTransaction(format!(
+                        "Token2022 instruction '{}' is not allowed because extension '{extension_type:?}' is blocked",
+                        instruction.instruction_name
+                    )));
+                }
+            }
+
+            if instruction.uses_fee_payer_as_update_authority(&self.fee_payer_pubkey)
+                && !self.fee_payer_policy.token_2022.allow_update_extension_authority
+            {
+                return Err(KoraError::InvalidTransaction(format!(
+                    "Fee payer cannot be used as the current Token2022 extension authority for '{}'",
+                    instruction.instruction_name
+                )));
+            }
+
+            if let Some(field) = instruction.planted_fee_payer_authority(&self.fee_payer_pubkey) {
+                if !self.fee_payer_policy.token_2022.allow_initialize_extension_authority {
+                    return Err(KoraError::InvalidTransaction(format!(
+                        "Fee payer cannot be planted as a Token2022 extension authority via {}",
+                        field.context
+                    )));
+                }
+            }
+        }
+
+        Ok(())
     }
 
     async fn calculate_total_outflow(
@@ -4511,7 +4525,7 @@ mod tests {
 
         let result = validator.validate_transaction(config, &mut transaction, &rpc_client).await;
         assert!(
-            matches!(result, Err(KoraError::InvalidTransaction(ref msg)) if msg.contains("Token2022 pausable authority")),
+            matches!(result, Err(KoraError::InvalidTransaction(ref msg)) if msg.contains("Token2022 InitializePausable authority")),
             "Expected rejection when fee payer is assigned as pausable authority, got: {result:?}"
         );
     }
@@ -4525,6 +4539,7 @@ mod tests {
 
         let mut config = get_config().unwrap().clone();
         config.validation.token_2022.transfer_hook_policy = TransferHookPolicy::DenyAll;
+        config.validation.fee_payer_policy.token_2022.allow_update_extension_authority = true;
         let validator = TransactionValidator::new(&config, fee_payer.pubkey()).unwrap();
         let mint = Pubkey::new_unique();
         let program_id = Pubkey::new_unique();
@@ -4566,6 +4581,7 @@ mod tests {
         let mut config = get_config().unwrap().clone();
         config.validation.token_2022.transfer_hook_policy =
             TransferHookPolicy::DenyMutableForDelayedSigning;
+        config.validation.fee_payer_policy.token_2022.allow_update_extension_authority = true;
         let validator = TransactionValidator::new(&config, fee_payer.pubkey()).unwrap();
         let mint = Pubkey::new_unique();
         let program_id = Pubkey::new_unique();
@@ -4629,6 +4645,211 @@ mod tests {
         assert!(
             matches!(result, Err(KoraError::InvalidTransaction(ref msg)) if msg.contains("InitializeTransferHook program_id")),
             "Expected disallowed transfer-hook program id rejection, got: {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_token2022_initialize_transfer_fee_config_rejects_fee_payer_authorities_by_default(
+    ) {
+        let fee_payer = Keypair::new();
+        let mint = Pubkey::new_unique();
+        let rpc_client = RpcMockBuilder::new().build();
+        setup_token2022_config_with_policy(FeePayerPolicy::default());
+
+        let config = get_config().unwrap();
+        let validator = TransactionValidator::new(config, fee_payer.pubkey()).unwrap();
+
+        let ix = spl_token_2022_interface::extension::transfer_fee::instruction::initialize_transfer_fee_config(
+            &spl_token_2022_interface::id(),
+            &mint,
+            Some(&fee_payer.pubkey()),
+            Some(&Pubkey::new_unique()),
+            25,
+            100,
+        )
+        .unwrap();
+
+        let message = VersionedMessage::Legacy(Message::new(&[ix], Some(&fee_payer.pubkey())));
+        let mut transaction =
+            TransactionUtil::new_unsigned_versioned_transaction_resolved(message).unwrap();
+
+        let result = validator.validate_transaction(config, &mut transaction, &rpc_client).await;
+        assert!(
+            matches!(result, Err(KoraError::InvalidTransaction(ref msg)) if msg.contains("InitializeTransferFeeConfig transferFeeConfigAuthority")),
+            "Expected rejection when fee payer is planted as transfer-fee authority, got: {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_token2022_initialize_transfer_fee_config_disallowed_withdraw_authority_rejected()
+    {
+        let fee_payer = Keypair::new();
+        let mint = Pubkey::new_unique();
+        let disallowed_authority = Pubkey::new_unique();
+        let rpc_client = RpcMockBuilder::new().build();
+        setup_config_with_policy_and_disallowed(
+            FeePayerPolicy::default(),
+            vec![spl_token_2022_interface::id().to_string()],
+            vec![disallowed_authority.to_string()],
+        );
+
+        let config = get_config().unwrap();
+        let validator = TransactionValidator::new(config, fee_payer.pubkey()).unwrap();
+
+        let ix = spl_token_2022_interface::extension::transfer_fee::instruction::initialize_transfer_fee_config(
+            &spl_token_2022_interface::id(),
+            &mint,
+            Some(&Pubkey::new_unique()),
+            Some(&disallowed_authority),
+            25,
+            100,
+        )
+        .unwrap();
+
+        let message = VersionedMessage::Legacy(Message::new(&[ix], Some(&fee_payer.pubkey())));
+        let mut transaction =
+            TransactionUtil::new_unsigned_versioned_transaction_resolved(message).unwrap();
+
+        let result = validator.validate_transaction(config, &mut transaction, &rpc_client).await;
+        assert!(
+            matches!(result, Err(KoraError::InvalidTransaction(ref msg)) if msg.contains("InitializeTransferFeeConfig withdrawWithheldAuthority")),
+            "Expected disallowed withdraw authority rejection, got: {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_token2022_update_metadata_pointer_rejects_fee_payer_authority_by_default() {
+        let fee_payer = Keypair::new();
+        let mint = Pubkey::new_unique();
+        let metadata_address = Pubkey::new_unique();
+        let rpc_client = RpcMockBuilder::new().build();
+        setup_token2022_config_with_policy(FeePayerPolicy::default());
+
+        let config = get_config().unwrap();
+        let validator = TransactionValidator::new(config, fee_payer.pubkey()).unwrap();
+
+        let ix = spl_token_2022_interface::extension::metadata_pointer::instruction::update(
+            &spl_token_2022_interface::id(),
+            &mint,
+            &fee_payer.pubkey(),
+            &[],
+            Some(metadata_address),
+        )
+        .unwrap();
+
+        let message = VersionedMessage::Legacy(Message::new(&[ix], Some(&fee_payer.pubkey())));
+        let mut transaction =
+            TransactionUtil::new_unsigned_versioned_transaction_resolved(message).unwrap();
+
+        let result = validator.validate_transaction(config, &mut transaction, &rpc_client).await;
+        assert!(
+            matches!(result, Err(KoraError::InvalidTransaction(ref msg)) if msg.contains("current Token2022 extension authority")),
+            "Expected rejection when fee payer updates metadata pointer, got: {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_token2022_update_metadata_pointer_allowed_when_extension_update_policy_enabled() {
+        let fee_payer = Keypair::new();
+        let mint = Pubkey::new_unique();
+        let metadata_address = Pubkey::new_unique();
+        let rpc_client = RpcMockBuilder::new().build();
+        let mut policy = FeePayerPolicy::default();
+        policy.token_2022.allow_update_extension_authority = true;
+        setup_token2022_config_with_policy(policy);
+
+        let config = get_config().unwrap();
+        let validator = TransactionValidator::new(config, fee_payer.pubkey()).unwrap();
+
+        let ix = spl_token_2022_interface::extension::metadata_pointer::instruction::update(
+            &spl_token_2022_interface::id(),
+            &mint,
+            &fee_payer.pubkey(),
+            &[],
+            Some(metadata_address),
+        )
+        .unwrap();
+
+        let message = VersionedMessage::Legacy(Message::new(&[ix], Some(&fee_payer.pubkey())));
+        let mut transaction =
+            TransactionUtil::new_unsigned_versioned_transaction_resolved(message).unwrap();
+
+        let result = validator.validate_transaction(config, &mut transaction, &rpc_client).await;
+        assert!(
+            result.is_ok(),
+            "Explicit extension update opt-in should allow metadata pointer updates: {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_token2022_initialize_mint_close_authority_rejects_disallowed_new_authority() {
+        let fee_payer = Keypair::new();
+        let mint = Pubkey::new_unique();
+        let disallowed_authority = Pubkey::new_unique();
+        let rpc_client = RpcMockBuilder::new().build();
+        setup_config_with_policy_and_disallowed(
+            FeePayerPolicy::default(),
+            vec![spl_token_2022_interface::id().to_string()],
+            vec![disallowed_authority.to_string()],
+        );
+
+        let config = get_config().unwrap();
+        let validator = TransactionValidator::new(config, fee_payer.pubkey()).unwrap();
+
+        let ix = spl_token_2022_interface::instruction::initialize_mint_close_authority(
+            &spl_token_2022_interface::id(),
+            &mint,
+            Some(&disallowed_authority),
+        )
+        .unwrap();
+
+        let message = VersionedMessage::Legacy(Message::new(&[ix], Some(&fee_payer.pubkey())));
+        let mut transaction =
+            TransactionUtil::new_unsigned_versioned_transaction_resolved(message).unwrap();
+
+        let result = validator.validate_transaction(config, &mut transaction, &rpc_client).await;
+        assert!(
+            matches!(result, Err(KoraError::InvalidTransaction(ref msg)) if msg.contains("InitializeMintCloseAuthority newAuthority")),
+            "Expected disallowed mint close authority rejection, got: {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_token2022_initialize_metadata_pointer_rejects_blocked_extension() {
+        let fee_payer = Keypair::new();
+        let mint = Pubkey::new_unique();
+        let metadata_address = Pubkey::new_unique();
+        let rpc_client = RpcMockBuilder::new().build();
+        let mut config = ConfigMockBuilder::new().build();
+        config.validation.allowed_programs.push(spl_token_2022_interface::id().to_string());
+        config.validation.token_2022.blocked_mint_extensions = vec!["metadata_pointer".to_string()];
+        config.validation.token_2022.initialize().unwrap();
+        let _config_guard = setup_config_mock(config.clone());
+
+        let validator = TransactionValidator::new(&config, fee_payer.pubkey()).unwrap();
+
+        let ix = spl_token_2022_interface::extension::metadata_pointer::instruction::initialize(
+            &spl_token_2022_interface::id(),
+            &mint,
+            Some(Pubkey::new_unique()),
+            Some(metadata_address),
+        )
+        .unwrap();
+
+        let message = VersionedMessage::Legacy(Message::new(&[ix], Some(&fee_payer.pubkey())));
+        let mut transaction =
+            TransactionUtil::new_unsigned_versioned_transaction_resolved(message).unwrap();
+
+        let result = validator.validate_transaction(&config, &mut transaction, &rpc_client).await;
+        assert!(
+            matches!(result, Err(KoraError::InvalidTransaction(ref msg)) if msg.contains("extension 'MetadataPointer' is blocked")),
+            "Expected blocked metadata pointer extension rejection, got: {result:?}"
         );
     }
 

--- a/crates/lib/src/validator/transaction_validator.rs
+++ b/crates/lib/src/validator/transaction_validator.rs
@@ -10,7 +10,7 @@ use crate::{
     transaction::{
         ParsedALTInstructionData, ParsedALTInstructionType, ParsedSPLInstructionData,
         ParsedSPLInstructionType, ParsedSystemInstructionData, ParsedSystemInstructionType,
-        VersionedTransactionResolved,
+        Token2022AccountUsagePolicy, VersionedTransactionResolved,
     },
 };
 use solana_client::nonblocking::rpc_client::RpcClient;
@@ -466,7 +466,7 @@ impl TransactionValidator {
             self.fee_payer_policy.token_2022.allow_thaw_account,
             "Fee payer cannot be used for Token2022 Resume");
 
-        self.validate_token2022_security_policies(config, transaction_resolved)?;
+        self.validate_token2022_extension_security(config, transaction_resolved)?;
 
         Ok(())
     }
@@ -624,14 +624,16 @@ impl TransactionValidator {
         self.disallowed_accounts.contains(account)
     }
 
-    fn validate_token2022_security_policies(
+    fn validate_token2022_extension_security(
         &self,
         config: &Config,
         transaction_resolved: &mut VersionedTransactionResolved,
     ) -> Result<(), KoraError> {
         for instruction in transaction_resolved.get_or_parse_token2022_security_instructions()? {
-            if instruction.reject_if_fee_payer_in_accounts
-                && instruction.accounts.contains(&self.fee_payer_pubkey)
+            if matches!(
+                instruction.account_usage_policy,
+                Token2022AccountUsagePolicy::RejectIfFeePayerPresent
+            ) && instruction.accounts.contains(&self.fee_payer_pubkey)
             {
                 return Err(KoraError::InvalidTransaction(format!(
                     "Fee payer cannot be an account in {}",
@@ -648,7 +650,7 @@ impl TransactionValidator {
                 }
             }
 
-            if instruction.uses_fee_payer_as_update_authority(&self.fee_payer_pubkey)
+            if instruction.uses_fee_payer_as_current_extension_authority(&self.fee_payer_pubkey)
                 && !self.fee_payer_policy.token_2022.allow_update_extension_authority
             {
                 return Err(KoraError::InvalidTransaction(format!(
@@ -657,7 +659,9 @@ impl TransactionValidator {
                 )));
             }
 
-            if let Some(field) = instruction.planted_fee_payer_authority(&self.fee_payer_pubkey) {
+            if let Some(field) =
+                instruction.find_planted_fee_payer_authority(&self.fee_payer_pubkey)
+            {
                 if !self.fee_payer_policy.token_2022.allow_initialize_extension_authority {
                     return Err(KoraError::InvalidTransaction(format!(
                         "Fee payer cannot be planted as a Token2022 extension authority via {}",


### PR DESCRIPTION
## Summary
- add a cached Token-2022 security parser for instruction-data authorities, delegates, and program ids
- enforce disallowed-account checks and fee-payer extension authority policy from the parsed security metadata instead of ad hoc special cases
- expand blocked mint extension support and instruction-time validation for metadata pointer, group pointer, group member pointer, and scaled ui amount extensions
- add regressions covering transfer-fee config, metadata pointer, mint close authority, and the updated transfer-hook / pausable policy interactions

## Test Plan
- cargo test -p kora-lib token2022_ -- --nocapture
- cargo test -p kora-lib token2022_security -- --nocapture
- cargo clippy -p kora-lib --tests -- -D warnings
- just fmt
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/solana-foundation/kora/pull/447" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


## 📊 Unit Test Coverage
![Coverage](https://img.shields.io/badge/coverage-85.4%25-green)

**Unit Test Coverage: 85.4%**

[View Detailed Coverage Report](https://github.com/solana-foundation/kora/actions/runs/24779831042)