### PR TITLE
ci: pin GCS source staging dir for devnet deploy

### DIFF
--- a/.github/workflows/deploy-devnet-paymaster.yml
+++ b/.github/workflows/deploy-devnet-paymaster.yml
@@ -54,6 +54,7 @@ jobs:
             --memory=1Gi
             --vpc-connector=${{ env.VPC_CONNECTOR }}
             --vpc-egress=private-ranges-only
+            --gcs-source-staging-dir=gs://run-sources-${{ env.GCP_PROJECT_ID }}-${{ env.GCP_REGION }}/source
 
       - name: Print service URL
         run: echo "Deployed ${{ env.CLOUD_RUN_SERVICE }} -> ${{ steps.deploy.outputs.url }}"


### PR DESCRIPTION
## Summary
- `gcloud run deploy --source` was failing with `storage.buckets.list` denied at project level — it's doing a discovery LIST before upload
- Passing `--gcs-source-staging-dir=gs://run-sources-<project>-<region>/source` skips that step
- Lets the deployer SA stay scoped to bucket-level permissions on the run-sources bucket only (no project-level storage perms)

## Test plan
- [ ] After merge, retrigger the **Deploy devnet paymaster** workflow from main and confirm it makes it past the upload step
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/solana-foundation/kora/pull/454" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
