### PR TITLE
feat(validator): add loader-v4 fee-payer policy for program deployment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3431,6 +3431,7 @@ dependencies = [
  "solana-commitment-config",
  "solana-compute-budget-interface",
  "solana-keychain",
+ "solana-loader-v4-interface",
  "solana-message",
  "solana-program",
  "solana-program-pack",
@@ -6268,6 +6269,21 @@ name = "solana-loader-v3-interface"
 version = "6.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dee44c9b1328c5c712c68966fb8de07b47f3e7bac006e74ddd1bb053d3e46e5d"
+dependencies = [
+ "serde",
+ "serde_bytes",
+ "serde_derive",
+ "solana-instruction",
+ "solana-pubkey",
+ "solana-sdk-ids",
+ "solana-system-interface",
+]
+
+[[package]]
+name = "solana-loader-v4-interface"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4c948b33ff81fa89699911b207059e493defdba9647eaf18f23abdf3674e0fb"
 dependencies = [
  "serde",
  "serde_bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ solana-system-interface = "2.0.0"
 solana-transaction-status-client-types = "3.0.8"
 solana-transaction-status = "3.0.8"
 solana-address-lookup-table-interface = "3.0.0"
+solana-loader-v4-interface = { version = "3.1.0", features = ["bincode", "serde"] }
 solana-program = "3.0.0"
 solana-program-pack = "3.0.0"
 solana-compute-budget-interface = "3.0.0"

--- a/crates/lib/Cargo.toml
+++ b/crates/lib/Cargo.toml
@@ -32,6 +32,7 @@ solana-compute-budget-interface = { workspace = true }
 solana-transaction-status-client-types = { workspace = true }
 solana-transaction-status = { workspace = true }
 solana-address-lookup-table-interface = { workspace = true }
+solana-loader-v4-interface = { workspace = true }
 solana-client = { workspace = true }
 bs58 = { workspace = true }
 bincode = { workspace = true }

--- a/crates/lib/src/config.rs
+++ b/crates/lib/src/config.rs
@@ -69,7 +69,7 @@ impl Default for FeePayerBalanceMetricsConfig {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
 pub enum SplTokenConfig {
     All,
     #[serde(untagged)]

--- a/crates/lib/src/config.rs
+++ b/crates/lib/src/config.rs
@@ -281,19 +281,15 @@ pub struct LoaderV4InstructionPolicy {
     pub allow_write: bool,
     /// Allow fee payer to be the authority in Copy instructions
     pub allow_copy: bool,
-    /// Allow fee payer to be the authority in SetProgramLength instructions.
-    /// When enabled, the recipient must equal the fee payer (or be absent) to prevent drainage
-    /// via shrink-to-zero or over-funded-growth refunds flowing to an attacker's account.
+    /// Allow fee payer to be the authority in SetProgramLength instructions
     pub allow_set_program_length: bool,
     /// Allow fee payer to be the authority in Deploy instructions
     pub allow_deploy: bool,
     /// Allow fee payer to be the authority in Retract instructions
     pub allow_retract: bool,
     /// Allow fee payer to be the current authority in TransferAuthority instructions
-    /// (drainage vector: hands control to a new authority who can then drain)
     pub allow_transfer_authority: bool,
     /// Allow fee payer to be the current authority in Finalize instructions
-    /// (makes program immutable and forwards to a next-version program)
     pub allow_finalize: bool,
 }
 

--- a/crates/lib/src/config.rs
+++ b/crates/lib/src/config.rs
@@ -165,6 +165,7 @@ pub struct FeePayerPolicy {
     pub spl_token: SplTokenInstructionPolicy,
     pub token_2022: Token2022InstructionPolicy,
     pub alt: AltInstructionPolicy,
+    pub loader_v4: LoaderV4InstructionPolicy,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema, Default)]
@@ -271,6 +272,29 @@ pub struct AltInstructionPolicy {
     pub allow_deactivate: bool,
     /// Allow fee payer to be authority in ALT CloseLookupTable instructions
     pub allow_close: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema, Default)]
+#[serde(default)]
+pub struct LoaderV4InstructionPolicy {
+    /// Allow fee payer to be the authority in Write instructions
+    pub allow_write: bool,
+    /// Allow fee payer to be the authority in Copy instructions
+    pub allow_copy: bool,
+    /// Allow fee payer to be the authority in SetProgramLength instructions.
+    /// When enabled, the recipient must equal the fee payer (or be absent) to prevent drainage
+    /// via shrink-to-zero or over-funded-growth refunds flowing to an attacker's account.
+    pub allow_set_program_length: bool,
+    /// Allow fee payer to be the authority in Deploy instructions
+    pub allow_deploy: bool,
+    /// Allow fee payer to be the authority in Retract instructions
+    pub allow_retract: bool,
+    /// Allow fee payer to be the current authority in TransferAuthority instructions
+    /// (drainage vector: hands control to a new authority who can then drain)
+    pub allow_transfer_authority: bool,
+    /// Allow fee payer to be the current authority in Finalize instructions
+    /// (makes program immutable and forwards to a next-version program)
+    pub allow_finalize: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema, Default)]

--- a/crates/lib/src/constant.rs
+++ b/crates/lib/src/constant.rs
@@ -37,6 +37,10 @@ pub const STAKE_PROGRAM_ID: Pubkey = pubkey!("Stake11111111111111111111111111111
 pub const BPF_LOADER_UPGRADEABLE_PROGRAM_ID: Pubkey =
     pubkey!("BPFLoaderUpgradeab1e11111111111111111111111");
 
+// Loader-v4 — successor to BPF Loader Upgradeable (loader-v3). Has a dedicated fee-payer parser
+// in Kora; policy enforcement lives in `LoaderV4InstructionPolicy`.
+pub const LOADER_V4_PROGRAM_ID: Pubkey = pubkey!("LoaderV411111111111111111111111111111111111");
+
 // Metrics
 pub const DEFAULT_METRICS_ENDPOINT: &str = "/metrics";
 pub const DEFAULT_METRICS_PORT: u16 = 8080;
@@ -278,5 +282,56 @@ pub mod instruction_indexes {
         pub const LOOKUP_TABLE_ACCOUNT_INDEX: usize = 0;
         pub const LOOKUP_TABLE_AUTHORITY_INDEX: usize = 1;
         pub const RECIPIENT_INDEX: usize = 2;
+    }
+
+    // Loader-v4 instruction layouts.
+    // Source: solana-loader-v4-interface::instruction::LoaderV4Instruction
+    pub mod loader_v4_write {
+        pub const REQUIRED_NUMBER_OF_ACCOUNTS: usize = 2;
+        pub const PROGRAM_INDEX: usize = 0;
+        pub const AUTHORITY_INDEX: usize = 1;
+    }
+
+    pub mod loader_v4_copy {
+        pub const REQUIRED_NUMBER_OF_ACCOUNTS: usize = 3;
+        pub const DESTINATION_PROGRAM_INDEX: usize = 0;
+        pub const AUTHORITY_INDEX: usize = 1;
+        pub const SOURCE_PROGRAM_INDEX: usize = 2;
+    }
+
+    pub mod loader_v4_set_program_length {
+        pub const MIN_REQUIRED_NUMBER_OF_ACCOUNTS: usize = 2;
+        pub const REQUIRED_NUMBER_OF_ACCOUNTS_WITH_RECIPIENT: usize = 3;
+        pub const PROGRAM_INDEX: usize = 0;
+        pub const AUTHORITY_INDEX: usize = 1;
+        pub const OPTIONAL_RECIPIENT_INDEX: usize = 2;
+    }
+
+    pub mod loader_v4_deploy {
+        pub const MIN_REQUIRED_NUMBER_OF_ACCOUNTS: usize = 2;
+        pub const REQUIRED_NUMBER_OF_ACCOUNTS_WITH_SOURCE: usize = 3;
+        pub const PROGRAM_INDEX: usize = 0;
+        pub const AUTHORITY_INDEX: usize = 1;
+        pub const OPTIONAL_SOURCE_PROGRAM_INDEX: usize = 2;
+    }
+
+    pub mod loader_v4_retract {
+        pub const REQUIRED_NUMBER_OF_ACCOUNTS: usize = 2;
+        pub const PROGRAM_INDEX: usize = 0;
+        pub const AUTHORITY_INDEX: usize = 1;
+    }
+
+    pub mod loader_v4_transfer_authority {
+        pub const REQUIRED_NUMBER_OF_ACCOUNTS: usize = 3;
+        pub const PROGRAM_INDEX: usize = 0;
+        pub const CURRENT_AUTHORITY_INDEX: usize = 1;
+        pub const NEW_AUTHORITY_INDEX: usize = 2;
+    }
+
+    pub mod loader_v4_finalize {
+        pub const REQUIRED_NUMBER_OF_ACCOUNTS: usize = 3;
+        pub const PROGRAM_INDEX: usize = 0;
+        pub const CURRENT_AUTHORITY_INDEX: usize = 1;
+        pub const NEXT_VERSION_INDEX: usize = 2;
     }
 }

--- a/crates/lib/src/oracle/oracle.rs
+++ b/crates/lib/src/oracle/oracle.rs
@@ -12,6 +12,7 @@ use tokio::time::sleep;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[cfg_attr(feature = "docs", derive(utoipa::ToSchema))]
 pub struct TokenPrice {
+    #[cfg_attr(feature = "docs", schema(value_type = String))]
     pub price: Decimal,
     pub confidence: f64,
     pub source: PriceSource,

--- a/crates/lib/src/rpc_server/openapi/docs.rs
+++ b/crates/lib/src/rpc_server/openapi/docs.rs
@@ -1,5 +1,9 @@
 use crate::{
-    config::{EnabledMethods, FeePayerPolicy, ValidationConfig},
+    config::{
+        AltInstructionPolicy, EnabledMethods, FeePayerPolicy, LoaderV4InstructionPolicy,
+        NonceInstructionPolicy, SplTokenConfig, SplTokenInstructionPolicy, SystemInstructionPolicy,
+        Token2022Config, Token2022InstructionPolicy, TransferHookPolicy, ValidationConfig,
+    },
     fee::price::{PriceConfig, PriceModel},
     oracle::oracle::{PriceSource, TokenPrice},
 };
@@ -43,6 +47,15 @@ const JSON_CONTENT_TYPE: &str = "application/json";
     components(schemas(
         ValidationConfig,
         FeePayerPolicy,
+        SystemInstructionPolicy,
+        NonceInstructionPolicy,
+        SplTokenInstructionPolicy,
+        Token2022InstructionPolicy,
+        AltInstructionPolicy,
+        LoaderV4InstructionPolicy,
+        SplTokenConfig,
+        Token2022Config,
+        TransferHookPolicy,
         EnabledMethods,
         PriceConfig,
         PriceModel,

--- a/crates/lib/src/rpc_server/openapi/spec/combined_api.json
+++ b/crates/lib/src/rpc_server/openapi/spec/combined_api.json
@@ -14,6 +14,155 @@
     }
   ],
   "paths": {
+    "/estimateBundleFee": {
+      "summary": "estimateBundleFee",
+      "post": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "jsonrpc",
+                  "id",
+                  "method",
+                  "params"
+                ],
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "description": "An ID to identify the request.",
+                    "enum": [
+                      "test-account"
+                    ]
+                  },
+                  "jsonrpc": {
+                    "type": "string",
+                    "description": "The version of the JSON-RPC protocol.",
+                    "enum": [
+                      "2.0"
+                    ]
+                  },
+                  "method": {
+                    "type": "string",
+                    "description": "The name of the method to invoke.",
+                    "enum": [
+                      "estimateBundleFee"
+                    ]
+                  },
+                  "params": {
+                    "type": "object",
+                    "required": [
+                      "transactions"
+                    ],
+                    "properties": {
+                      "fee_token": {
+                        "type": "string",
+                        "nullable": true
+                      },
+                      "sig_verify": {
+                        "type": "boolean",
+                        "description": "Whether to verify signatures during simulation (defaults to false)"
+                      },
+                      "sign_only_indices": {
+                        "type": "array",
+                        "items": {
+                          "type": "integer",
+                          "minimum": 0
+                        },
+                        "description": "Optional indices of transactions to estimate fees for (defaults to all if not specified)",
+                        "nullable": true
+                      },
+                      "signer_key": {
+                        "type": "string",
+                        "description": "Optional signer signer_key to ensure consistency across related RPC calls",
+                        "nullable": true
+                      },
+                      "transactions": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "description": "Array of base64-encoded transactions"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "fee_in_lamports",
+                    "signer_pubkey",
+                    "payment_address"
+                  ],
+                  "properties": {
+                    "fee_in_lamports": {
+                      "type": "integer",
+                      "format": "int64",
+                      "minimum": 0
+                    },
+                    "fee_in_token": {
+                      "type": "integer",
+                      "format": "int64",
+                      "nullable": true,
+                      "minimum": 0
+                    },
+                    "payment_address": {
+                      "type": "string",
+                      "description": "Public key of the payment destination"
+                    },
+                    "signer_pubkey": {
+                      "type": "string",
+                      "description": "Public key of the signer used for fee estimation (for client consistency)"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Exceeded rate limit.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/estimateTransactionFee": {
       "summary": "estimateTransactionFee",
       "post": {
@@ -52,25 +201,28 @@
                   },
                   "params": {
                     "type": "object",
+                    "description": "Request payload for estimating the fee of a transaction.\n\nThis endpoint calculates the required fee for a given transaction based on current\noracle prices and Kora's configuration. It can estimate fees in native SOL (lamports)\nand in a specific supported SPL token if `fee_token` is provided.",
                     "required": [
                       "transaction"
                     ],
                     "properties": {
                       "fee_token": {
                         "type": "string",
+                        "description": "Optional mint address of the SPL token to calculate the fee in. If omitted, returns only the lamport fee.",
                         "nullable": true
                       },
                       "sig_verify": {
                         "type": "boolean",
-                        "description": "Whether to verify signatures during simulation (defaults to true)"
+                        "description": "Whether to verify signatures during simulation (defaults to false)"
                       },
                       "signer_key": {
                         "type": "string",
-                        "description": "Optional signer signer_key to ensure consistency across related RPC calls",
+                        "description": "Optional public key of the signer to ensure consistency",
                         "nullable": true
                       },
                       "transaction": {
-                        "type": "string"
+                        "type": "string",
+                        "description": "Base64-encoded serialized transaction"
                       }
                     }
                   }
@@ -87,6 +239,7 @@
               "application/json": {
                 "schema": {
                   "type": "object",
+                  "description": "Response payload containing the estimated transaction fee.",
                   "required": [
                     "fee_in_lamports",
                     "signer_pubkey",
@@ -96,16 +249,19 @@
                     "fee_in_lamports": {
                       "type": "integer",
                       "format": "int64",
+                      "description": "The exact fee required in native SOL (lamports)",
                       "minimum": 0
                     },
                     "fee_in_token": {
-                      "type": "number",
-                      "format": "double",
-                      "nullable": true
+                      "type": "integer",
+                      "format": "int64",
+                      "description": "The estimated fee in the requested SPL token (if `fee_token` was provided in the request)",
+                      "nullable": true,
+                      "minimum": 0
                     },
                     "payment_address": {
                       "type": "string",
-                      "description": "Public key of the payment destination"
+                      "description": "Public key of the payment destination where the fee should be sent"
                     },
                     "signer_pubkey": {
                       "type": "string",
@@ -541,6 +697,245 @@
         }
       }
     },
+    "/getVersion": {
+      "summary": "getVersion",
+      "post": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "jsonrpc",
+                  "id",
+                  "method"
+                ],
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "description": "An ID to identify the request.",
+                    "enum": [
+                      "test-account"
+                    ]
+                  },
+                  "jsonrpc": {
+                    "type": "string",
+                    "description": "The version of the JSON-RPC protocol.",
+                    "enum": [
+                      "2.0"
+                    ]
+                  },
+                  "method": {
+                    "type": "string",
+                    "description": "The name of the method to invoke.",
+                    "enum": [
+                      "getVersion"
+                    ]
+                  }
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "version"
+                  ],
+                  "properties": {
+                    "version": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Exceeded rate limit.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/signAndSendBundle": {
+      "summary": "signAndSendBundle",
+      "post": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "jsonrpc",
+                  "id",
+                  "method",
+                  "params"
+                ],
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "description": "An ID to identify the request.",
+                    "enum": [
+                      "test-account"
+                    ]
+                  },
+                  "jsonrpc": {
+                    "type": "string",
+                    "description": "The version of the JSON-RPC protocol.",
+                    "enum": [
+                      "2.0"
+                    ]
+                  },
+                  "method": {
+                    "type": "string",
+                    "description": "The name of the method to invoke.",
+                    "enum": [
+                      "signAndSendBundle"
+                    ]
+                  },
+                  "params": {
+                    "type": "object",
+                    "required": [
+                      "transactions"
+                    ],
+                    "properties": {
+                      "sig_verify": {
+                        "type": "boolean",
+                        "description": "Whether to verify signatures during simulation (defaults to false)"
+                      },
+                      "sign_only_indices": {
+                        "type": "array",
+                        "items": {
+                          "type": "integer",
+                          "minimum": 0
+                        },
+                        "description": "Optional indices of transactions to sign (defaults to all if not specified)",
+                        "nullable": true
+                      },
+                      "signer_key": {
+                        "type": "string",
+                        "description": "Optional signer key to ensure consistency across related RPC calls",
+                        "nullable": true
+                      },
+                      "transactions": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "description": "Array of base64-encoded transactions"
+                      },
+                      "user_id": {
+                        "type": "string",
+                        "description": "Optional user ID for usage tracking (required when pricing is free and usage tracking is enabled)",
+                        "nullable": true
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "signed_transactions",
+                    "signer_pubkey",
+                    "bundle_uuid"
+                  ],
+                  "properties": {
+                    "bundle_uuid": {
+                      "type": "string",
+                      "description": "Jito bundle UUID"
+                    },
+                    "signed_transactions": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      },
+                      "description": "Array of base64-encoded signed transactions"
+                    },
+                    "signer_pubkey": {
+                      "type": "string",
+                      "description": "Public key of the signer used (for client consistency)"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Exceeded rate limit.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/signAndSendTransaction": {
       "summary": "signAndSendTransaction",
       "post": {
@@ -585,7 +980,7 @@
                     "properties": {
                       "sig_verify": {
                         "type": "boolean",
-                        "description": "Whether to verify signatures during simulation (defaults to true)"
+                        "description": "Whether to verify signatures during simulation (defaults to false)"
                       },
                       "signer_key": {
                         "type": "string",
@@ -594,6 +989,11 @@
                       },
                       "transaction": {
                         "type": "string"
+                      },
+                      "user_id": {
+                        "type": "string",
+                        "description": "Optional user ID for usage tracking (required when pricing is free and usage tracking is enabled)",
+                        "nullable": true
                       }
                     }
                   }
@@ -612,11 +1012,157 @@
                   "type": "object",
                   "required": [
                     "signed_transaction",
+                    "signer_pubkey",
+                    "signature"
+                  ],
+                  "properties": {
+                    "signature": {
+                      "type": "string",
+                      "description": "Transaction signature"
+                    },
+                    "signed_transaction": {
+                      "type": "string"
+                    },
+                    "signer_pubkey": {
+                      "type": "string",
+                      "description": "Public key of the signer used (for client consistency)"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Exceeded rate limit.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/signBundle": {
+      "summary": "signBundle",
+      "post": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "jsonrpc",
+                  "id",
+                  "method",
+                  "params"
+                ],
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "description": "An ID to identify the request.",
+                    "enum": [
+                      "test-account"
+                    ]
+                  },
+                  "jsonrpc": {
+                    "type": "string",
+                    "description": "The version of the JSON-RPC protocol.",
+                    "enum": [
+                      "2.0"
+                    ]
+                  },
+                  "method": {
+                    "type": "string",
+                    "description": "The name of the method to invoke.",
+                    "enum": [
+                      "signBundle"
+                    ]
+                  },
+                  "params": {
+                    "type": "object",
+                    "required": [
+                      "transactions"
+                    ],
+                    "properties": {
+                      "sig_verify": {
+                        "type": "boolean",
+                        "description": "Whether to verify signatures during simulation (defaults to false)"
+                      },
+                      "sign_only_indices": {
+                        "type": "array",
+                        "items": {
+                          "type": "integer",
+                          "minimum": 0
+                        },
+                        "description": "Optional indices of transactions to sign (defaults to all if not specified)",
+                        "nullable": true
+                      },
+                      "signer_key": {
+                        "type": "string",
+                        "description": "Optional signer key to ensure consistency across related RPC calls",
+                        "nullable": true
+                      },
+                      "transactions": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        },
+                        "description": "Array of base64-encoded transactions"
+                      },
+                      "user_id": {
+                        "type": "string",
+                        "description": "Optional user ID for usage tracking (required when pricing is free and usage tracking is enabled)",
+                        "nullable": true
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "signed_transactions",
                     "signer_pubkey"
                   ],
                   "properties": {
-                    "signed_transaction": {
-                      "type": "string"
+                    "signed_transactions": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      },
+                      "description": "Array of base64-encoded signed transactions"
                     },
                     "signer_pubkey": {
                       "type": "string",
@@ -698,21 +1244,28 @@
                   },
                   "params": {
                     "type": "object",
+                    "description": "Request payload for signing a transaction.\n\nThis endpoint accepts a base64-encoded Solana transaction, validates it against\nthe configured fee payer policies, and if successful, signs it using Kora's\nconfigured signer policy\nbut not broadcasted to the network.",
                     "required": [
                       "transaction"
                     ],
                     "properties": {
                       "sig_verify": {
                         "type": "boolean",
-                        "description": "Whether to verify signatures during simulation (defaults to true)"
+                        "description": "Whether to verify signatures during simulation (defaults to false)"
                       },
                       "signer_key": {
                         "type": "string",
-                        "description": "Optional signer signer_key to ensure consistency across related RPC calls",
+                        "description": "Optional public key of the signer to ensure consistency",
                         "nullable": true
                       },
                       "transaction": {
-                        "type": "string"
+                        "type": "string",
+                        "description": "Base64-encoded Solana transaction"
+                      },
+                      "user_id": {
+                        "type": "string",
+                        "description": "Optional user ID for usage tracking (required when pricing is Free and usage tracking is enabled)",
+                        "nullable": true
                       }
                     }
                   }
@@ -729,13 +1282,15 @@
               "application/json": {
                 "schema": {
                   "type": "object",
+                  "description": "Response payload containing the signed transaction.",
                   "required": [
                     "signed_transaction",
                     "signer_pubkey"
                   ],
                   "properties": {
                     "signed_transaction": {
-                      "type": "string"
+                      "type": "string",
+                      "description": "Base64-encoded transaction signed by the Kora fee payer"
                     },
                     "signer_pubkey": {
                       "type": "string",
@@ -817,6 +1372,7 @@
                   },
                   "params": {
                     "type": "object",
+                    "description": "**DEPRECATED**: Use `getPaymentInstruction` instead for fee payment flows.\nThis endpoint will be removed in a future version.\n\nRequest payload for creating a simple token or SOL transfer transaction.\nThis endpoint constructs an unsigned transfer where Kora acts as the fee payer,\nbut the user must still sign the transaction before it can be submitted.",
                     "required": [
                       "amount",
                       "token",
@@ -827,21 +1383,25 @@
                       "amount": {
                         "type": "integer",
                         "format": "int64",
+                        "description": "Amount to transfer (in the token's smallest unit, e.g. lamports for SOL)",
                         "minimum": 0
                       },
                       "destination": {
-                        "type": "string"
+                        "type": "string",
+                        "description": "The destination wallet address that will receive the tokens"
                       },
                       "signer_key": {
                         "type": "string",
-                        "description": "Optional signer signer_key to ensure consistency across related RPC calls",
+                        "description": "Optional public key of the signer to ensure consistency",
                         "nullable": true
                       },
                       "source": {
-                        "type": "string"
+                        "type": "string",
+                        "description": "The source wallet address that will send the tokens"
                       },
                       "token": {
-                        "type": "string"
+                        "type": "string",
+                        "description": "Token mint address to transfer (use native SOL address for SOL transfers)"
                       }
                     }
                   }
@@ -858,6 +1418,7 @@
               "application/json": {
                 "schema": {
                   "type": "object",
+                  "description": "**DEPRECATED**: Use `getPaymentInstruction` instead for fee payment flows.\n\nResponse payload containing the constructed transfer transaction.",
                   "required": [
                     "transaction",
                     "message",
@@ -866,17 +1427,20 @@
                   ],
                   "properties": {
                     "blockhash": {
-                      "type": "string"
+                      "type": "string",
+                      "description": "The blockhash used when constructing the transaction"
                     },
                     "message": {
-                      "type": "string"
+                      "type": "string",
+                      "description": "Unsigned base64-encoded message"
                     },
                     "signer_pubkey": {
                       "type": "string",
-                      "description": "Public key of the signer used (for client consistency)"
+                      "description": "Public key of the Kora signer used as the fee payer (for client consistency)"
                     },
                     "transaction": {
-                      "type": "string"
+                      "type": "string",
+                      "description": "Unsigned base64-encoded transaction ready for the user to sign"
                     }
                   }
                 }
@@ -919,81 +1483,189 @@
   },
   "components": {
     "schemas": {
+      "AltInstructionPolicy": {
+        "type": "object",
+        "properties": {
+          "allow_close": {
+            "type": "boolean",
+            "description": "Allow fee payer to be authority in ALT CloseLookupTable instructions",
+            "default": false
+          },
+          "allow_create": {
+            "type": "boolean",
+            "description": "Allow fee payer to be authority/payer in ALT CreateLookupTable instructions",
+            "default": false
+          },
+          "allow_deactivate": {
+            "type": "boolean",
+            "description": "Allow fee payer to be authority in ALT DeactivateLookupTable instructions",
+            "default": false
+          },
+          "allow_extend": {
+            "type": "boolean",
+            "description": "Allow fee payer to be authority/payer in ALT ExtendLookupTable instructions",
+            "default": false
+          },
+          "allow_freeze": {
+            "type": "boolean",
+            "description": "Allow fee payer to be authority in ALT FreezeLookupTable instructions",
+            "default": false
+          }
+        }
+      },
       "EnabledMethods": {
         "type": "object",
-        "required": [
-          "liveness",
-          "estimate_transaction_fee",
-          "get_supported_tokens",
-          "get_payer_signer",
-          "sign_transaction",
-          "sign_and_send_transaction",
-          "transfer_transaction",
-          "get_blockhash",
-          "get_config"
-        ],
         "properties": {
+          "estimate_bundle_fee": {
+            "type": "boolean",
+            "description": "Bundle methods (require bundle.enabled = true)",
+            "default": false
+          },
           "estimate_transaction_fee": {
-            "type": "boolean"
+            "type": "boolean",
+            "default": true
           },
           "get_blockhash": {
-            "type": "boolean"
+            "type": "boolean",
+            "default": true
           },
           "get_config": {
-            "type": "boolean"
+            "type": "boolean",
+            "default": true
           },
           "get_payer_signer": {
-            "type": "boolean"
+            "type": "boolean",
+            "default": true
           },
           "get_supported_tokens": {
-            "type": "boolean"
+            "type": "boolean",
+            "default": true
+          },
+          "get_version": {
+            "type": "boolean",
+            "default": true
           },
           "liveness": {
-            "type": "boolean"
+            "type": "boolean",
+            "default": true
+          },
+          "sign_and_send_bundle": {
+            "type": "boolean",
+            "default": false
           },
           "sign_and_send_transaction": {
-            "type": "boolean"
+            "type": "boolean",
+            "default": true
+          },
+          "sign_bundle": {
+            "type": "boolean",
+            "default": false
           },
           "sign_transaction": {
-            "type": "boolean"
+            "type": "boolean",
+            "default": true
           },
           "transfer_transaction": {
-            "type": "boolean"
+            "type": "boolean",
+            "default": true
           }
         }
       },
       "FeePayerPolicy": {
         "type": "object",
-        "required": [
-          "allow_sol_transfers",
-          "allow_spl_transfers",
-          "allow_token2022_transfers",
-          "allow_assign",
-          "allow_burn",
-          "allow_close_account",
-          "allow_approve"
-        ],
         "properties": {
-          "allow_approve": {
-            "type": "boolean"
+          "alt": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AltInstructionPolicy"
+              }
+            ],
+            "default": {
+              "allow_close": false,
+              "allow_create": false,
+              "allow_deactivate": false,
+              "allow_extend": false,
+              "allow_freeze": false
+            }
           },
-          "allow_assign": {
-            "type": "boolean"
+          "loader_v4": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LoaderV4InstructionPolicy"
+              }
+            ],
+            "default": {
+              "allow_copy": false,
+              "allow_deploy": false,
+              "allow_finalize": false,
+              "allow_retract": false,
+              "allow_set_program_length": false,
+              "allow_transfer_authority": false,
+              "allow_write": false
+            }
           },
-          "allow_burn": {
-            "type": "boolean"
+          "spl_token": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SplTokenInstructionPolicy"
+              }
+            ],
+            "default": {
+              "allow_approve": false,
+              "allow_burn": false,
+              "allow_close_account": false,
+              "allow_freeze_account": false,
+              "allow_initialize_account": false,
+              "allow_initialize_mint": false,
+              "allow_initialize_multisig": false,
+              "allow_mint_to": false,
+              "allow_revoke": false,
+              "allow_set_authority": false,
+              "allow_thaw_account": false,
+              "allow_transfer": false
+            }
           },
-          "allow_close_account": {
-            "type": "boolean"
+          "system": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SystemInstructionPolicy"
+              }
+            ],
+            "default": {
+              "allow_allocate": false,
+              "allow_assign": false,
+              "allow_create_account": false,
+              "allow_transfer": false,
+              "nonce": {
+                "allow_advance": false,
+                "allow_authorize": false,
+                "allow_initialize": false,
+                "allow_withdraw": false
+              }
+            }
           },
-          "allow_sol_transfers": {
-            "type": "boolean"
-          },
-          "allow_spl_transfers": {
-            "type": "boolean"
-          },
-          "allow_token2022_transfers": {
-            "type": "boolean"
+          "token_2022": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Token2022InstructionPolicy"
+              }
+            ],
+            "default": {
+              "allow_approve": false,
+              "allow_burn": false,
+              "allow_close_account": false,
+              "allow_freeze_account": false,
+              "allow_initialize_account": false,
+              "allow_initialize_extension_authority": false,
+              "allow_initialize_mint": false,
+              "allow_initialize_multisig": false,
+              "allow_mint_to": false,
+              "allow_revoke": false,
+              "allow_set_authority": false,
+              "allow_thaw_account": false,
+              "allow_transfer": false,
+              "allow_update_extension_authority": false
+            }
           }
         }
       },
@@ -1061,6 +1733,84 @@
           }
         }
       },
+      "GetVersionResponse": {
+        "type": "object",
+        "required": [
+          "version"
+        ],
+        "properties": {
+          "version": {
+            "type": "string"
+          }
+        }
+      },
+      "LoaderV4InstructionPolicy": {
+        "type": "object",
+        "properties": {
+          "allow_copy": {
+            "type": "boolean",
+            "description": "Allow fee payer to be the authority in Copy instructions",
+            "default": false
+          },
+          "allow_deploy": {
+            "type": "boolean",
+            "description": "Allow fee payer to be the authority in Deploy instructions",
+            "default": false
+          },
+          "allow_finalize": {
+            "type": "boolean",
+            "description": "Allow fee payer to be the current authority in Finalize instructions",
+            "default": false
+          },
+          "allow_retract": {
+            "type": "boolean",
+            "description": "Allow fee payer to be the authority in Retract instructions",
+            "default": false
+          },
+          "allow_set_program_length": {
+            "type": "boolean",
+            "description": "Allow fee payer to be the authority in SetProgramLength instructions",
+            "default": false
+          },
+          "allow_transfer_authority": {
+            "type": "boolean",
+            "description": "Allow fee payer to be the current authority in TransferAuthority instructions",
+            "default": false
+          },
+          "allow_write": {
+            "type": "boolean",
+            "description": "Allow fee payer to be the authority in Write instructions",
+            "default": false
+          }
+        }
+      },
+      "NonceInstructionPolicy": {
+        "type": "object",
+        "required": [
+          "allow_initialize",
+          "allow_advance",
+          "allow_withdraw",
+          "allow_authorize"
+        ],
+        "properties": {
+          "allow_advance": {
+            "type": "boolean",
+            "description": "Allow fee payer to be the nonce authority in AdvanceNonceAccount instructions"
+          },
+          "allow_authorize": {
+            "type": "boolean",
+            "description": "Allow fee payer to be the current nonce authority in AuthorizeNonceAccount instructions"
+          },
+          "allow_initialize": {
+            "type": "boolean",
+            "description": "Allow fee payer to be set as the nonce authority in InitializeNonceAccount instructions"
+          },
+          "allow_withdraw": {
+            "type": "boolean",
+            "description": "Allow fee payer to be the nonce authority in WithdrawNonceAccount instructions"
+          }
+        }
+      },
       "PriceConfig": {
         "allOf": [
           {
@@ -1097,6 +1847,7 @@
             "required": [
               "amount",
               "token",
+              "strict",
               "type"
             ],
             "properties": {
@@ -1104,6 +1855,9 @@
                 "type": "integer",
                 "format": "int64",
                 "minimum": 0
+              },
+              "strict": {
+                "type": "boolean"
               },
               "token": {
                 "type": "string"
@@ -1150,7 +1904,7 @@
         "properties": {
           "sig_verify": {
             "type": "boolean",
-            "description": "Whether to verify signatures during simulation (defaults to true)"
+            "description": "Whether to verify signatures during simulation (defaults to false)"
           },
           "signer_key": {
             "type": "string",
@@ -1159,6 +1913,11 @@
           },
           "transaction": {
             "type": "string"
+          },
+          "user_id": {
+            "type": "string",
+            "description": "Optional user ID for usage tracking (required when pricing is free and usage tracking is enabled)",
+            "nullable": true
           }
         }
       },
@@ -1170,51 +1929,292 @@
           "signature"
         ],
         "properties": {
+          "signature": {
+            "type": "string",
+            "description": "Transaction signature"
+          },
           "signed_transaction": {
             "type": "string"
           },
           "signer_pubkey": {
             "type": "string",
             "description": "Public key of the signer used (for client consistency)"
-          },
-          "signature": {
-            "type": "string"
           }
         }
       },
       "SignTransactionRequest": {
         "type": "object",
+        "description": "Request payload for signing a transaction.\n\nThis endpoint accepts a base64-encoded Solana transaction, validates it against\nthe configured fee payer policies, and if successful, signs it using Kora's\nconfigured signer policy\nbut not broadcasted to the network.",
         "required": [
           "transaction"
         ],
         "properties": {
           "sig_verify": {
             "type": "boolean",
-            "description": "Whether to verify signatures during simulation (defaults to true)"
+            "description": "Whether to verify signatures during simulation (defaults to false)"
           },
           "signer_key": {
             "type": "string",
-            "description": "Optional signer signer_key to ensure consistency across related RPC calls",
+            "description": "Optional public key of the signer to ensure consistency",
             "nullable": true
           },
           "transaction": {
-            "type": "string"
+            "type": "string",
+            "description": "Base64-encoded Solana transaction"
+          },
+          "user_id": {
+            "type": "string",
+            "description": "Optional user ID for usage tracking (required when pricing is Free and usage tracking is enabled)",
+            "nullable": true
           }
         }
       },
       "SignTransactionResponse": {
         "type": "object",
+        "description": "Response payload containing the signed transaction.",
         "required": [
           "signed_transaction",
           "signer_pubkey"
         ],
         "properties": {
           "signed_transaction": {
-            "type": "string"
+            "type": "string",
+            "description": "Base64-encoded transaction signed by the Kora fee payer"
           },
           "signer_pubkey": {
             "type": "string",
             "description": "Public key of the signer used (for client consistency)"
+          }
+        }
+      },
+      "SplTokenConfig": {
+        "oneOf": [
+          {
+            "type": "string",
+            "enum": [
+              "All"
+            ]
+          },
+          {
+            "type": "object",
+            "required": [
+              "Allowlist"
+            ],
+            "properties": {
+              "Allowlist": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        ]
+      },
+      "SplTokenInstructionPolicy": {
+        "type": "object",
+        "required": [
+          "allow_transfer",
+          "allow_burn",
+          "allow_close_account",
+          "allow_approve",
+          "allow_revoke",
+          "allow_set_authority",
+          "allow_mint_to",
+          "allow_initialize_mint",
+          "allow_initialize_account",
+          "allow_initialize_multisig",
+          "allow_freeze_account",
+          "allow_thaw_account"
+        ],
+        "properties": {
+          "allow_approve": {
+            "type": "boolean",
+            "description": "Allow fee payer to be the owner in SPL Token Approve/ApproveChecked instructions"
+          },
+          "allow_burn": {
+            "type": "boolean",
+            "description": "Allow fee payer to be the owner in SPL Token Burn/BurnChecked instructions"
+          },
+          "allow_close_account": {
+            "type": "boolean",
+            "description": "Allow fee payer to be the owner in SPL Token CloseAccount instructions"
+          },
+          "allow_freeze_account": {
+            "type": "boolean",
+            "description": "Allow fee payer to be the freeze authority in SPL Token FreezeAccount instructions"
+          },
+          "allow_initialize_account": {
+            "type": "boolean",
+            "description": "Allow fee payer to be set as the owner in SPL Token InitializeAccount instructions"
+          },
+          "allow_initialize_mint": {
+            "type": "boolean",
+            "description": "Allow fee payer to be the mint authority in SPL Token InitializeMint/InitializeMint2 instructions"
+          },
+          "allow_initialize_multisig": {
+            "type": "boolean",
+            "description": "Allow fee payer to be a signer in SPL Token InitializeMultisig instructions"
+          },
+          "allow_mint_to": {
+            "type": "boolean",
+            "description": "Allow fee payer to be the mint authority in SPL Token MintTo/MintToChecked instructions"
+          },
+          "allow_revoke": {
+            "type": "boolean",
+            "description": "Allow fee payer to be the owner in SPL Token Revoke instructions"
+          },
+          "allow_set_authority": {
+            "type": "boolean",
+            "description": "Allow fee payer to be the current authority in SPL Token SetAuthority instructions"
+          },
+          "allow_thaw_account": {
+            "type": "boolean",
+            "description": "Allow fee payer to be the freeze authority in SPL Token ThawAccount instructions"
+          },
+          "allow_transfer": {
+            "type": "boolean",
+            "description": "Allow fee payer to be the owner in SPL Token Transfer/TransferChecked instructions"
+          }
+        }
+      },
+      "SystemInstructionPolicy": {
+        "type": "object",
+        "properties": {
+          "allow_allocate": {
+            "type": "boolean",
+            "description": "Allow fee payer to be the account in System Allocate/AllocateWithSeed instructions",
+            "default": false
+          },
+          "allow_assign": {
+            "type": "boolean",
+            "description": "Allow fee payer to be the authority in System Assign/AssignWithSeed instructions",
+            "default": false
+          },
+          "allow_create_account": {
+            "type": "boolean",
+            "description": "Allow fee payer to be the payer in System CreateAccount/CreateAccountWithSeed instructions",
+            "default": false
+          },
+          "allow_transfer": {
+            "type": "boolean",
+            "description": "Allow fee payer to be the sender in System Transfer/TransferWithSeed instructions",
+            "default": false
+          },
+          "nonce": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/NonceInstructionPolicy"
+              }
+            ],
+            "default": {
+              "allow_advance": false,
+              "allow_authorize": false,
+              "allow_initialize": false,
+              "allow_withdraw": false
+            }
+          }
+        }
+      },
+      "Token2022Config": {
+        "type": "object",
+        "properties": {
+          "blocked_account_extensions": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "default": []
+          },
+          "blocked_mint_extensions": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "default": []
+          },
+          "transfer_hook_policy": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/TransferHookPolicy"
+              }
+            ],
+            "default": "deny_all"
+          }
+        }
+      },
+      "Token2022InstructionPolicy": {
+        "type": "object",
+        "properties": {
+          "allow_approve": {
+            "type": "boolean",
+            "description": "Allow fee payer to be the owner in Token2022 Approve/ApproveChecked instructions",
+            "default": false
+          },
+          "allow_burn": {
+            "type": "boolean",
+            "description": "Allow fee payer to be the owner in Token2022 Burn/BurnChecked instructions",
+            "default": false
+          },
+          "allow_close_account": {
+            "type": "boolean",
+            "description": "Allow fee payer to be the owner in Token2022 CloseAccount instructions",
+            "default": false
+          },
+          "allow_freeze_account": {
+            "type": "boolean",
+            "description": "Allow fee payer to be the freeze authority in Token2022 FreezeAccount instructions",
+            "default": false
+          },
+          "allow_initialize_account": {
+            "type": "boolean",
+            "description": "Allow fee payer to be set as the owner in Token2022 InitializeAccount instructions",
+            "default": false
+          },
+          "allow_initialize_extension_authority": {
+            "type": "boolean",
+            "description": "Allow fee payer to be planted as a future Token2022 extension authority/delegate during\nextension initialization.",
+            "default": false
+          },
+          "allow_initialize_mint": {
+            "type": "boolean",
+            "description": "Allow fee payer to be the mint authority in Token2022 InitializeMint/InitializeMint2 instructions",
+            "default": false
+          },
+          "allow_initialize_multisig": {
+            "type": "boolean",
+            "description": "Allow fee payer to be a signer in Token2022 InitializeMultisig instructions",
+            "default": false
+          },
+          "allow_mint_to": {
+            "type": "boolean",
+            "description": "Allow fee payer to be the mint authority in Token2022 MintTo/MintToChecked instructions",
+            "default": false
+          },
+          "allow_revoke": {
+            "type": "boolean",
+            "description": "Allow fee payer to be the owner in Token2022 Revoke instructions",
+            "default": false
+          },
+          "allow_set_authority": {
+            "type": "boolean",
+            "description": "Allow fee payer to be the current authority in Token2022 SetAuthority instructions",
+            "default": false
+          },
+          "allow_thaw_account": {
+            "type": "boolean",
+            "description": "Allow fee payer to be the freeze authority in Token2022 ThawAccount instructions",
+            "default": false
+          },
+          "allow_transfer": {
+            "type": "boolean",
+            "description": "Allow fee payer to be the owner in Token2022 Transfer/TransferChecked instructions",
+            "default": false
+          },
+          "allow_update_extension_authority": {
+            "type": "boolean",
+            "description": "Allow fee payer to be used as the current authority for Token2022 extension update/admin\ninstructions.",
+            "default": false
           }
         }
       },
@@ -1226,21 +2226,35 @@
           "source"
         ],
         "properties": {
+          "block_id": {
+            "type": "integer",
+            "format": "int64",
+            "nullable": true,
+            "minimum": 0
+          },
           "confidence": {
             "type": "number",
             "format": "double"
           },
           "price": {
-            "type": "number",
-            "format": "double"
+            "type": "string"
           },
           "source": {
             "$ref": "#/components/schemas/PriceSource"
           }
         }
       },
+      "TransferHookPolicy": {
+        "type": "string",
+        "enum": [
+          "deny_all",
+          "deny_mutable_for_delayed_signing",
+          "allow_all"
+        ]
+      },
       "TransferTransactionRequest": {
         "type": "object",
+        "description": "**DEPRECATED**: Use `getPaymentInstruction` instead for fee payment flows.\nThis endpoint will be removed in a future version.\n\nRequest payload for creating a simple token or SOL transfer transaction.\nThis endpoint constructs an unsigned transfer where Kora acts as the fee payer,\nbut the user must still sign the transaction before it can be submitted.",
         "required": [
           "amount",
           "token",
@@ -1251,26 +2265,31 @@
           "amount": {
             "type": "integer",
             "format": "int64",
+            "description": "Amount to transfer (in the token's smallest unit, e.g. lamports for SOL)",
             "minimum": 0
           },
           "destination": {
-            "type": "string"
+            "type": "string",
+            "description": "The destination wallet address that will receive the tokens"
           },
           "signer_key": {
             "type": "string",
-            "description": "Optional signer signer_key to ensure consistency across related RPC calls",
+            "description": "Optional public key of the signer to ensure consistency",
             "nullable": true
           },
           "source": {
-            "type": "string"
+            "type": "string",
+            "description": "The source wallet address that will send the tokens"
           },
           "token": {
-            "type": "string"
+            "type": "string",
+            "description": "Token mint address to transfer (use native SOL address for SOL transfers)"
           }
         }
       },
       "TransferTransactionResponse": {
         "type": "object",
+        "description": "**DEPRECATED**: Use `getPaymentInstruction` instead for fee payment flows.\n\nResponse payload containing the constructed transfer transaction.",
         "required": [
           "transaction",
           "message",
@@ -1279,17 +2298,20 @@
         ],
         "properties": {
           "blockhash": {
-            "type": "string"
+            "type": "string",
+            "description": "The blockhash used when constructing the transaction"
           },
           "message": {
-            "type": "string"
+            "type": "string",
+            "description": "Unsigned base64-encoded message"
           },
           "signer_pubkey": {
             "type": "string",
-            "description": "Public key of the signer used (for client consistency)"
+            "description": "Public key of the Kora signer used as the fee payer (for client consistency)"
           },
           "transaction": {
-            "type": "string"
+            "type": "string",
+            "description": "Unsigned base64-encoded transaction ready for the user to sign"
           }
         }
       },
@@ -1305,6 +2327,10 @@
           "price_source"
         ],
         "properties": {
+          "allow_durable_transactions": {
+            "type": "boolean",
+            "description": "Allow durable transactions (nonce-based). Default: false.\nWhen false, rejects any transaction containing AdvanceNonceAccount instruction.\nWARNING: Enabling with dynamic pricing creates price arbitrage risk."
+          },
           "allowed_programs": {
             "type": "array",
             "items": {
@@ -1334,6 +2360,12 @@
             "format": "int64",
             "minimum": 0
           },
+          "max_price_staleness_slots": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Maximum allowed age of oracle price data in slots. 0 = disabled (default).\nWhen >0, prices with a block_id older than `current_slot - max_price_staleness_slots` are rejected.",
+            "minimum": 0
+          },
           "max_signatures": {
             "type": "integer",
             "format": "int64",
@@ -1344,6 +2376,13 @@
           },
           "price_source": {
             "$ref": "#/components/schemas/PriceSource"
+          },
+          "require_one_of_programs": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Programs where at least one must be called by the transaction (OR semantics).\nEach required program must also be listed in `allowed_programs`.\nDefault: empty (no restriction)."
           },
           "token_2022": {
             "$ref": "#/components/schemas/Token2022Config"

--- a/crates/lib/src/tests/config_mock.rs
+++ b/crates/lib/src/tests/config_mock.rs
@@ -702,6 +702,7 @@ impl FeePayerPolicyBuilder {
                     allow_deactivate: false,
                     allow_close: false,
                 },
+                loader_v4: crate::config::LoaderV4InstructionPolicy::default(),
             },
         }
     }

--- a/crates/lib/src/transaction/instruction_util.rs
+++ b/crates/lib/src/transaction/instruction_util.rs
@@ -4,6 +4,7 @@ use solana_address_lookup_table_interface::{
     instruction::ProgramInstruction as AddressLookupTableInstruction,
     program::ID as ADDRESS_LOOKUP_TABLE_PROGRAM_ID,
 };
+use solana_loader_v4_interface::instruction::LoaderV4Instruction;
 use solana_message::compiled_instruction::CompiledInstruction;
 use solana_sdk::{
     instruction::{AccountMeta, Instruction},
@@ -16,7 +17,9 @@ use solana_transaction_status_client_types::{
 };
 
 use crate::{
-    constant::instruction_indexes, error::KoraError, sanitize_error,
+    constant::{instruction_indexes, LOADER_V4_PROGRAM_ID},
+    error::KoraError,
+    sanitize_error,
     transaction::VersionedTransactionResolved,
 };
 
@@ -247,6 +250,60 @@ pub enum ParsedALTInstructionData {
         lookup_table_account: Pubkey,
         lookup_table_authority: Pubkey,
         recipient: Pubkey,
+    },
+}
+
+/// Loader-v4 instruction types parsed from a transaction.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum ParsedLoaderV4InstructionType {
+    Write,
+    Copy,
+    SetProgramLength,
+    Deploy,
+    Retract,
+    TransferAuthority,
+    Finalize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum ParsedLoaderV4InstructionData {
+    Write {
+        program: Pubkey,
+        authority: Pubkey,
+        offset: u32,
+    },
+    Copy {
+        destination_program: Pubkey,
+        authority: Pubkey,
+        source_program: Pubkey,
+        destination_offset: u32,
+        source_offset: u32,
+        length: u32,
+    },
+    SetProgramLength {
+        program: Pubkey,
+        authority: Pubkey,
+        recipient: Option<Pubkey>,
+        new_size: u32,
+    },
+    Deploy {
+        program: Pubkey,
+        authority: Pubkey,
+        source_program: Option<Pubkey>,
+    },
+    Retract {
+        program: Pubkey,
+        authority: Pubkey,
+    },
+    TransferAuthority {
+        program: Pubkey,
+        current_authority: Pubkey,
+        new_authority: Pubkey,
+    },
+    Finalize {
+        program: Pubkey,
+        current_authority: Pubkey,
+        next_version: Pubkey,
     },
 }
 
@@ -1954,6 +2011,197 @@ impl IxUtils {
                                 .pubkey,
                             recipient: instruction.accounts
                                 [instruction_indexes::alt_close_lookup_table::RECIPIENT_INDEX]
+                                .pubkey,
+                        });
+                }
+            }
+        }
+
+        Ok(parsed_instructions)
+    }
+
+    pub fn parse_loader_v4_instructions(
+        transaction: &VersionedTransactionResolved,
+    ) -> Result<HashMap<ParsedLoaderV4InstructionType, Vec<ParsedLoaderV4InstructionData>>, KoraError>
+    {
+        let mut parsed_instructions: HashMap<
+            ParsedLoaderV4InstructionType,
+            Vec<ParsedLoaderV4InstructionData>,
+        > = HashMap::new();
+
+        for instruction in &transaction.all_instructions {
+            if instruction.program_id != LOADER_V4_PROGRAM_ID {
+                continue;
+            }
+
+            let loader_ix = bincode::deserialize::<LoaderV4Instruction>(&instruction.data)
+                .map_err(|e| {
+                    KoraError::InvalidTransaction(format!(
+                        "Failed to parse Loader-v4 instruction: {}",
+                        sanitize_error!(e)
+                    ))
+                })?;
+
+            match loader_ix {
+                LoaderV4Instruction::Write { offset, .. } => {
+                    validate_number_accounts!(
+                        instruction,
+                        instruction_indexes::loader_v4_write::REQUIRED_NUMBER_OF_ACCOUNTS
+                    );
+
+                    parsed_instructions
+                        .entry(ParsedLoaderV4InstructionType::Write)
+                        .or_default()
+                        .push(ParsedLoaderV4InstructionData::Write {
+                            program: instruction.accounts
+                                [instruction_indexes::loader_v4_write::PROGRAM_INDEX]
+                                .pubkey,
+                            authority: instruction.accounts
+                                [instruction_indexes::loader_v4_write::AUTHORITY_INDEX]
+                                .pubkey,
+                            offset,
+                        });
+                }
+                LoaderV4Instruction::Copy { destination_offset, source_offset, length } => {
+                    validate_number_accounts!(
+                        instruction,
+                        instruction_indexes::loader_v4_copy::REQUIRED_NUMBER_OF_ACCOUNTS
+                    );
+
+                    parsed_instructions
+                        .entry(ParsedLoaderV4InstructionType::Copy)
+                        .or_default()
+                        .push(ParsedLoaderV4InstructionData::Copy {
+                            destination_program: instruction.accounts
+                                [instruction_indexes::loader_v4_copy::DESTINATION_PROGRAM_INDEX]
+                                .pubkey,
+                            authority: instruction.accounts
+                                [instruction_indexes::loader_v4_copy::AUTHORITY_INDEX]
+                                .pubkey,
+                            source_program: instruction.accounts
+                                [instruction_indexes::loader_v4_copy::SOURCE_PROGRAM_INDEX]
+                                .pubkey,
+                            destination_offset,
+                            source_offset,
+                            length,
+                        });
+                }
+                LoaderV4Instruction::SetProgramLength { new_size } => {
+                    let account_count = instruction.accounts.len();
+                    if account_count
+                        < instruction_indexes::loader_v4_set_program_length::MIN_REQUIRED_NUMBER_OF_ACCOUNTS
+                    {
+                        return Err(KoraError::InvalidTransaction(format!(
+                            "Loader-v4 SetProgramLength has {account_count} accounts, expected at least 2"
+                        )));
+                    }
+
+                    let recipient = if account_count
+                        >= instruction_indexes::loader_v4_set_program_length::REQUIRED_NUMBER_OF_ACCOUNTS_WITH_RECIPIENT
+                    {
+                        Some(
+                            instruction.accounts[instruction_indexes::loader_v4_set_program_length::OPTIONAL_RECIPIENT_INDEX]
+                                .pubkey,
+                        )
+                    } else {
+                        None
+                    };
+
+                    parsed_instructions
+                        .entry(ParsedLoaderV4InstructionType::SetProgramLength)
+                        .or_default()
+                        .push(ParsedLoaderV4InstructionData::SetProgramLength {
+                            program: instruction.accounts[instruction_indexes::loader_v4_set_program_length::PROGRAM_INDEX].pubkey,
+                            authority: instruction.accounts[instruction_indexes::loader_v4_set_program_length::AUTHORITY_INDEX].pubkey,
+                            recipient,
+                            new_size,
+                        });
+                }
+                LoaderV4Instruction::Deploy => {
+                    let account_count = instruction.accounts.len();
+                    if account_count
+                        < instruction_indexes::loader_v4_deploy::MIN_REQUIRED_NUMBER_OF_ACCOUNTS
+                    {
+                        return Err(KoraError::InvalidTransaction(format!(
+                            "Loader-v4 Deploy has {account_count} accounts, expected at least 2"
+                        )));
+                    }
+
+                    let source_program = if account_count
+                        >= instruction_indexes::loader_v4_deploy::REQUIRED_NUMBER_OF_ACCOUNTS_WITH_SOURCE
+                    {
+                        Some(
+                            instruction.accounts[instruction_indexes::loader_v4_deploy::OPTIONAL_SOURCE_PROGRAM_INDEX]
+                                .pubkey,
+                        )
+                    } else {
+                        None
+                    };
+
+                    parsed_instructions
+                        .entry(ParsedLoaderV4InstructionType::Deploy)
+                        .or_default()
+                        .push(ParsedLoaderV4InstructionData::Deploy {
+                            program: instruction.accounts
+                                [instruction_indexes::loader_v4_deploy::PROGRAM_INDEX]
+                                .pubkey,
+                            authority: instruction.accounts
+                                [instruction_indexes::loader_v4_deploy::AUTHORITY_INDEX]
+                                .pubkey,
+                            source_program,
+                        });
+                }
+                LoaderV4Instruction::Retract => {
+                    validate_number_accounts!(
+                        instruction,
+                        instruction_indexes::loader_v4_retract::REQUIRED_NUMBER_OF_ACCOUNTS
+                    );
+
+                    parsed_instructions
+                        .entry(ParsedLoaderV4InstructionType::Retract)
+                        .or_default()
+                        .push(ParsedLoaderV4InstructionData::Retract {
+                            program: instruction.accounts
+                                [instruction_indexes::loader_v4_retract::PROGRAM_INDEX]
+                                .pubkey,
+                            authority: instruction.accounts
+                                [instruction_indexes::loader_v4_retract::AUTHORITY_INDEX]
+                                .pubkey,
+                        });
+                }
+                LoaderV4Instruction::TransferAuthority => {
+                    validate_number_accounts!(
+                        instruction,
+                        instruction_indexes::loader_v4_transfer_authority::REQUIRED_NUMBER_OF_ACCOUNTS
+                    );
+
+                    parsed_instructions
+                        .entry(ParsedLoaderV4InstructionType::TransferAuthority)
+                        .or_default()
+                        .push(ParsedLoaderV4InstructionData::TransferAuthority {
+                            program: instruction.accounts[instruction_indexes::loader_v4_transfer_authority::PROGRAM_INDEX].pubkey,
+                            current_authority: instruction.accounts[instruction_indexes::loader_v4_transfer_authority::CURRENT_AUTHORITY_INDEX].pubkey,
+                            new_authority: instruction.accounts[instruction_indexes::loader_v4_transfer_authority::NEW_AUTHORITY_INDEX].pubkey,
+                        });
+                }
+                LoaderV4Instruction::Finalize => {
+                    validate_number_accounts!(
+                        instruction,
+                        instruction_indexes::loader_v4_finalize::REQUIRED_NUMBER_OF_ACCOUNTS
+                    );
+
+                    parsed_instructions
+                        .entry(ParsedLoaderV4InstructionType::Finalize)
+                        .or_default()
+                        .push(ParsedLoaderV4InstructionData::Finalize {
+                            program: instruction.accounts
+                                [instruction_indexes::loader_v4_finalize::PROGRAM_INDEX]
+                                .pubkey,
+                            current_authority: instruction.accounts
+                                [instruction_indexes::loader_v4_finalize::CURRENT_AUTHORITY_INDEX]
+                                .pubkey,
+                            next_version: instruction.accounts
+                                [instruction_indexes::loader_v4_finalize::NEXT_VERSION_INDEX]
                                 .pubkey,
                         });
                 }

--- a/crates/lib/src/transaction/versioned_transaction.rs
+++ b/crates/lib/src/transaction/versioned_transaction.rs
@@ -26,8 +26,9 @@ use crate::{
     token::token::TransferHookValidationFlow,
     transaction::{
         instruction_util::IxUtils, ParsedALTInstructionData, ParsedALTInstructionType,
-        ParsedSPLInstructionData, ParsedSPLInstructionType, ParsedSystemInstructionData,
-        ParsedSystemInstructionType, Token2022SecurityInstruction, Token2022SecurityParser,
+        ParsedLoaderV4InstructionData, ParsedLoaderV4InstructionType, ParsedSPLInstructionData,
+        ParsedSPLInstructionType, ParsedSystemInstructionData, ParsedSystemInstructionType,
+        Token2022SecurityInstruction, Token2022SecurityParser,
     },
     validator::transaction_validator::TransactionValidator,
     CacheUtil,
@@ -57,6 +58,10 @@ pub struct VersionedTransactionResolved {
     // Parsed ALT instructions by type (None if not parsed yet)
     parsed_alt_instructions:
         Option<HashMap<ParsedALTInstructionType, Vec<ParsedALTInstructionData>>>,
+
+    // Parsed Loader-v4 instructions by type (None if not parsed yet)
+    parsed_loader_v4_instructions:
+        Option<HashMap<ParsedLoaderV4InstructionType, Vec<ParsedLoaderV4InstructionData>>>,
 
     parsed_token2022_security_instructions: Option<Vec<Token2022SecurityInstruction>>,
 }
@@ -105,6 +110,7 @@ impl VersionedTransactionResolved {
             parsed_system_instructions: None,
             parsed_spl_instructions: None,
             parsed_alt_instructions: None,
+            parsed_loader_v4_instructions: None,
             parsed_token2022_security_instructions: None,
         };
 
@@ -156,6 +162,7 @@ impl VersionedTransactionResolved {
             parsed_system_instructions: None,
             parsed_spl_instructions: None,
             parsed_alt_instructions: None,
+            parsed_loader_v4_instructions: None,
             parsed_token2022_security_instructions: None,
         })
     }
@@ -256,6 +263,21 @@ impl VersionedTransactionResolved {
 
         self.parsed_alt_instructions.as_ref().ok_or_else(|| {
             KoraError::SerializationError("Parsed ALT instructions not found".to_string())
+        })
+    }
+
+    pub fn get_or_parse_loader_v4_instructions(
+        &mut self,
+    ) -> Result<
+        &HashMap<ParsedLoaderV4InstructionType, Vec<ParsedLoaderV4InstructionData>>,
+        KoraError,
+    > {
+        if self.parsed_loader_v4_instructions.is_none() {
+            self.parsed_loader_v4_instructions = Some(IxUtils::parse_loader_v4_instructions(self)?);
+        }
+
+        self.parsed_loader_v4_instructions.as_ref().ok_or_else(|| {
+            KoraError::SerializationError("Parsed Loader-v4 instructions not found".to_string())
         })
     }
 

--- a/crates/lib/src/usage_limit/rules/instruction.rs
+++ b/crates/lib/src/usage_limit/rules/instruction.rs
@@ -4,7 +4,10 @@ use solana_sdk::pubkey::Pubkey;
 use solana_system_interface::program::ID as SYSTEM_PROGRAM_ID;
 use spl_associated_token_account_interface::program::ID as ATA_PROGRAM_ID;
 
-use crate::transaction::{ParsedSystemInstructionData, ParsedSystemInstructionType};
+use crate::{
+    constant::LOADER_V4_PROGRAM_ID,
+    transaction::{ParsedSystemInstructionData, ParsedSystemInstructionType},
+};
 
 use super::super::limiter::LimiterContext;
 
@@ -18,6 +21,15 @@ const SYSTEM_CREATE_ACCOUNT_WITH_SEED: &str = "createaccountwithseed";
 const ATA_CREATE: &str = "create";
 const ATA_CREATE_IDEMPOTENT: &str = "createidempotent";
 
+// Loader-v4 instruction names. Values correspond to bincode discriminators of LoaderV4Instruction.
+const LOADER_V4_WRITE: &str = "write";
+const LOADER_V4_COPY: &str = "copy";
+const LOADER_V4_SET_PROGRAM_LENGTH: &str = "setprogramlength";
+const LOADER_V4_DEPLOY: &str = "deploy";
+const LOADER_V4_RETRACT: &str = "retract";
+const LOADER_V4_TRANSFER_AUTHORITY: &str = "transferauthority";
+const LOADER_V4_FINALIZE: &str = "finalize";
+
 /// Rule that limits specific instruction types per wallet
 ///
 /// Counts matching instructions in each transaction and enforces limits.
@@ -26,6 +38,7 @@ const ATA_CREATE_IDEMPOTENT: &str = "createidempotent";
 /// Currently supported instruction types:
 /// - System: CreateAccount / CreateAccountWithSeed
 /// - ATA: CreateIdempotent / Create
+/// - Loader-v4: Write / Copy / SetProgramLength / Deploy / Retract / TransferAuthority / Finalize
 #[derive(Debug)]
 pub struct InstructionRule {
     program: Pubkey,
@@ -224,6 +237,7 @@ impl InstructionIdentifier {
         match *program_id {
             _ if *program_id == SYSTEM_PROGRAM_ID => Self::system(data),
             _ if *program_id == ATA_PROGRAM_ID => Self::ata(data),
+            _ if *program_id == LOADER_V4_PROGRAM_ID => Self::loader_v4(data),
             _ => None,
         }
     }
@@ -241,6 +255,22 @@ impl InstructionIdentifier {
         match data.first().copied() {
             None | Some(0) => Some(ATA_CREATE.to_string()),
             Some(1) => Some(ATA_CREATE_IDEMPOTENT.to_string()),
+            _ => None,
+        }
+    }
+
+    fn loader_v4(data: &[u8]) -> Option<String> {
+        // bincode serializes enum variants as a little-endian u32 discriminator.
+        // Values match `LoaderV4Instruction` declaration order.
+        let discriminator = u32::from_le_bytes(data.get(..4)?.try_into().ok()?);
+        match discriminator {
+            0 => Some(LOADER_V4_WRITE.to_string()),
+            1 => Some(LOADER_V4_COPY.to_string()),
+            2 => Some(LOADER_V4_SET_PROGRAM_LENGTH.to_string()),
+            3 => Some(LOADER_V4_DEPLOY.to_string()),
+            4 => Some(LOADER_V4_RETRACT.to_string()),
+            5 => Some(LOADER_V4_TRANSFER_AUTHORITY.to_string()),
+            6 => Some(LOADER_V4_FINALIZE.to_string()),
             _ => None,
         }
     }
@@ -329,6 +359,34 @@ mod tests {
         assert_eq!(InstructionIdentifier::ata(&[]), Some(ATA_CREATE.to_string()));
         assert_eq!(InstructionIdentifier::ata(&[0]), Some(ATA_CREATE.to_string()));
         assert_eq!(InstructionIdentifier::ata(&[1]), Some(ATA_CREATE_IDEMPOTENT.to_string()));
+    }
+
+    #[test]
+    fn test_identify_loader_v4_via_bincode_serialized_data() {
+        use solana_loader_v4_interface::instruction::LoaderV4Instruction;
+
+        // Round-trip through bincode to keep our discriminator map aligned with the upstream enum.
+        let cases: &[(LoaderV4Instruction, &str)] = &[
+            (LoaderV4Instruction::Write { offset: 0, bytes: vec![1, 2] }, LOADER_V4_WRITE),
+            (
+                LoaderV4Instruction::Copy { destination_offset: 0, source_offset: 0, length: 16 },
+                LOADER_V4_COPY,
+            ),
+            (
+                LoaderV4Instruction::SetProgramLength { new_size: 1024 },
+                LOADER_V4_SET_PROGRAM_LENGTH,
+            ),
+            (LoaderV4Instruction::Deploy, LOADER_V4_DEPLOY),
+            (LoaderV4Instruction::Retract, LOADER_V4_RETRACT),
+            (LoaderV4Instruction::TransferAuthority, LOADER_V4_TRANSFER_AUTHORITY),
+            (LoaderV4Instruction::Finalize, LOADER_V4_FINALIZE),
+        ];
+
+        for (ix, expected_name) in cases {
+            let data = bincode::serialize(ix).unwrap();
+            let identified = InstructionIdentifier::identify(&LOADER_V4_PROGRAM_ID, &data);
+            assert_eq!(identified.as_deref(), Some(*expected_name), "failed to identify {ix:?}");
+        }
     }
 
     #[test]

--- a/crates/lib/src/usage_limit/rules/instruction.rs
+++ b/crates/lib/src/usage_limit/rules/instruction.rs
@@ -191,6 +191,25 @@ impl InstructionRule {
                                 }
                                 _ => {}
                             }
+                        } else if rule.program == LOADER_V4_PROGRAM_ID {
+                            // Loader-v4 instructions: only count when Kora is the (new/current)
+                            // authority, since those are the ops Kora actually subsidizes. All
+                            // 7 variants place the primary authority at account index 1;
+                            // TransferAuthority additionally has new_authority at index 2.
+                            let kora_is_authority = instruction
+                                .accounts
+                                .get(1)
+                                .zip(kora_signer)
+                                .is_some_and(|(acc, kora)| acc.pubkey == kora);
+                            let kora_is_new_authority = instr_type == LOADER_V4_TRANSFER_AUTHORITY
+                                && instruction
+                                    .accounts
+                                    .get(2)
+                                    .zip(kora_signer)
+                                    .is_some_and(|(acc, kora)| acc.pubkey == kora);
+                            if kora_is_authority || kora_is_new_authority {
+                                counts[*idx] += 1;
+                            }
                         } else {
                             // For other programs, count all matching instructions
                             counts[*idx] += 1;
@@ -449,5 +468,83 @@ mod tests {
         assert_eq!(batch_counts.len(), 2);
         assert_eq!(batch_counts[0], count1);
         assert_eq!(batch_counts[1], count2);
+    }
+
+    #[test]
+    fn test_loader_v4_counting_filters_by_kora_authority() {
+        // Usage limits for loader-v4 should only count instructions where Kora is the
+        // (current/new) authority, since those are the ops Kora subsidizes. A user-authored
+        // loader-v4 tx where Kora is only fee-paying (not authority) must not increment
+        // the user's loader-v4 deploy count.
+        use crate::transaction::VersionedTransactionResolved;
+        use solana_loader_v4_interface::instruction as loader_v4;
+        use solana_message::{Message, VersionedMessage};
+        use solana_sdk::{signature::Keypair, signer::Signer, transaction::VersionedTransaction};
+
+        let kora = Keypair::new();
+        let user = Keypair::new();
+        let program = Pubkey::new_unique();
+
+        let build_tx = |authority: &Pubkey| -> VersionedTransactionResolved {
+            let ix = loader_v4::write(&program, authority, 0, vec![1, 2, 3]);
+            let message = VersionedMessage::Legacy(Message::new(&[ix], Some(&kora.pubkey())));
+            let tx = VersionedTransaction { signatures: vec![], message };
+            VersionedTransactionResolved::from_kora_built_transaction(&tx).unwrap()
+        };
+
+        let rule = InstructionRule::lifetime(LOADER_V4_PROGRAM_ID, LOADER_V4_WRITE.to_string(), 10);
+
+        // Kora is authority -> counted
+        let mut tx_kora = build_tx(&kora.pubkey());
+        let mut ctx = LimiterContext {
+            transaction: &mut tx_kora,
+            user_id: "user".to_string(),
+            kora_signer: Some(kora.pubkey()),
+            timestamp: 0,
+        };
+        assert_eq!(rule.count_increment(&mut ctx), 1);
+
+        // User is authority -> NOT counted (even though Kora is fee payer)
+        let mut tx_user = build_tx(&user.pubkey());
+        let mut ctx = LimiterContext {
+            transaction: &mut tx_user,
+            user_id: "user".to_string(),
+            kora_signer: Some(kora.pubkey()),
+            timestamp: 0,
+        };
+        assert_eq!(rule.count_increment(&mut ctx), 0);
+    }
+
+    #[test]
+    fn test_loader_v4_transfer_authority_counts_when_kora_is_new_authority() {
+        // TransferAuthority is special: Kora can be at index 1 (giving up authority) or
+        // index 2 (accepting authority). Both are subsidized operations — count both.
+        use crate::transaction::VersionedTransactionResolved;
+        use solana_loader_v4_interface::instruction as loader_v4;
+        use solana_message::{Message, VersionedMessage};
+        use solana_sdk::{signature::Keypair, signer::Signer, transaction::VersionedTransaction};
+
+        let kora = Keypair::new();
+        let attacker = Keypair::new();
+        let program = Pubkey::new_unique();
+
+        let ix = loader_v4::transfer_authority(&program, &attacker.pubkey(), &kora.pubkey());
+        let message = VersionedMessage::Legacy(Message::new(&[ix], Some(&kora.pubkey())));
+        let tx = VersionedTransaction { signatures: vec![], message };
+        let mut tx_resolved =
+            VersionedTransactionResolved::from_kora_built_transaction(&tx).unwrap();
+
+        let rule = InstructionRule::lifetime(
+            LOADER_V4_PROGRAM_ID,
+            LOADER_V4_TRANSFER_AUTHORITY.to_string(),
+            10,
+        );
+        let mut ctx = LimiterContext {
+            transaction: &mut tx_resolved,
+            user_id: "user".to_string(),
+            kora_signer: Some(kora.pubkey()),
+            timestamp: 0,
+        };
+        assert_eq!(rule.count_increment(&mut ctx), 1);
     }
 }

--- a/crates/lib/src/validator/config_validator.rs
+++ b/crates/lib/src/validator/config_validator.rs
@@ -211,6 +211,27 @@ impl ConfigValidator {
 
             alt, allow_close, "ALT CloseLookupTable instructions",
                 "Users can close lookup tables controlled by the fee payer and redirect lamports to arbitrary recipients";
+
+            loader_v4, allow_write, "Loader-v4 Write instructions",
+                "Users can make the fee payer write arbitrary bytes into program accounts it is the authority for";
+
+            loader_v4, allow_copy, "Loader-v4 Copy instructions",
+                "Users can make the fee payer copy data between program accounts it is the authority for";
+
+            loader_v4, allow_set_program_length, "Loader-v4 SetProgramLength instructions",
+                "Users can make the fee payer resize program accounts. A drainage guard keeps refunds flowing back to the fee payer, but enabling this still lets users force-grow accounts and consume fee-payer rent";
+
+            loader_v4, allow_deploy, "Loader-v4 Deploy instructions",
+                "Users can make the fee payer deploy programs it is the authority for, committing rent";
+
+            loader_v4, allow_retract, "Loader-v4 Retract instructions",
+                "Users can make the fee payer retract deployed programs, taking them out of execution";
+
+            loader_v4, allow_transfer_authority, "Loader-v4 TransferAuthority instructions",
+                "Users can make the fee payer hand program authority to a different account. This can lead to complete loss of control and subsequent drainage";
+
+            loader_v4, allow_finalize, "Loader-v4 Finalize instructions",
+                "Users can make the fee payer finalize programs, making them immutable and forwarding to a next-version program";
         }
 
         // Check nonce policy separately (nested structure)
@@ -2097,7 +2118,15 @@ mod tests {
                         allow_deactivate: true,
                         allow_close: true,
                     },
-                    loader_v4: crate::config::LoaderV4InstructionPolicy::default(),
+                    loader_v4: crate::config::LoaderV4InstructionPolicy {
+                        allow_write: true,
+                        allow_copy: true,
+                        allow_set_program_length: true,
+                        allow_deploy: true,
+                        allow_retract: true,
+                        allow_transfer_authority: true,
+                        allow_finalize: true,
+                    },
                 },
                 price: PriceConfig { model: PriceModel::Free },
                 token_2022: Token2022Config::default(),
@@ -2245,6 +2274,29 @@ mod tests {
         assert!(warnings
             .iter()
             .any(|w| w.contains("ALT CloseLookupTable") && w.contains("allow_close")));
+
+        // Loader-v4 policies
+        assert!(warnings
+            .iter()
+            .any(|w| w.contains("Loader-v4 Write") && w.contains("allow_write")));
+        assert!(warnings.iter().any(|w| w.contains("Loader-v4 Copy") && w.contains("allow_copy")));
+        assert!(warnings
+            .iter()
+            .any(|w| w.contains("Loader-v4 SetProgramLength")
+                && w.contains("allow_set_program_length")));
+        assert!(warnings
+            .iter()
+            .any(|w| w.contains("Loader-v4 Deploy") && w.contains("allow_deploy")));
+        assert!(warnings
+            .iter()
+            .any(|w| w.contains("Loader-v4 Retract") && w.contains("allow_retract")));
+        assert!(warnings
+            .iter()
+            .any(|w| w.contains("Loader-v4 TransferAuthority")
+                && w.contains("allow_transfer_authority")));
+        assert!(warnings
+            .iter()
+            .any(|w| w.contains("Loader-v4 Finalize") && w.contains("allow_finalize")));
 
         // Each warning should contain risk explanation
         let fee_payer_warnings: Vec<_> =

--- a/crates/lib/src/validator/config_validator.rs
+++ b/crates/lib/src/validator/config_validator.rs
@@ -4,8 +4,8 @@ use crate::{
     admin::token_util::find_missing_atas,
     config::{FeePayerPolicy, SplTokenConfig, Token2022Config, TransferHookPolicy},
     constant::{
-        BPF_LOADER_UPGRADEABLE_PROGRAM_ID, LIGHTHOUSE_PROGRAM_ID, LOADER_V4_PROGRAM_ID,
-        MAX_RECAPTCHA_SCORE, MIN_RECAPTCHA_SCORE, STAKE_PROGRAM_ID, VOTE_PROGRAM_ID,
+        LIGHTHOUSE_PROGRAM_ID, LOADER_V4_PROGRAM_ID, MAX_RECAPTCHA_SCORE, MIN_RECAPTCHA_SCORE,
+        STAKE_PROGRAM_ID, VOTE_PROGRAM_ID,
     },
     fee::price::PriceModel,
     oracle::PriceSource,
@@ -272,18 +272,17 @@ impl ConfigValidator {
     /// instruction parser.
     ///
     /// Two tiers:
-    /// 1. **High-risk native programs** (Vote, Stake, BpfUpgradeableLoader) — these can
-    ///    directly control funds without routing through inner System/SPL instructions, so a
-    ///    targeted warning is emitted.
+    /// 1. **High-risk native programs** (Vote, Stake) — these can directly control funds
+    ///    without routing through inner System/SPL instructions, so a targeted warning is
+    ///    emitted.
     /// 2. **Any other unrecognised program** — custom programs always use inner instructions
-    ///    (System, SPL Token, Token-2022, ALT) for actual fund movement, so only those inner
-    ///    instructions are validated.  This is a known, accepted limitation; an informational
-    ///    warning is emitted so operators are aware.
+    ///    (System, SPL Token, Token-2022, ALT, Loader-v4) for actual fund movement, so only
+    ///    those inner instructions are validated. This is a known, accepted limitation; an
+    ///    informational warning is emitted so operators are aware.
     fn warn_unvalidated_programs(allowed_programs: &[String], warnings: &mut Vec<String>) {
         let high_risk = [
             (VOTE_PROGRAM_ID.to_string(), "Vote Program"),
             (STAKE_PROGRAM_ID.to_string(), "Stake Program"),
-            (BPF_LOADER_UPGRADEABLE_PROGRAM_ID.to_string(), "BPF Loader Upgradeable"),
         ];
 
         for (program_id, program_name) in &high_risk {
@@ -2731,13 +2730,18 @@ mod tests {
 
     #[test]
     fn test_warn_unvalidated_programs_warns_for_bpf_loader_upgradeable() {
+        // BPF Loader Upgradeable (loader-v3) no longer gets a targeted high-risk warning now
+        // that loader-v4 is the primary loader we validate. It still lacks a dedicated parser
+        // in Kora, so it falls through to the generic "no dedicated fee-payer instruction
+        // parser" warning like any other custom program.
         use crate::constant::BPF_LOADER_UPGRADEABLE_PROGRAM_ID;
         let allowed =
             vec![SYSTEM_PROGRAM_ID.to_string(), BPF_LOADER_UPGRADEABLE_PROGRAM_ID.to_string()];
         let mut warnings = Vec::new();
         ConfigValidator::warn_unvalidated_programs(&allowed, &mut warnings);
         assert_eq!(warnings.len(), 1);
-        assert!(warnings[0].contains("BPF Loader Upgradeable"));
+        assert!(warnings[0].contains(&BPF_LOADER_UPGRADEABLE_PROGRAM_ID.to_string()));
+        assert!(warnings[0].contains("no dedicated fee-payer instruction parser"));
     }
 
     #[test]

--- a/crates/lib/src/validator/config_validator.rs
+++ b/crates/lib/src/validator/config_validator.rs
@@ -4,8 +4,8 @@ use crate::{
     admin::token_util::find_missing_atas,
     config::{FeePayerPolicy, SplTokenConfig, Token2022Config, TransferHookPolicy},
     constant::{
-        BPF_LOADER_UPGRADEABLE_PROGRAM_ID, LIGHTHOUSE_PROGRAM_ID, MAX_RECAPTCHA_SCORE,
-        MIN_RECAPTCHA_SCORE, STAKE_PROGRAM_ID, VOTE_PROGRAM_ID,
+        BPF_LOADER_UPGRADEABLE_PROGRAM_ID, LIGHTHOUSE_PROGRAM_ID, LOADER_V4_PROGRAM_ID,
+        MAX_RECAPTCHA_SCORE, MIN_RECAPTCHA_SCORE, STAKE_PROGRAM_ID, VOTE_PROGRAM_ID,
     },
     fee::price::PriceModel,
     oracle::PriceSource,
@@ -284,6 +284,7 @@ impl ConfigValidator {
             spl_associated_token_account_interface::program::id().to_string(),
             solana_compute_budget_interface::id().to_string(),
             LIGHTHOUSE_PROGRAM_ID.to_string(),
+            LOADER_V4_PROGRAM_ID.to_string(),
         ]
         .into_iter()
         .chain(high_risk.iter().map(|(id, _)| id.clone()))
@@ -2096,6 +2097,7 @@ mod tests {
                         allow_deactivate: true,
                         allow_close: true,
                     },
+                    loader_v4: crate::config::LoaderV4InstructionPolicy::default(),
                 },
                 price: PriceConfig { model: PriceModel::Free },
                 token_2022: Token2022Config::default(),

--- a/crates/lib/src/validator/macros.rs
+++ b/crates/lib/src/validator/macros.rs
@@ -74,9 +74,11 @@ macro_rules! validate_spl_multisig {
     };
 }
 
-/// Macro to validate ALT instructions with custom fee-payer matching logic
+/// Macro to validate ALT instructions with custom fee-payer matching logic.
+/// The caller's `$fee_payer_used` expression is pre-evaluated and already references
+/// `self.fee_payer_pubkey`, so the macro does not need to capture `self`.
 macro_rules! validate_alt {
-    ($self:expr, $instructions:expr, $type:ident, $pattern:pat => $fee_payer_used:expr, $policy:expr, $name:expr) => {
+    ($instructions:expr, $type:ident, $pattern:pat => $fee_payer_used:expr, $policy:expr, $name:expr) => {
         for instruction in $instructions.get(&ParsedALTInstructionType::$type).unwrap_or(&vec![]) {
             if let $pattern = instruction {
                 if $fee_payer_used && !$policy {
@@ -90,9 +92,11 @@ macro_rules! validate_alt {
     };
 }
 
-/// Macro to validate Loader-v4 instructions with custom fee-payer matching logic
+/// Macro to validate Loader-v4 instructions with custom fee-payer matching logic.
+/// Same shape as `validate_alt!` — the caller's `$fee_payer_used` expression is
+/// pre-evaluated against `self.fee_payer_pubkey` at the call site.
 macro_rules! validate_loader_v4 {
-    ($self:expr, $instructions:expr, $type:ident, $pattern:pat => $fee_payer_used:expr, $policy:expr, $name:expr) => {
+    ($instructions:expr, $type:ident, $pattern:pat => $fee_payer_used:expr, $policy:expr, $name:expr) => {
         for instruction in
             $instructions.get(&ParsedLoaderV4InstructionType::$type).unwrap_or(&vec![])
         {

--- a/crates/lib/src/validator/macros.rs
+++ b/crates/lib/src/validator/macros.rs
@@ -90,6 +90,24 @@ macro_rules! validate_alt {
     };
 }
 
+/// Macro to validate Loader-v4 instructions with custom fee-payer matching logic
+macro_rules! validate_loader_v4 {
+    ($self:expr, $instructions:expr, $type:ident, $pattern:pat => $fee_payer_used:expr, $policy:expr, $name:expr) => {
+        for instruction in
+            $instructions.get(&ParsedLoaderV4InstructionType::$type).unwrap_or(&vec![])
+        {
+            if let $pattern = instruction {
+                if $fee_payer_used && !$policy {
+                    return Err(KoraError::InvalidTransaction(format!(
+                        "Fee payer cannot be used for '{}'",
+                        $name
+                    )));
+                }
+            }
+        }
+    };
+}
+
 /// Macro to validate Token2022-only instructions with custom fee-payer matching logic
 macro_rules! validate_token2022 {
     ($self:expr, $instructions:expr, $type:ident, $pattern:pat => $fee_payer_used:expr, $message:expr) => {

--- a/crates/lib/src/validator/transaction_validator.rs
+++ b/crates/lib/src/validator/transaction_validator.rs
@@ -404,7 +404,7 @@ impl TransactionValidator {
         // Validate ALT instructions
         let alt_instructions = transaction_resolved.get_or_parse_alt_instructions()?;
 
-        validate_alt!(self, alt_instructions, AltCreateLookupTable,
+        validate_alt!(alt_instructions, AltCreateLookupTable,
             ParsedALTInstructionData::AltCreateLookupTable {
                 lookup_table_authority,
                 payer_account,
@@ -414,7 +414,7 @@ impl TransactionValidator {
             self.fee_payer_policy.alt.allow_create,
             "ALT CreateLookupTable");
 
-        validate_alt!(self, alt_instructions, AltExtendLookupTable,
+        validate_alt!(alt_instructions, AltExtendLookupTable,
             ParsedALTInstructionData::AltExtendLookupTable {
                 lookup_table_authority,
                 payer_account,
@@ -424,19 +424,19 @@ impl TransactionValidator {
             self.fee_payer_policy.alt.allow_extend,
             "ALT ExtendLookupTable");
 
-        validate_alt!(self, alt_instructions, AltFreezeLookupTable,
+        validate_alt!(alt_instructions, AltFreezeLookupTable,
             ParsedALTInstructionData::AltFreezeLookupTable { lookup_table_authority, .. } =>
             *lookup_table_authority == self.fee_payer_pubkey,
             self.fee_payer_policy.alt.allow_freeze,
             "ALT FreezeLookupTable");
 
-        validate_alt!(self, alt_instructions, AltDeactivateLookupTable,
+        validate_alt!(alt_instructions, AltDeactivateLookupTable,
             ParsedALTInstructionData::AltDeactivateLookupTable { lookup_table_authority, .. } =>
             *lookup_table_authority == self.fee_payer_pubkey,
             self.fee_payer_policy.alt.allow_deactivate,
             "ALT DeactivateLookupTable");
 
-        validate_alt!(self, alt_instructions, AltCloseLookupTable,
+        validate_alt!(alt_instructions, AltCloseLookupTable,
             ParsedALTInstructionData::AltCloseLookupTable { lookup_table_authority, .. } =>
             *lookup_table_authority == self.fee_payer_pubkey,
             self.fee_payer_policy.alt.allow_close,
@@ -445,19 +445,19 @@ impl TransactionValidator {
         // Validate Loader-v4 (BPF loader successor) instructions.
         let loader_v4_instructions = transaction_resolved.get_or_parse_loader_v4_instructions()?;
 
-        validate_loader_v4!(self, loader_v4_instructions, Write,
+        validate_loader_v4!(loader_v4_instructions, Write,
             ParsedLoaderV4InstructionData::Write { authority, .. } =>
             *authority == self.fee_payer_pubkey,
             self.fee_payer_policy.loader_v4.allow_write,
             "Loader-v4 Write");
 
-        validate_loader_v4!(self, loader_v4_instructions, Copy,
+        validate_loader_v4!(loader_v4_instructions, Copy,
             ParsedLoaderV4InstructionData::Copy { authority, .. } =>
             *authority == self.fee_payer_pubkey,
             self.fee_payer_policy.loader_v4.allow_copy,
             "Loader-v4 Copy");
 
-        validate_loader_v4!(self, loader_v4_instructions, SetProgramLength,
+        validate_loader_v4!(loader_v4_instructions, SetProgramLength,
             ParsedLoaderV4InstructionData::SetProgramLength { authority, recipient, .. } =>
             (*authority == self.fee_payer_pubkey
                 || recipient.is_some_and(|r| r == self.fee_payer_pubkey)),
@@ -489,25 +489,25 @@ impl TransactionValidator {
             }
         }
 
-        validate_loader_v4!(self, loader_v4_instructions, Deploy,
+        validate_loader_v4!(loader_v4_instructions, Deploy,
             ParsedLoaderV4InstructionData::Deploy { authority, .. } =>
             *authority == self.fee_payer_pubkey,
             self.fee_payer_policy.loader_v4.allow_deploy,
             "Loader-v4 Deploy");
 
-        validate_loader_v4!(self, loader_v4_instructions, Retract,
+        validate_loader_v4!(loader_v4_instructions, Retract,
             ParsedLoaderV4InstructionData::Retract { authority, .. } =>
             *authority == self.fee_payer_pubkey,
             self.fee_payer_policy.loader_v4.allow_retract,
             "Loader-v4 Retract");
 
-        validate_loader_v4!(self, loader_v4_instructions, TransferAuthority,
+        validate_loader_v4!(loader_v4_instructions, TransferAuthority,
             ParsedLoaderV4InstructionData::TransferAuthority { current_authority, .. } =>
             *current_authority == self.fee_payer_pubkey,
             self.fee_payer_policy.loader_v4.allow_transfer_authority,
             "Loader-v4 TransferAuthority");
 
-        validate_loader_v4!(self, loader_v4_instructions, Finalize,
+        validate_loader_v4!(loader_v4_instructions, Finalize,
             ParsedLoaderV4InstructionData::Finalize { current_authority, .. } =>
             *current_authority == self.fee_payer_pubkey,
             self.fee_payer_policy.loader_v4.allow_finalize,

--- a/crates/lib/src/validator/transaction_validator.rs
+++ b/crates/lib/src/validator/transaction_validator.rs
@@ -8,9 +8,10 @@ use crate::{
         token::{TokenUtil, TransferHookValidationFlow},
     },
     transaction::{
-        ParsedALTInstructionData, ParsedALTInstructionType, ParsedSPLInstructionData,
-        ParsedSPLInstructionType, ParsedSystemInstructionData, ParsedSystemInstructionType,
-        Token2022AccountUsagePolicy, VersionedTransactionResolved,
+        ParsedALTInstructionData, ParsedALTInstructionType, ParsedLoaderV4InstructionData,
+        ParsedLoaderV4InstructionType, ParsedSPLInstructionData, ParsedSPLInstructionType,
+        ParsedSystemInstructionData, ParsedSystemInstructionType, Token2022AccountUsagePolicy,
+        VersionedTransactionResolved,
     },
 };
 use solana_client::nonblocking::rpc_client::RpcClient;
@@ -440,6 +441,77 @@ impl TransactionValidator {
             *lookup_table_authority == self.fee_payer_pubkey,
             self.fee_payer_policy.alt.allow_close,
             "ALT CloseLookupTable");
+
+        // Validate Loader-v4 (BPF loader successor) instructions.
+        let loader_v4_instructions = transaction_resolved.get_or_parse_loader_v4_instructions()?;
+
+        validate_loader_v4!(self, loader_v4_instructions, Write,
+            ParsedLoaderV4InstructionData::Write { authority, .. } =>
+            *authority == self.fee_payer_pubkey,
+            self.fee_payer_policy.loader_v4.allow_write,
+            "Loader-v4 Write");
+
+        validate_loader_v4!(self, loader_v4_instructions, Copy,
+            ParsedLoaderV4InstructionData::Copy { authority, .. } =>
+            *authority == self.fee_payer_pubkey,
+            self.fee_payer_policy.loader_v4.allow_copy,
+            "Loader-v4 Copy");
+
+        validate_loader_v4!(self, loader_v4_instructions, SetProgramLength,
+            ParsedLoaderV4InstructionData::SetProgramLength { authority, recipient, .. } =>
+            (*authority == self.fee_payer_pubkey
+                || recipient.is_some_and(|r| r == self.fee_payer_pubkey)),
+            self.fee_payer_policy.loader_v4.allow_set_program_length,
+            "Loader-v4 SetProgramLength");
+
+        // Drainage guard: when the fee payer is the SetProgramLength authority, the recipient
+        // (if present) must be the fee payer. Otherwise shrink-to-zero or over-funded-growth
+        // refunds would flow to an attacker-controlled account, draining Kora's rent.
+        for instruction in loader_v4_instructions
+            .get(&ParsedLoaderV4InstructionType::SetProgramLength)
+            .unwrap_or(&vec![])
+        {
+            if let ParsedLoaderV4InstructionData::SetProgramLength {
+                authority, recipient, ..
+            } = instruction
+            {
+                if *authority == self.fee_payer_pubkey {
+                    if let Some(r) = recipient {
+                        if *r != self.fee_payer_pubkey {
+                            return Err(KoraError::InvalidTransaction(
+                                "Loader-v4 SetProgramLength: when fee payer is the authority, \
+                                 recipient must also be the fee payer (drainage guard)"
+                                    .to_string(),
+                            ));
+                        }
+                    }
+                }
+            }
+        }
+
+        validate_loader_v4!(self, loader_v4_instructions, Deploy,
+            ParsedLoaderV4InstructionData::Deploy { authority, .. } =>
+            *authority == self.fee_payer_pubkey,
+            self.fee_payer_policy.loader_v4.allow_deploy,
+            "Loader-v4 Deploy");
+
+        validate_loader_v4!(self, loader_v4_instructions, Retract,
+            ParsedLoaderV4InstructionData::Retract { authority, .. } =>
+            *authority == self.fee_payer_pubkey,
+            self.fee_payer_policy.loader_v4.allow_retract,
+            "Loader-v4 Retract");
+
+        validate_loader_v4!(self, loader_v4_instructions, TransferAuthority,
+            ParsedLoaderV4InstructionData::TransferAuthority { current_authority, .. } =>
+            *current_authority == self.fee_payer_pubkey,
+            self.fee_payer_policy.loader_v4.allow_transfer_authority,
+            "Loader-v4 TransferAuthority");
+
+        validate_loader_v4!(self, loader_v4_instructions, Finalize,
+            ParsedLoaderV4InstructionData::Finalize { current_authority, .. } =>
+            *current_authority == self.fee_payer_pubkey,
+            self.fee_payer_policy.loader_v4.allow_finalize,
+            "Loader-v4 Finalize");
 
         let spl_instructions = transaction_resolved.get_or_parse_spl_instructions()?;
         validate_token2022!(self, spl_instructions, SplTokenReallocate,
@@ -4977,5 +5049,259 @@ mod tests {
         } else {
             panic!("Expected InvalidTransaction error for revoke policy");
         }
+    }
+
+    // ----------------------------------------------------------------------------
+    // Loader-v4 tests
+    // ----------------------------------------------------------------------------
+
+    fn setup_loader_v4_config_with_policy(policy: FeePayerPolicy) {
+        use crate::constant::LOADER_V4_PROGRAM_ID;
+        let config = ConfigMockBuilder::new()
+            .with_price_source(PriceSource::Mock)
+            .with_allowed_programs(vec![
+                LOADER_V4_PROGRAM_ID.to_string(),
+                SYSTEM_PROGRAM_ID.to_string(),
+            ])
+            .with_max_allowed_lamports(10_000_000_000)
+            .with_fee_payer_policy(policy)
+            .build();
+        setup_both_configs(config);
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_loader_v4_write_requires_policy() {
+        use solana_loader_v4_interface::instruction as loader_v4;
+        let fee_payer = Pubkey::new_unique();
+        let program = Pubkey::new_unique();
+
+        // allow_write = true -> accepted
+        let mut policy = FeePayerPolicy::default();
+        policy.loader_v4.allow_write = true;
+        setup_loader_v4_config_with_policy(policy);
+
+        let rpc_client = RpcMockBuilder::new().build();
+        let config = get_config().unwrap();
+        let validator = TransactionValidator::new(config, fee_payer).unwrap();
+
+        let ix = loader_v4::write(&program, &fee_payer, 0, vec![1, 2, 3]);
+        let message = VersionedMessage::Legacy(Message::new(&[ix], Some(&fee_payer)));
+        let mut transaction =
+            TransactionUtil::new_unsigned_versioned_transaction_resolved(message).unwrap();
+        assert!(validator
+            .validate_transaction(config, &mut transaction, &rpc_client)
+            .await
+            .is_ok());
+
+        // default (allow_write = false) -> rejected
+        setup_loader_v4_config_with_policy(FeePayerPolicy::default());
+        let rpc_client = RpcMockBuilder::new().build();
+        let config = get_config().unwrap();
+        let validator = TransactionValidator::new(config, fee_payer).unwrap();
+
+        let ix = loader_v4::write(&program, &fee_payer, 0, vec![1, 2, 3]);
+        let message = VersionedMessage::Legacy(Message::new(&[ix], Some(&fee_payer)));
+        let mut transaction =
+            TransactionUtil::new_unsigned_versioned_transaction_resolved(message).unwrap();
+        assert!(validator
+            .validate_transaction(config, &mut transaction, &rpc_client)
+            .await
+            .is_err());
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_loader_v4_deploy_requires_policy() {
+        use solana_loader_v4_interface::instruction as loader_v4;
+        let fee_payer = Pubkey::new_unique();
+        let program = Pubkey::new_unique();
+
+        let mut policy = FeePayerPolicy::default();
+        policy.loader_v4.allow_deploy = true;
+        setup_loader_v4_config_with_policy(policy);
+
+        let rpc_client = RpcMockBuilder::new().build();
+        let config = get_config().unwrap();
+        let validator = TransactionValidator::new(config, fee_payer).unwrap();
+
+        let ix = loader_v4::deploy(&program, &fee_payer);
+        let message = VersionedMessage::Legacy(Message::new(&[ix], Some(&fee_payer)));
+        let mut transaction =
+            TransactionUtil::new_unsigned_versioned_transaction_resolved(message).unwrap();
+        assert!(validator
+            .validate_transaction(config, &mut transaction, &rpc_client)
+            .await
+            .is_ok());
+
+        // disabled -> rejected
+        setup_loader_v4_config_with_policy(FeePayerPolicy::default());
+        let rpc_client = RpcMockBuilder::new().build();
+        let config = get_config().unwrap();
+        let validator = TransactionValidator::new(config, fee_payer).unwrap();
+
+        let ix = loader_v4::deploy(&program, &fee_payer);
+        let message = VersionedMessage::Legacy(Message::new(&[ix], Some(&fee_payer)));
+        let mut transaction =
+            TransactionUtil::new_unsigned_versioned_transaction_resolved(message).unwrap();
+        assert!(validator
+            .validate_transaction(config, &mut transaction, &rpc_client)
+            .await
+            .is_err());
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_loader_v4_retract_requires_policy() {
+        use solana_loader_v4_interface::instruction as loader_v4;
+        let fee_payer = Pubkey::new_unique();
+        let program = Pubkey::new_unique();
+
+        let mut policy = FeePayerPolicy::default();
+        policy.loader_v4.allow_retract = true;
+        setup_loader_v4_config_with_policy(policy);
+
+        let rpc_client = RpcMockBuilder::new().build();
+        let config = get_config().unwrap();
+        let validator = TransactionValidator::new(config, fee_payer).unwrap();
+
+        let ix = loader_v4::retract(&program, &fee_payer);
+        let message = VersionedMessage::Legacy(Message::new(&[ix], Some(&fee_payer)));
+        let mut transaction =
+            TransactionUtil::new_unsigned_versioned_transaction_resolved(message).unwrap();
+        assert!(validator
+            .validate_transaction(config, &mut transaction, &rpc_client)
+            .await
+            .is_ok());
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_loader_v4_set_program_length_accepts_self_recipient() {
+        // When the fee payer is authority AND recipient, freed lamports return to Kora.
+        use solana_loader_v4_interface::instruction as loader_v4;
+        let fee_payer = Pubkey::new_unique();
+        let program = Pubkey::new_unique();
+
+        let mut policy = FeePayerPolicy::default();
+        policy.loader_v4.allow_set_program_length = true;
+        setup_loader_v4_config_with_policy(policy);
+
+        let rpc_client = RpcMockBuilder::new().build();
+        let config = get_config().unwrap();
+        let validator = TransactionValidator::new(config, fee_payer).unwrap();
+
+        let ix = loader_v4::set_program_length(&program, &fee_payer, 1024, &fee_payer);
+        let message = VersionedMessage::Legacy(Message::new(&[ix], Some(&fee_payer)));
+        let mut transaction =
+            TransactionUtil::new_unsigned_versioned_transaction_resolved(message).unwrap();
+        assert!(validator
+            .validate_transaction(config, &mut transaction, &rpc_client)
+            .await
+            .is_ok());
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_loader_v4_set_program_length_rejects_foreign_recipient() {
+        // Drainage guard: when Kora is authority, any recipient other than Kora is rejected.
+        // Shrinking to zero with a user recipient would drain Kora's rent lamports.
+        use solana_loader_v4_interface::instruction as loader_v4;
+        let fee_payer = Pubkey::new_unique();
+        let user_recipient = Pubkey::new_unique();
+        let program = Pubkey::new_unique();
+
+        let mut policy = FeePayerPolicy::default();
+        policy.loader_v4.allow_set_program_length = true;
+        setup_loader_v4_config_with_policy(policy);
+
+        let rpc_client = RpcMockBuilder::new().build();
+        let config = get_config().unwrap();
+        let validator = TransactionValidator::new(config, fee_payer).unwrap();
+
+        let ix = loader_v4::set_program_length(&program, &fee_payer, 0, &user_recipient);
+        let message = VersionedMessage::Legacy(Message::new(&[ix], Some(&fee_payer)));
+        let mut transaction =
+            TransactionUtil::new_unsigned_versioned_transaction_resolved(message).unwrap();
+        let err = validator
+            .validate_transaction(config, &mut transaction, &rpc_client)
+            .await
+            .expect_err("shrink to foreign recipient must be rejected");
+        if let KoraError::InvalidTransaction(msg) = err {
+            assert!(msg.contains("drainage guard"));
+        } else {
+            panic!("expected InvalidTransaction, got {err:?}");
+        }
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_loader_v4_set_program_length_rejects_when_policy_disabled() {
+        use solana_loader_v4_interface::instruction as loader_v4;
+        let fee_payer = Pubkey::new_unique();
+        let program = Pubkey::new_unique();
+
+        setup_loader_v4_config_with_policy(FeePayerPolicy::default());
+
+        let rpc_client = RpcMockBuilder::new().build();
+        let config = get_config().unwrap();
+        let validator = TransactionValidator::new(config, fee_payer).unwrap();
+
+        let ix = loader_v4::set_program_length(&program, &fee_payer, 1024, &fee_payer);
+        let message = VersionedMessage::Legacy(Message::new(&[ix], Some(&fee_payer)));
+        let mut transaction =
+            TransactionUtil::new_unsigned_versioned_transaction_resolved(message).unwrap();
+        assert!(validator
+            .validate_transaction(config, &mut transaction, &rpc_client)
+            .await
+            .is_err());
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_loader_v4_transfer_authority_denied_by_default() {
+        use solana_loader_v4_interface::instruction as loader_v4;
+        let fee_payer = Pubkey::new_unique();
+        let program = Pubkey::new_unique();
+        let new_authority = Pubkey::new_unique();
+
+        setup_loader_v4_config_with_policy(FeePayerPolicy::default());
+
+        let rpc_client = RpcMockBuilder::new().build();
+        let config = get_config().unwrap();
+        let validator = TransactionValidator::new(config, fee_payer).unwrap();
+
+        let ix = loader_v4::transfer_authority(&program, &fee_payer, &new_authority);
+        let message = VersionedMessage::Legacy(Message::new(&[ix], Some(&fee_payer)));
+        let mut transaction =
+            TransactionUtil::new_unsigned_versioned_transaction_resolved(message).unwrap();
+        assert!(validator
+            .validate_transaction(config, &mut transaction, &rpc_client)
+            .await
+            .is_err());
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_loader_v4_finalize_denied_by_default() {
+        use solana_loader_v4_interface::instruction as loader_v4;
+        let fee_payer = Pubkey::new_unique();
+        let program = Pubkey::new_unique();
+        let next_version = Pubkey::new_unique();
+
+        setup_loader_v4_config_with_policy(FeePayerPolicy::default());
+
+        let rpc_client = RpcMockBuilder::new().build();
+        let config = get_config().unwrap();
+        let validator = TransactionValidator::new(config, fee_payer).unwrap();
+
+        let ix = loader_v4::finalize(&program, &fee_payer, &next_version);
+        let message = VersionedMessage::Legacy(Message::new(&[ix], Some(&fee_payer)));
+        let mut transaction =
+            TransactionUtil::new_unsigned_versioned_transaction_resolved(message).unwrap();
+        assert!(validator
+            .validate_transaction(config, &mut transaction, &rpc_client)
+            .await
+            .is_err());
     }
 }

--- a/crates/lib/src/validator/transaction_validator.rs
+++ b/crates/lib/src/validator/transaction_validator.rs
@@ -501,9 +501,16 @@ impl TransactionValidator {
             self.fee_payer_policy.loader_v4.allow_retract,
             "Loader-v4 Retract");
 
+        // Both current_authority and new_authority are required signers in TransferAuthority.
+        // The fee payer's transaction-level signature satisfies either slot, so guard both:
+        // without the `new_authority` check, an attacker could craft a tx with
+        // current_authority=attacker and new_authority=fee_payer and silently transfer program
+        // authority to Kora (setting up later abuse if allow_write/allow_deploy are enabled).
         validate_loader_v4!(loader_v4_instructions, TransferAuthority,
-            ParsedLoaderV4InstructionData::TransferAuthority { current_authority, .. } =>
-            *current_authority == self.fee_payer_pubkey,
+            ParsedLoaderV4InstructionData::TransferAuthority {
+                current_authority, new_authority, ..
+            } => (*current_authority == self.fee_payer_pubkey
+                || *new_authority == self.fee_payer_pubkey),
             self.fee_payer_policy.loader_v4.allow_transfer_authority,
             "Loader-v4 TransferAuthority");
 
@@ -5314,6 +5321,36 @@ mod tests {
         let validator = TransactionValidator::new(config, fee_payer).unwrap();
 
         let ix = loader_v4::transfer_authority(&program, &fee_payer, &new_authority);
+        let message = VersionedMessage::Legacy(Message::new(&[ix], Some(&fee_payer)));
+        let mut transaction =
+            TransactionUtil::new_unsigned_versioned_transaction_resolved(message).unwrap();
+        assert!(validator
+            .validate_transaction(config, &mut transaction, &rpc_client)
+            .await
+            .is_err());
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_loader_v4_transfer_authority_rejects_when_fee_payer_is_new_authority() {
+        // Regression: loader-v4 TransferAuthority requires BOTH current and new authority to
+        // sign. The fee payer's transaction-level signature satisfies the new_authority slot,
+        // so an attacker can set current_authority=attacker and new_authority=fee_payer and
+        // silently push program authority onto Kora. The validator must reject this even when
+        // current_authority != fee_payer.
+        use solana_loader_v4_interface::instruction as loader_v4;
+        let fee_payer = Pubkey::new_unique();
+        let attacker = Pubkey::new_unique();
+        let program = Pubkey::new_unique();
+
+        setup_loader_v4_config_with_policy(FeePayerPolicy::default());
+
+        let rpc_client = RpcMockBuilder::new().build();
+        let config = get_config().unwrap();
+        let validator = TransactionValidator::new(config, fee_payer).unwrap();
+
+        // current_authority = attacker (not fee_payer), new_authority = fee_payer.
+        let ix = loader_v4::transfer_authority(&program, &attacker, &fee_payer);
         let message = VersionedMessage::Legacy(Message::new(&[ix], Some(&fee_payer)));
         let mut transaction =
             TransactionUtil::new_unsigned_versioned_transaction_resolved(message).unwrap();

--- a/crates/lib/src/validator/transaction_validator.rs
+++ b/crates/lib/src/validator/transaction_validator.rs
@@ -5152,6 +5152,48 @@ mod tests {
 
     #[tokio::test]
     #[serial]
+    async fn test_loader_v4_copy_requires_policy() {
+        use solana_loader_v4_interface::instruction as loader_v4;
+        let fee_payer = Pubkey::new_unique();
+        let destination = Pubkey::new_unique();
+        let source = Pubkey::new_unique();
+
+        // allow_copy = true -> accepted
+        let mut policy = FeePayerPolicy::default();
+        policy.loader_v4.allow_copy = true;
+        setup_loader_v4_config_with_policy(policy);
+
+        let rpc_client = RpcMockBuilder::new().build();
+        let config = get_config().unwrap();
+        let validator = TransactionValidator::new(config, fee_payer).unwrap();
+
+        let ix = loader_v4::copy(&destination, &fee_payer, &source, 0, 0, 64);
+        let message = VersionedMessage::Legacy(Message::new(&[ix], Some(&fee_payer)));
+        let mut transaction =
+            TransactionUtil::new_unsigned_versioned_transaction_resolved(message).unwrap();
+        assert!(validator
+            .validate_transaction(config, &mut transaction, &rpc_client)
+            .await
+            .is_ok());
+
+        // default (allow_copy = false) -> rejected
+        setup_loader_v4_config_with_policy(FeePayerPolicy::default());
+        let rpc_client = RpcMockBuilder::new().build();
+        let config = get_config().unwrap();
+        let validator = TransactionValidator::new(config, fee_payer).unwrap();
+
+        let ix = loader_v4::copy(&destination, &fee_payer, &source, 0, 0, 64);
+        let message = VersionedMessage::Legacy(Message::new(&[ix], Some(&fee_payer)));
+        let mut transaction =
+            TransactionUtil::new_unsigned_versioned_transaction_resolved(message).unwrap();
+        assert!(validator
+            .validate_transaction(config, &mut transaction, &rpc_client)
+            .await
+            .is_err());
+    }
+
+    #[tokio::test]
+    #[serial]
     async fn test_loader_v4_retract_requires_policy() {
         use solana_loader_v4_interface::instruction as loader_v4;
         let fee_payer = Pubkey::new_unique();

--- a/tests/src/common/fixtures/fee-payer-policy-test.toml
+++ b/tests/src/common/fixtures/fee-payer-policy-test.toml
@@ -33,6 +33,7 @@ allowed_programs = [
     "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb",  # Token-2022 Program
     "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL", # Associated Token Program
     "AddressLookupTab1e1111111111111111111111111",  # Address Lookup Table Program
+    "LoaderV411111111111111111111111111111111111",  # Loader-v4 Program
 ]
 allowed_tokens = [
     "9BgeTKqmFsPVnfYscfM6NvsgmZxei7XfdciShQ6D3bxJ", # Test USDC mint for local testing
@@ -95,6 +96,15 @@ allow_initialize_account = false
 allow_initialize_multisig = false
 allow_freeze_account = false
 allow_thaw_account = false
+
+[validation.fee_payer_policy.loader_v4]
+allow_write = false
+allow_copy = false
+allow_set_program_length = false
+allow_deploy = false
+allow_retract = false
+allow_transfer_authority = false
+allow_finalize = false
 
 [kora.usage_limit]
 enabled = false


### PR DESCRIPTION
## Summary
- Adds `LoaderV4InstructionPolicy` covering all 7 loader-v4 variants (Write, Copy, SetProgramLength, Deploy, Retract, TransferAuthority, Finalize), default-deny, so operators can opt into subsidizing program deployment on loader-v4 without re-opening drainage vectors.
- **SetProgramLength drainage guard**: when the fee payer is the authority, the recipient (if present) must equal the fee payer. Blocks shrink-to-zero or over-funded-growth refunds flowing to an attacker-controlled account.
- `TransferAuthority` and `Finalize` are gated by policy so users can't hand off control of a Kora-sponsored program or forward it to a next-version program.
- Loader-v4 instructions are wired into the per-wallet usage-limit matcher via `InstructionIdentifier::loader_v4()`, so operators can rate-limit e.g. `Deploy` or `Write` per API key.

## Test Plan
- `cargo test -p kora-lib --lib loader_v4` — 9 validator tests + 1 bincode roundtrip identifier test, all green
- `cargo test -p kora-lib --lib validator:: usage_limit:: transaction::` — 341 tests across touched modules, 0 regressions
- `cargo clippy -p kora-lib --all-targets` — clean
- `cargo fmt --check` — clean
- Policy struct derives `#[serde(default)]`, so existing `kora.toml` files without a `[validation.fee_payer_policy.loader_v4]` section keep loader-v4 fully disabled (backwards compatible)

## Notes
- BPF Loader Upgradeable (loader-v3) support was considered but not included — loader-v4 is the new canonical loader, and adding v3 alongside adds surface area we don't currently need. If a use case emerges, the same pattern works for v3.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/solana-foundation/kora/pull/449" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->










## 📊 Unit Test Coverage
![Coverage](https://img.shields.io/badge/coverage-85.6%25-green)

**Unit Test Coverage: 85.6%**

[View Detailed Coverage Report](https://github.com/solana-foundation/kora/actions/runs/24851167718)