### PR TITLE
feat(plugin): add DeployAuthority plugin for devnet-deploy paymasters

### DIFF
--- a/crates/lib/src/cache.rs
+++ b/crates/lib/src/cache.rs
@@ -41,11 +41,13 @@ impl CacheUtil {
 
         #[allow(clippy::needless_borrow)]
         let pool = if CacheUtil::is_cache_enabled(&config) {
-            let redis_url = config.kora.cache.url.as_ref().ok_or(KoraError::ConfigError(
-                "Redis URL is required when cache is enabled. Set redis_url in config".to_string(),
+            let redis_url = config.kora.cache.resolved_url().ok_or(KoraError::ConfigError(
+                "Redis URL is required when cache is enabled. Set the url in config or the \
+                 KORA_REDIS_URL environment variable."
+                    .to_string(),
             ))?;
 
-            let cfg = deadpool_redis::Config::from_url(redis_url);
+            let cfg = deadpool_redis::Config::from_url(&redis_url);
             let pool = cfg.create_pool(Some(Runtime::Tokio1)).map_err(|e| {
                 KoraError::InternalServerError(format!(
                     "Failed to create cache pool: {}",
@@ -189,7 +191,7 @@ impl CacheUtil {
 
     /// Check if cache is enabled and available
     fn is_cache_enabled(config: &Config) -> bool {
-        config.kora.cache.enabled && config.kora.cache.url.is_some()
+        config.kora.cache.enabled && config.kora.cache.resolved_url().is_some()
     }
 
     /// Get account from cache with optional force refresh

--- a/crates/lib/src/config.rs
+++ b/crates/lib/src/config.rs
@@ -547,10 +547,19 @@ impl Default for CacheConfig {
     }
 }
 
+impl CacheConfig {
+    /// Resolve the Redis URL to use. Priority: `KORA_REDIS_URL` env var over the `url`
+    /// field from the TOML config. Returns `None` when neither is set.
+    pub fn resolved_url(&self) -> Option<String> {
+        std::env::var("KORA_REDIS_URL").ok().or_else(|| self.url.clone())
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema, PartialEq, Eq, Hash)]
 #[serde(rename_all = "snake_case")]
 pub enum TransactionPluginType {
     GasSwap,
+    DeployAuthority,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema, Default)]
@@ -1098,5 +1107,46 @@ allow_create = true
 
         assert!(config.kora.enabled_methods.transfer_transaction);
         assert!(!config.kora.enabled_methods.sign_transaction);
+    }
+
+    fn scoped_redis_env<F: FnOnce()>(value: Option<&str>, f: F) {
+        let previous = std::env::var("KORA_REDIS_URL").ok();
+        match value {
+            Some(v) => std::env::set_var("KORA_REDIS_URL", v),
+            None => std::env::remove_var("KORA_REDIS_URL"),
+        }
+        f();
+        match previous {
+            Some(v) => std::env::set_var("KORA_REDIS_URL", v),
+            None => std::env::remove_var("KORA_REDIS_URL"),
+        }
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_resolved_url_env_var_takes_priority_over_config() {
+        let cfg = CacheConfig { url: Some("redis://config:6379".into()), ..Default::default() };
+        scoped_redis_env(Some("redis://from-env:6379"), || {
+            assert_eq!(cfg.resolved_url(), Some("redis://from-env:6379".into()));
+        });
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_resolved_url_falls_back_to_config_when_env_missing() {
+        let cfg =
+            CacheConfig { url: Some("redis://from-config:6379".into()), ..Default::default() };
+        scoped_redis_env(None, || {
+            assert_eq!(cfg.resolved_url(), Some("redis://from-config:6379".into()));
+        });
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_resolved_url_returns_none_when_neither_set() {
+        let cfg = CacheConfig::default();
+        scoped_redis_env(None, || {
+            assert_eq!(cfg.resolved_url(), None);
+        });
     }
 }

--- a/crates/lib/src/plugin/mod.rs
+++ b/crates/lib/src/plugin/mod.rs
@@ -9,8 +9,10 @@ use crate::{
     transaction::VersionedTransactionResolved,
 };
 
+mod plugin_deploy_authority;
 mod plugin_gas_swap;
 
+use plugin_deploy_authority::DeployAuthorityPlugin;
 use plugin_gas_swap::GasSwapPlugin;
 
 #[derive(Debug, Clone, Copy)]
@@ -78,6 +80,9 @@ impl TransactionPluginRunner {
                 TransactionPluginType::GasSwap => {
                     plugins.push(Box::new(GasSwapPlugin));
                 }
+                TransactionPluginType::DeployAuthority => {
+                    plugins.push(Box::new(DeployAuthorityPlugin));
+                }
             }
         }
 
@@ -95,6 +100,7 @@ impl TransactionPluginRunner {
             }
             let plugin: Box<dyn TransactionPlugin> = match plugin_type {
                 TransactionPluginType::GasSwap => Box::new(GasSwapPlugin),
+                TransactionPluginType::DeployAuthority => Box::new(DeployAuthorityPlugin),
             };
             let (e, w) = plugin.validate_config(config);
             errors.extend(e);

--- a/crates/lib/src/plugin/plugin_deploy_authority.rs
+++ b/crates/lib/src/plugin/plugin_deploy_authority.rs
@@ -1,0 +1,399 @@
+use async_trait::async_trait;
+use solana_client::nonblocking::rpc_client::RpcClient;
+use solana_sdk::pubkey::Pubkey;
+
+use crate::{
+    config::Config,
+    constant::LOADER_V4_PROGRAM_ID,
+    error::KoraError,
+    transaction::{ParsedLoaderV4InstructionData, VersionedTransactionResolved},
+};
+
+use super::{PluginExecutionContext, TransactionPlugin};
+
+/// Enforces that the fee payer is the authority on every loader-v4 instruction we sign.
+///
+/// Stacks on top of [`LoaderV4InstructionPolicy`](crate::config::LoaderV4InstructionPolicy):
+/// the core fee-payer policy gates whether Kora is *willing* to participate as authority;
+/// this plugin requires Kora to *be* the authority. The plugin is inert unless an operator
+/// also flipped the matching `allow_*` flags.
+///
+/// Use case: a devnet paymaster that sponsors program deploys and needs to keep control of
+/// every deployed program.
+pub(super) struct DeployAuthorityPlugin;
+
+#[async_trait]
+impl TransactionPlugin for DeployAuthorityPlugin {
+    async fn validate(
+        &self,
+        transaction: &mut VersionedTransactionResolved,
+        _config: &Config,
+        _rpc_client: &RpcClient,
+        fee_payer: &Pubkey,
+        context: PluginExecutionContext,
+    ) -> Result<(), KoraError> {
+        let loader_v4 = transaction.get_or_parse_loader_v4_instructions()?;
+
+        for data in loader_v4.values().flatten() {
+            match data {
+                ParsedLoaderV4InstructionData::Write { authority, .. }
+                | ParsedLoaderV4InstructionData::Copy { authority, .. }
+                | ParsedLoaderV4InstructionData::SetProgramLength { authority, .. }
+                | ParsedLoaderV4InstructionData::Deploy { authority, .. }
+                | ParsedLoaderV4InstructionData::Retract { authority, .. } => {
+                    if authority != fee_payer {
+                        return Err(KoraError::InvalidTransaction(format!(
+                            "DeployAuthority plugin: loader-v4 authority must be the fee payer \
+                             ({fee_payer}), got {authority} in {}",
+                            context.method_name()
+                        )));
+                    }
+                }
+                ParsedLoaderV4InstructionData::TransferAuthority { new_authority, .. } => {
+                    if new_authority != fee_payer {
+                        return Err(KoraError::InvalidTransaction(format!(
+                            "DeployAuthority plugin: TransferAuthority must keep authority with \
+                             the fee payer ({fee_payer}), got new_authority={new_authority} in {}",
+                            context.method_name()
+                        )));
+                    }
+                }
+                ParsedLoaderV4InstructionData::Finalize { .. } => {
+                    return Err(KoraError::InvalidTransaction(format!(
+                        "DeployAuthority plugin: Finalize is not allowed; programs must stay \
+                         upgradable so the fee payer can reclaim rent (context: {})",
+                        context.method_name()
+                    )));
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    fn validate_config(&self, config: &Config) -> (Vec<String>, Vec<String>) {
+        let mut errors = Vec::new();
+        let mut warnings = Vec::new();
+
+        // Without LoaderV4 in allowed_programs, every loader-v4 instruction is rejected by
+        // the core validator before the plugin ever runs — the plugin is completely inert.
+        if !config.validation.allowed_programs.contains(&LOADER_V4_PROGRAM_ID.to_string()) {
+            errors.push(format!(
+                "DeployAuthority plugin requires LoaderV4 program ({LOADER_V4_PROGRAM_ID}) \
+                 in allowed_programs"
+            ));
+        }
+
+        let loader_v4 = &config.validation.fee_payer_policy.loader_v4;
+        let any_allow_set = loader_v4.allow_write
+            || loader_v4.allow_copy
+            || loader_v4.allow_set_program_length
+            || loader_v4.allow_deploy
+            || loader_v4.allow_retract
+            || loader_v4.allow_transfer_authority;
+        if !any_allow_set {
+            warnings.push(
+                "DeployAuthority plugin is enabled but every fee_payer_policy.loader_v4.allow_* \
+                 flag is false, so the plugin will never see a loader-v4 instruction. Enable the \
+                 relevant allow_* flags (e.g. allow_write, allow_deploy) if you intend to sponsor \
+                 program deploys."
+                    .to_string(),
+            );
+        }
+
+        (errors, warnings)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{super::TransactionPluginRunner, *};
+    use crate::{
+        config::TransactionPluginType,
+        constant::LOADER_V4_PROGRAM_ID,
+        tests::{common::RpcMockBuilder, config_mock::ConfigMockBuilder},
+        transaction::TransactionUtil,
+    };
+    use solana_loader_v4_interface::instruction as loader_v4;
+    use solana_message::{Message, VersionedMessage};
+    use solana_sdk::pubkey::Pubkey;
+    use solana_system_interface::instruction::transfer as system_transfer;
+    use std::sync::Arc;
+
+    fn enable_deploy_authority_plugin(config: &mut Config) {
+        config.kora.plugins.enabled = vec![TransactionPluginType::DeployAuthority];
+    }
+
+    fn build_runner() -> (Config, Arc<RpcClient>) {
+        let mut config = ConfigMockBuilder::new()
+            .with_allowed_programs(vec![LOADER_V4_PROGRAM_ID.to_string()])
+            .build();
+        enable_deploy_authority_plugin(&mut config);
+        let rpc_client = RpcMockBuilder::new().build();
+        (config, rpc_client)
+    }
+
+    async fn run_plugin(
+        config: &Config,
+        rpc_client: &Arc<RpcClient>,
+        fee_payer: &Pubkey,
+        ix: solana_sdk::instruction::Instruction,
+    ) -> Result<(), KoraError> {
+        let tx = TransactionUtil::new_unsigned_versioned_transaction(VersionedMessage::Legacy(
+            Message::new(&[ix], Some(fee_payer)),
+        ));
+        let mut resolved = VersionedTransactionResolved::from_kora_built_transaction(&tx).unwrap();
+        let runner = TransactionPluginRunner::from_config(config);
+        runner
+            .run(
+                &mut resolved,
+                config,
+                rpc_client.as_ref(),
+                fee_payer,
+                PluginExecutionContext::SignTransaction,
+            )
+            .await
+    }
+
+    #[tokio::test]
+    async fn accepts_write_when_kora_is_authority() {
+        let (config, rpc_client) = build_runner();
+        let fee_payer = Pubkey::new_unique();
+        let program = Pubkey::new_unique();
+        let ix = loader_v4::write(&program, &fee_payer, 0, vec![1, 2, 3]);
+
+        assert!(run_plugin(&config, &rpc_client, &fee_payer, ix).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn rejects_write_when_user_is_authority() {
+        let (config, rpc_client) = build_runner();
+        let fee_payer = Pubkey::new_unique();
+        let user = Pubkey::new_unique();
+        let program = Pubkey::new_unique();
+        let ix = loader_v4::write(&program, &user, 0, vec![1, 2, 3]);
+
+        let err = run_plugin(&config, &rpc_client, &fee_payer, ix).await.expect_err("must reject");
+        assert!(
+            matches!(&err, KoraError::InvalidTransaction(msg) if msg.contains("DeployAuthority")),
+            "{err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn accepts_copy_when_kora_is_authority() {
+        let (config, rpc_client) = build_runner();
+        let fee_payer = Pubkey::new_unique();
+        let dest = Pubkey::new_unique();
+        let source = Pubkey::new_unique();
+        let ix = loader_v4::copy(&dest, &fee_payer, &source, 0, 0, 64);
+
+        assert!(run_plugin(&config, &rpc_client, &fee_payer, ix).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn rejects_copy_when_user_is_authority() {
+        let (config, rpc_client) = build_runner();
+        let fee_payer = Pubkey::new_unique();
+        let user = Pubkey::new_unique();
+        let dest = Pubkey::new_unique();
+        let source = Pubkey::new_unique();
+        let ix = loader_v4::copy(&dest, &user, &source, 0, 0, 64);
+
+        let err = run_plugin(&config, &rpc_client, &fee_payer, ix).await.expect_err("must reject");
+        assert!(matches!(err, KoraError::InvalidTransaction(_)));
+    }
+
+    #[tokio::test]
+    async fn accepts_set_program_length_when_kora_is_authority() {
+        let (config, rpc_client) = build_runner();
+        let fee_payer = Pubkey::new_unique();
+        let program = Pubkey::new_unique();
+        let ix = loader_v4::set_program_length(&program, &fee_payer, 1024, &fee_payer);
+
+        assert!(run_plugin(&config, &rpc_client, &fee_payer, ix).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn rejects_set_program_length_when_user_is_authority() {
+        let (config, rpc_client) = build_runner();
+        let fee_payer = Pubkey::new_unique();
+        let user = Pubkey::new_unique();
+        let program = Pubkey::new_unique();
+        let ix = loader_v4::set_program_length(&program, &user, 1024, &user);
+
+        let err = run_plugin(&config, &rpc_client, &fee_payer, ix).await.expect_err("must reject");
+        assert!(matches!(err, KoraError::InvalidTransaction(_)));
+    }
+
+    #[tokio::test]
+    async fn accepts_deploy_when_kora_is_authority() {
+        let (config, rpc_client) = build_runner();
+        let fee_payer = Pubkey::new_unique();
+        let program = Pubkey::new_unique();
+        let ix = loader_v4::deploy(&program, &fee_payer);
+
+        assert!(run_plugin(&config, &rpc_client, &fee_payer, ix).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn rejects_deploy_when_user_is_authority() {
+        let (config, rpc_client) = build_runner();
+        let fee_payer = Pubkey::new_unique();
+        let user = Pubkey::new_unique();
+        let program = Pubkey::new_unique();
+        let ix = loader_v4::deploy(&program, &user);
+
+        let err = run_plugin(&config, &rpc_client, &fee_payer, ix).await.expect_err("must reject");
+        assert!(matches!(err, KoraError::InvalidTransaction(_)));
+    }
+
+    #[tokio::test]
+    async fn accepts_retract_when_kora_is_authority() {
+        let (config, rpc_client) = build_runner();
+        let fee_payer = Pubkey::new_unique();
+        let program = Pubkey::new_unique();
+        let ix = loader_v4::retract(&program, &fee_payer);
+
+        assert!(run_plugin(&config, &rpc_client, &fee_payer, ix).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn rejects_retract_when_user_is_authority() {
+        let (config, rpc_client) = build_runner();
+        let fee_payer = Pubkey::new_unique();
+        let user = Pubkey::new_unique();
+        let program = Pubkey::new_unique();
+        let ix = loader_v4::retract(&program, &user);
+
+        let err = run_plugin(&config, &rpc_client, &fee_payer, ix).await.expect_err("must reject");
+        assert!(matches!(err, KoraError::InvalidTransaction(_)));
+    }
+
+    #[tokio::test]
+    async fn accepts_transfer_authority_when_new_is_kora() {
+        // Attacker hands authority to Kora via TransferAuthority — plugin accepts because the
+        // authority lands back with the fee payer. Note the core fee-payer policy would reject
+        // this as a drainage vector (see #449); the plugin is additive, not a replacement.
+        let (config, rpc_client) = build_runner();
+        let fee_payer = Pubkey::new_unique();
+        let old_auth = Pubkey::new_unique();
+        let program = Pubkey::new_unique();
+        let ix = loader_v4::transfer_authority(&program, &old_auth, &fee_payer);
+
+        assert!(run_plugin(&config, &rpc_client, &fee_payer, ix).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn rejects_transfer_authority_to_user() {
+        let (config, rpc_client) = build_runner();
+        let fee_payer = Pubkey::new_unique();
+        let user = Pubkey::new_unique();
+        let program = Pubkey::new_unique();
+        let ix = loader_v4::transfer_authority(&program, &fee_payer, &user);
+
+        let err = run_plugin(&config, &rpc_client, &fee_payer, ix).await.expect_err("must reject");
+        assert!(
+            matches!(&err, KoraError::InvalidTransaction(msg) if msg.contains("TransferAuthority")),
+            "{err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn rejects_finalize_even_when_kora_is_authority() {
+        let (config, rpc_client) = build_runner();
+        let fee_payer = Pubkey::new_unique();
+        let program = Pubkey::new_unique();
+        let next_version = Pubkey::new_unique();
+        let ix = loader_v4::finalize(&program, &fee_payer, &next_version);
+
+        let err = run_plugin(&config, &rpc_client, &fee_payer, ix).await.expect_err("must reject");
+        assert!(
+            matches!(&err, KoraError::InvalidTransaction(msg) if msg.contains("Finalize")),
+            "{err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn mixed_tx_rejects_when_loader_v4_authority_wrong() {
+        let (config, rpc_client) = build_runner();
+        let fee_payer = Pubkey::new_unique();
+        let user = Pubkey::new_unique();
+        let program = Pubkey::new_unique();
+        let recipient = Pubkey::new_unique();
+
+        let write_ix = loader_v4::write(&program, &user, 0, vec![1]);
+        let sol_ix = system_transfer(&fee_payer, &recipient, 1);
+
+        let tx = TransactionUtil::new_unsigned_versioned_transaction(VersionedMessage::Legacy(
+            Message::new(&[sol_ix, write_ix], Some(&fee_payer)),
+        ));
+        let mut resolved = VersionedTransactionResolved::from_kora_built_transaction(&tx).unwrap();
+        let runner = TransactionPluginRunner::from_config(&config);
+        let err = runner
+            .run(
+                &mut resolved,
+                &config,
+                rpc_client.as_ref(),
+                &fee_payer,
+                PluginExecutionContext::SignAndSendTransaction,
+            )
+            .await
+            .expect_err("must reject");
+        assert!(matches!(err, KoraError::InvalidTransaction(_)));
+    }
+
+    #[tokio::test]
+    async fn no_loader_v4_instructions_is_noop() {
+        // Plugin should not interfere with non-loader-v4 transactions.
+        let (config, rpc_client) = build_runner();
+        let fee_payer = Pubkey::new_unique();
+        let recipient = Pubkey::new_unique();
+        let ix = system_transfer(&fee_payer, &recipient, 1);
+
+        assert!(run_plugin(&config, &rpc_client, &fee_payer, ix).await.is_ok());
+    }
+
+    fn config_with_loader_v4_allowed() -> Config {
+        let mut config = ConfigMockBuilder::new()
+            .with_allowed_programs(vec![LOADER_V4_PROGRAM_ID.to_string()])
+            .build();
+        enable_deploy_authority_plugin(&mut config);
+        config
+    }
+
+    #[test]
+    fn validate_config_errors_when_loader_v4_not_in_allowed_programs() {
+        let plugin = DeployAuthorityPlugin;
+        let mut config = ConfigMockBuilder::new().build();
+        enable_deploy_authority_plugin(&mut config);
+        config.validation.fee_payer_policy.loader_v4.allow_write = true;
+
+        let (errors, _warnings) = plugin.validate_config(&config);
+        assert!(
+            errors.iter().any(|e| e.contains("LoaderV4") && e.contains("allowed_programs")),
+            "got errors: {errors:?}"
+        );
+    }
+
+    #[test]
+    fn validate_config_warns_when_all_allow_flags_false() {
+        let plugin = DeployAuthorityPlugin;
+        let config = config_with_loader_v4_allowed();
+
+        let (errors, warnings) = plugin.validate_config(&config);
+        assert!(errors.is_empty(), "got errors: {errors:?}");
+        assert!(warnings.iter().any(|w| w.contains("allow_*")), "got warnings: {warnings:?}");
+    }
+
+    #[test]
+    fn validate_config_no_warning_when_any_allow_flag_true() {
+        let plugin = DeployAuthorityPlugin;
+        let mut config = config_with_loader_v4_allowed();
+        config.validation.fee_payer_policy.loader_v4.allow_write = true;
+
+        let (errors, warnings) = plugin.validate_config(&config);
+        assert!(errors.is_empty(), "got errors: {errors:?}");
+        assert!(warnings.is_empty(), "expected no warnings, got: {warnings:?}");
+    }
+}

--- a/crates/lib/src/usage_limit/config.rs
+++ b/crates/lib/src/usage_limit/config.rs
@@ -37,6 +37,13 @@ impl UsageLimitConfig {
     pub fn build_rules(&self) -> Result<Vec<UsageRule>, KoraError> {
         self.rules.iter().map(|r| r.build()).collect()
     }
+
+    /// Resolve the cache URL to use. Priority: `KORA_REDIS_URL` env var over the
+    /// `cache_url` field from the TOML config. Returns `None` (in-memory store) when
+    /// neither is set.
+    pub fn resolved_cache_url(&self) -> Option<String> {
+        std::env::var("KORA_REDIS_URL").ok().or_else(|| self.cache_url.clone())
+    }
 }
 
 /// Configuration for a single usage limit rule (TOML-serializable)
@@ -367,5 +374,51 @@ mod tests {
         assert_eq!(rules.len(), 2);
         assert_eq!(rules[0].rule_type(), "transaction");
         assert_eq!(rules[1].rule_type(), "instruction");
+    }
+
+    fn scoped_redis_env<F: FnOnce()>(value: Option<&str>, f: F) {
+        let previous = std::env::var("KORA_REDIS_URL").ok();
+        match value {
+            Some(v) => std::env::set_var("KORA_REDIS_URL", v),
+            None => std::env::remove_var("KORA_REDIS_URL"),
+        }
+        f();
+        match previous {
+            Some(v) => std::env::set_var("KORA_REDIS_URL", v),
+            None => std::env::remove_var("KORA_REDIS_URL"),
+        }
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_resolved_cache_url_env_var_takes_priority_over_config() {
+        let cfg = UsageLimitConfig {
+            cache_url: Some("redis://config:6379".into()),
+            ..Default::default()
+        };
+        scoped_redis_env(Some("redis://from-env:6379"), || {
+            assert_eq!(cfg.resolved_cache_url(), Some("redis://from-env:6379".into()));
+        });
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_resolved_cache_url_falls_back_to_config_when_env_missing() {
+        let cfg = UsageLimitConfig {
+            cache_url: Some("redis://from-config:6379".into()),
+            ..Default::default()
+        };
+        scoped_redis_env(None, || {
+            assert_eq!(cfg.resolved_cache_url(), Some("redis://from-config:6379".into()));
+        });
+    }
+
+    #[test]
+    #[serial_test::serial]
+    fn test_resolved_cache_url_returns_none_when_neither_set() {
+        let cfg = UsageLimitConfig::default();
+        scoped_redis_env(None, || {
+            assert_eq!(cfg.resolved_cache_url(), None);
+        });
     }
 }

--- a/crates/lib/src/usage_limit/usage_tracker.rs
+++ b/crates/lib/src/usage_limit/usage_tracker.rs
@@ -366,8 +366,9 @@ impl UsageTracker {
             .filter_map(|info| info.public_key.parse().ok())
             .collect();
 
+        let resolved_cache_url = usage_config.resolved_cache_url();
         let (store, backend): (Arc<dyn UsageStore>, &str) =
-            if let Some(cache_url) = &usage_config.cache_url {
+            if let Some(cache_url) = &resolved_cache_url {
                 let cfg = deadpool_redis::Config::from_url(cache_url);
                 let pool = cfg.create_pool(Some(Runtime::Tokio1)).map_err(|e| {
                     KoraError::InternalServerError(format!(

--- a/crates/lib/src/validator/cache_validator.rs
+++ b/crates/lib/src/validator/cache_validator.rs
@@ -35,8 +35,10 @@ impl CacheValidator {
             return (errors, warnings);
         }
 
+        let resolved_cache_url = usage_config.resolved_cache_url();
+
         // Check if cache_url is provided when enabled
-        match &usage_config.cache_url {
+        match &resolved_cache_url {
             None => {
                 // In-memory store will be used - warn about non-persistence
                 warnings.push(
@@ -64,7 +66,7 @@ impl CacheValidator {
         }
 
         // Test Redis connection
-        if let Some(cache_url) = &usage_config.cache_url {
+        if let Some(cache_url) = &resolved_cache_url {
             if cache_url.starts_with("redis://") || cache_url.starts_with("rediss://") {
                 if let Err(e) = Self::test_redis_connection(cache_url).await {
                     if usage_config.fallback_if_unavailable {
@@ -95,7 +97,7 @@ impl CacheValidator {
             return (errors, warnings);
         }
 
-        match &cache_config.url {
+        match cache_config.resolved_url() {
             None => {
                 errors.push("RPC cache is enabled but no Redis URL is configured".to_string());
             }
@@ -105,7 +107,7 @@ impl CacheValidator {
                         "Invalid cache_url format: must start with redis:// or rediss://"
                             .to_string(),
                     );
-                } else if let Err(_e) = Self::test_redis_connection(cache_url).await {
+                } else if let Err(_e) = Self::test_redis_connection(&cache_url).await {
                     errors.push("RPC cache Redis connection failed".to_string());
                 }
             }

--- a/examples/devnet-deploy-paymaster/Dockerfile
+++ b/examples/devnet-deploy-paymaster/Dockerfile
@@ -1,0 +1,8 @@
+FROM rust:1.88
+
+RUN cargo install kora-cli
+
+COPY kora.toml ./
+COPY signers.toml ./
+
+CMD kora --config kora.toml --rpc-url ${RPC_URL} rpc start --signers-config signers.toml --port ${PORT:-8080}

--- a/examples/devnet-deploy-paymaster/kora.toml
+++ b/examples/devnet-deploy-paymaster/kora.toml
@@ -1,0 +1,104 @@
+# Example config for a devnet-deploy paymaster.
+[kora]
+rate_limit = 100
+
+[kora.auth]
+
+[kora.cache]
+enabled = true
+# url is read from the KORA_REDIS_URL env var at startup.
+default_ttl = 300
+account_ttl = 60
+
+[kora.enabled_methods]
+liveness = true
+estimate_transaction_fee = false
+estimate_bundle_fee = false
+get_supported_tokens = false
+sign_transaction = true
+sign_and_send_transaction = true
+transfer_transaction = false
+get_blockhash = false
+get_config = false
+get_payer_signer = true
+get_version = true
+sign_bundle = false
+sign_and_send_bundle = false
+
+[kora.plugins]
+enabled = ["deploy_authority"]
+
+[validation]
+max_allowed_lamports = 10000000000
+max_signatures = 20
+price_source = "Mock"
+allow_durable_transactions = false
+allowed_programs = [
+    "11111111111111111111111111111111",             # System Program
+    "ComputeBudget111111111111111111111111111111",  # Compute Budget Program
+    "LoaderV411111111111111111111111111111111111",  # Loader-v4 Program
+]
+allowed_tokens = []
+allowed_spl_paid_tokens = []
+disallowed_accounts = []
+
+[validation.price]
+type = "free"
+
+[validation.token_2022]
+transfer_hook_policy = "deny_mutable_for_delayed_signing"
+blocked_mint_extensions = []
+blocked_account_extensions = []
+
+[validation.fee_payer_policy]
+
+[validation.fee_payer_policy.system]
+allow_transfer = false
+allow_assign = false
+# Needed so Kora can fund the loader-v4 program account (CreateAccount + SetProgramLength).
+allow_create_account = true
+allow_allocate = true
+
+[validation.fee_payer_policy.system.nonce]
+allow_initialize = false
+allow_advance = false
+allow_authorize = false
+allow_withdraw = false
+
+[validation.fee_payer_policy.loader_v4]
+# Operator opts Kora into being loader-v4 authority. The plugin then pins that authority to
+# Kora on every instruction.
+allow_write = true
+allow_copy = true
+allow_set_program_length = true
+allow_deploy = true
+allow_retract = true
+# Leave these false: the plugin enforces "new_authority == fee_payer" on TransferAuthority and
+# always rejects Finalize, so even if we flipped these on, the plugin layer would still block
+# any tx that tries to hand off or freeze control.
+allow_transfer_authority = false
+allow_finalize = false
+
+[kora.usage_limit]
+enabled = true
+# cache_url is read from the KORA_REDIS_URL env var at startup (shared with [kora.cache]).
+fallback_if_unavailable = false
+
+# Cap deploys per wallet per day. Covers initial deploy + several upgrades
+# (loader-v4 upgrade = Retract + Write + Deploy, so Deploy counts each upgrade).
+[[kora.usage_limit.rules]]
+type = "instruction"
+program = "LoaderV411111111111111111111111111111111111"
+instruction = "deploy"
+max = 5
+window_seconds = 86400
+
+[[kora.usage_limit.rules]]
+type = "instruction"
+program = "LoaderV411111111111111111111111111111111111"
+instruction = "write"
+max = 2000
+window_seconds = 86400
+
+[kora.bundle]
+enabled = false

--- a/examples/devnet-deploy-paymaster/signers.toml
+++ b/examples/devnet-deploy-paymaster/signers.toml
@@ -1,0 +1,9 @@
+[signer_pool]
+strategy = "round_robin"
+
+[[signers]]
+name = "kora_gcp_kms"
+type = "gcp_kms"
+key_name_env = "KORA_GCP_KMS_KEY_NAME"
+public_key_env = "KORA_GCP_KMS_PUBLIC_KEY"
+weight = 1


### PR DESCRIPTION
## Summary
- New `TransactionPluginType::DeployAuthority` variant. Operators enable it with `enabled = ["deploy_authority"]`.
- Plugin enforces **fee_payer == authority** on every loader-v4 instruction Kora signs (Write / Copy / SetProgramLength / Deploy / Retract); rejects `TransferAuthority` that hands authority elsewhere; rejects `Finalize` entirely so Kora can reclaim rent later via program close.
- Stacks on top of the loader-v4 fee-payer policy from #449 — the core policy gates whether Kora is *willing* to participate as authority, this plugin requires Kora to *be* the authority. Both must be turned on for a real devnet-deploy node.
- `validate_config` warns at startup if the plugin is enabled but every `fee_payer_policy.loader_v4.allow_*` flag is still false (the plugin would be inert).
- Reference fixture at [tests/src/common/fixtures/deploy-authority-plugin-test.toml](tests/src/common/fixtures/deploy-authority-plugin-test.toml) shows a full devnet-deploy paymaster config.

## Why a plugin (not a core fee-payer-policy flag)
The loader-v4 policy lives in the core validator because every operator benefits from default-deny. "Kora = upgrade authority" is the opposite — most operators don't want it. Plugins are the right abstraction: opt-in, no blast radius on existing operators. @amilz suggested this shape in the #449 review.

## Deploy UX once a devnet Kora runs this

```bash
KORA_PUBKEY=$(curl -s https://kora-devnet.example/getPayerSigner | jq -r .signer_address)
solana program deploy \
  --url https://kora-devnet.example/rpc \
  --upgrade-authority \$KORA_PUBKEY \
  my_program.so
```

Users deploy; Kora pays + signs as authority; users can't close the program to drain the rent.

## Test Plan
- \`cargo test -p kora-lib --lib plugin::plugin_deploy_authority\` — 17/17 pass (accept + reject for each of the 7 loader-v4 variants, mixed-tx, no-op case, startup warning)
- \`cargo test -p kora-lib --lib plugin::\` — 26/26 plugin tests pass, no gas_swap regressions
- \`cargo clippy -p kora-lib --all-targets\` — clean
- \`cargo fmt --check\` — clean

## Out of scope (follow-ups)
- Integration-test wiring for loader-v4 via \`test_cases.toml\` — needs pre-seeded loader-v4 accounts on the local validator (same gap flagged in #449).
- \`kora-deploy\` TS wrapper in \`sdks/ts/\` that hides the \`--upgrade-authority \$KORA_PUBKEY\` plumbing.
- GCP deployment (Cloud Run + KMS + Memorystore + daily devnet airdrop cron).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/solana-foundation/kora/pull/451" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->











## 📊 Unit Test Coverage
![Coverage](https://img.shields.io/badge/coverage-85.8%25-green)

**Unit Test Coverage: 85.8%**

[View Detailed Coverage Report](https://github.com/solana-foundation/kora/actions/runs/24893138528)