### PR TITLE
fix(validator): allow empty allowed_tokens under Free pricing + unblock devnet-deploy-paymaster example

### DIFF
--- a/crates/lib/src/validator/config_validator.rs
+++ b/crates/lib/src/validator/config_validator.rs
@@ -325,11 +325,13 @@ impl ConfigValidator {
     pub async fn validate(_rpc_client: &RpcClient) -> Result<(), KoraError> {
         let config = &get_config()?;
 
-        if config.validation.allowed_tokens.is_empty() {
+        if config.validation.is_payment_required() && config.validation.allowed_tokens.is_empty() {
             return Err(KoraError::InternalServerError("No tokens enabled".to_string()));
         }
 
-        TokenUtil::check_valid_tokens(&config.validation.allowed_tokens)?;
+        if !config.validation.allowed_tokens.is_empty() {
+            TokenUtil::check_valid_tokens(&config.validation.allowed_tokens)?;
+        }
 
         if let Some(payment_address) = &config.kora.payment_address {
             if let Err(e) = Pubkey::from_str(payment_address) {
@@ -537,11 +539,15 @@ impl ConfigValidator {
             }
         }
 
-        // Validate allowed tokens
-        if config.validation.allowed_tokens.is_empty() {
+        // Validate allowed tokens. Only required when the price model actually charges fees;
+        // a Free-pricing operator (e.g. a devnet-deploy paymaster) has no reason to maintain
+        // an allowlist since no SPL token is ever used for payment.
+        if config.validation.is_payment_required() && config.validation.allowed_tokens.is_empty() {
             errors.push("No allowed tokens configured".to_string());
-        } else if let Err(e) = TokenUtil::check_valid_tokens(&config.validation.allowed_tokens) {
-            errors.push(format!("Invalid token address: {e}"));
+        } else if !config.validation.allowed_tokens.is_empty() {
+            if let Err(e) = TokenUtil::check_valid_tokens(&config.validation.allowed_tokens) {
+                errors.push(format!("Invalid token address: {e}"));
+            }
         }
 
         // Validate allowed spl paid tokens
@@ -1243,6 +1249,83 @@ mod tests {
             .unwrap_err()
             .iter()
             .any(|e| e.contains("GasSwap plugin cannot be used with Free pricing")));
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_validate_with_result_empty_allowed_tokens_ok_when_free() {
+        // Free-pricing operators (e.g. devnet-deploy paymaster) have no reason to maintain
+        // an allowed_tokens list since no SPL token is ever used for payment.
+        std::env::set_var("JUPITER_API_KEY", "test-api-key");
+        let config = Config {
+            validation: ValidationConfig {
+                max_allowed_lamports: 1_000_000,
+                max_signatures: 10,
+                allowed_programs: vec![SYSTEM_PROGRAM_ID.to_string()],
+                allowed_tokens: vec![],
+                allowed_spl_paid_tokens: SplTokenConfig::Allowlist(vec![]),
+                disallowed_accounts: vec![],
+                price_source: PriceSource::Jupiter,
+                fee_payer_policy: FeePayerPolicy::default(),
+                price: PriceConfig { model: PriceModel::Free },
+                token_2022: Token2022Config::default(),
+                allow_durable_transactions: false,
+                max_price_staleness_slots: 0,
+                require_one_of_programs: vec![],
+            },
+            kora: KoraConfig::default(),
+            metrics: MetricsConfig::default(),
+        };
+
+        let _ = update_config(config);
+
+        let rpc_client = RpcClient::new_with_commitment(
+            "http://localhost:8899".to_string(),
+            CommitmentConfig::confirmed(),
+        );
+        let result = ConfigValidator::validate_with_result(&rpc_client, true).await;
+        assert!(result.is_ok(), "Free pricing with empty allowed_tokens must not error");
+        let warnings = result.unwrap();
+        assert!(!warnings.iter().any(|w| w.contains("No allowed tokens configured")));
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_validate_with_result_empty_allowed_tokens_errors_when_fees_required() {
+        // When the price model charges fees, allowed_tokens still must be populated.
+        std::env::set_var("JUPITER_API_KEY", "test-api-key");
+        let config = Config {
+            validation: ValidationConfig {
+                max_allowed_lamports: 1_000_000,
+                max_signatures: 10,
+                allowed_programs: vec![SYSTEM_PROGRAM_ID.to_string()],
+                allowed_tokens: vec![],
+                allowed_spl_paid_tokens: SplTokenConfig::Allowlist(vec![
+                    "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU".to_string(),
+                ]),
+                disallowed_accounts: vec![],
+                price_source: PriceSource::Jupiter,
+                fee_payer_policy: FeePayerPolicy::default(),
+                price: PriceConfig { model: PriceModel::Margin { margin: 0.1 } },
+                token_2022: Token2022Config::default(),
+                allow_durable_transactions: false,
+                max_price_staleness_slots: 0,
+                require_one_of_programs: vec![],
+            },
+            kora: KoraConfig::default(),
+            metrics: MetricsConfig::default(),
+        };
+
+        let _ = update_config(config);
+
+        let rpc_client = RpcClient::new_with_commitment(
+            "http://localhost:8899".to_string(),
+            CommitmentConfig::confirmed(),
+        );
+        let result = ConfigValidator::validate_with_result(&rpc_client, true).await;
+        assert!(result.is_err());
+        let errors = result.unwrap_err();
+        assert!(errors.iter().any(|e| e.contains("No allowed tokens configured")));
     }
 
     #[tokio::test]

--- a/examples/devnet-deploy-paymaster/Dockerfile
+++ b/examples/devnet-deploy-paymaster/Dockerfile
@@ -1,6 +1,13 @@
-FROM rust:1.88
+FROM rustlang/rust:nightly
 
-RUN cargo install kora-cli
+# Build from main until a crates.io release includes the DeployAuthority plugin and
+# KORA_REDIS_URL support. Switch back to `cargo install kora-cli` once that lands.
+# The Kora workspace pins nightly via rust-toolchain.toml; matching here avoids
+# dep-version skew (e.g. aws-sdk-kms currently requires rustc 1.91.1+).
+RUN cargo install \
+    --git https://github.com/solana-foundation/kora \
+    --branch main \
+    kora-cli
 
 COPY kora.toml ./
 COPY signers.toml ./


### PR DESCRIPTION
## Summary
- `allowed_tokens.is_empty()` no longer raises a startup error when the price model is `Free`. Free-pricing operators (e.g. the new devnet-deploy paymaster example) never consume the allowed-tokens list, so requiring a placeholder mint was noise. Check now runs only when `ValidationConfig::is_payment_required()` is true.
- `check_valid_tokens` still validates pubkey format when the list is populated.
- Two regression tests (empty + Free → ok, empty + Margin → error).
- **Also**: bump the devnet-deploy-paymaster Dockerfile to \`rustlang/rust:nightly\` and install kora-cli from the main branch via \`--git\` until the next crates.io release lands. The prior config (rust:1.88 + crates.io install) can't build the current workspace because aws-sdk-kms now requires rustc 1.91+ and because the published kora-cli 2.0.5 predates the DeployAuthority plugin.

## Why
I stood up the example on GCP Cloud Run, hit two blockers in this order:
1. Build failed with rustc version mismatch (aws-sdk deps → 1.91).
2. Container started, then Kora startup-validation errored with \`No allowed tokens configured\`.

Both are fixed here. After this merges, the example deploys cleanly with empty \`allowed_tokens = []\` as intended.

## Test Plan
- \`cargo test -p kora-lib --lib config_validator\` — 56/56, including the two new tests
- \`cargo clippy -p kora-lib --all-targets\` — clean
- \`cargo fmt --check\` — clean
- Verified live on GCP Cloud Run with the nightly Dockerfile (Kora revision \`kora-devnet-paymaster-00002-lcx\` serving). Planning to redeploy with empty \`allowed_tokens\` after this lands to confirm the validator fix end-to-end.

## Out of scope / follow-up
- Revert the Dockerfile back to the clean \`cargo install kora-cli\` line once a crates.io release of kora-cli includes both the DeployAuthority plugin and the \`KORA_REDIS_URL\` env var support from #451.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/solana-foundation/kora/pull/452" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


## 📊 Unit Test Coverage
![Coverage](https://img.shields.io/badge/coverage-85.8%25-green)

**Unit Test Coverage: 85.8%**

[View Detailed Coverage Report](https://github.com/solana-foundation/kora/actions/runs/24907738412)