### PR TITLE
ci(deploy): split build + deploy to drop project-level storage perms

### DIFF
--- a/.github/workflows/deploy-devnet-paymaster.yml
+++ b/.github/workflows/deploy-devnet-paymaster.yml
@@ -35,13 +35,28 @@ jobs:
           workload_identity_provider: ${{ env.GCP_WIF_PROVIDER }}
           service_account: ${{ env.GCP_DEPLOYER_SERVICE_ACCOUNT }}
 
+      - uses: google-github-actions/setup-gcloud@v2
+
+      - id: build
+        env:
+          REGION: ${{ env.GCP_REGION }}
+          PROJECT: ${{ env.GCP_PROJECT_ID }}
+          SERVICE: ${{ env.CLOUD_RUN_SERVICE }}
+        run: |
+          IMAGE="${REGION}-docker.pkg.dev/${PROJECT}/cloud-run-source-deploy/${SERVICE}:${GITHUB_SHA::12}"
+          gcloud builds submit examples/devnet-deploy-paymaster/ \
+            --tag "$IMAGE" \
+            --project="$PROJECT" \
+            --gcs-source-staging-dir="gs://${PROJECT}_cloudbuild/source"
+          echo "image=$IMAGE" >> "$GITHUB_OUTPUT"
+
       - id: deploy
         uses: google-github-actions/deploy-cloudrun@v3
         with:
           service: ${{ env.CLOUD_RUN_SERVICE }}
           region: ${{ env.GCP_REGION }}
           project_id: ${{ env.GCP_PROJECT_ID }}
-          source: examples/devnet-deploy-paymaster/
+          image: ${{ steps.build.outputs.image }}
           env_vars: |-
             RPC_URL=${{ env.DEVNET_RPC_URL }}
             KORA_GCP_KMS_KEY_NAME=${{ env.DEVNET_KORA_GCP_KMS_KEY_NAME }}
@@ -54,7 +69,6 @@ jobs:
             --memory=1Gi
             --vpc-connector=${{ env.VPC_CONNECTOR }}
             --vpc-egress=private-ranges-only
-            --gcs-source-staging-dir=gs://run-sources-${{ env.GCP_PROJECT_ID }}-${{ env.GCP_REGION }}/source
 
       - name: Print service URL
         run: echo "Deployed ${{ env.CLOUD_RUN_SERVICE }} -> ${{ steps.deploy.outputs.url }}"

--- a/examples/devnet-deploy-paymaster/README.md
+++ b/examples/devnet-deploy-paymaster/README.md
@@ -33,11 +33,15 @@ workflow can run. Re-running the workflow does not re-create them.
    workflow updates revisions, it does not create the service.
 5. **Workload Identity Federation pool + provider** — trusts
    `solana-foundation/kora` (filter on `attribute.repository`) and is bound to
-   a deployer service account that holds:
-   - `roles/run.admin` on the Cloud Run service
-   - `roles/iam.serviceAccountUser` on the runtime service account
-   - `roles/cloudkms.signer` on the KMS key (the runtime SA needs this; the
-     deployer SA only needs it if it ever invokes KMS directly)
+   a deployer service account holding **only** these scoped roles (no
+   project-wide storage perms — important when the GCP project is shared):
+   - `roles/run.admin` scoped to the one Cloud Run service
+   - `roles/iam.serviceAccountUser` scoped to the runtime service account
+   - `roles/cloudbuild.builds.editor` (project — required by `gcloud builds submit`)
+   - `roles/artifactregistry.writer` scoped to the `cloud-run-source-deploy` AR repo
+   - `roles/storage.objectAdmin` scoped to `gs://<PROJECT>_cloudbuild` (build staging only)
+   - The runtime SA holds `roles/cloudkms.signer` on the KMS key. The deployer
+     SA does not need KMS access — it only orchestrates deploys.
 
 ### Doppler config
 


### PR DESCRIPTION
## Summary
- `gcloud run deploy --source` requires project-level `storage.buckets.list/create/get` on the deployer SA (per `roles/run.sourceDeveloper`) — too broad for our shared GCP project
- Switching to Google's recommended ["more control"](https://cloud.google.com/run/docs/deploying-source-code) path: pre-build with `gcloud builds submit --tag` (which supports `--gcs-source-staging-dir`), deploy with `--image`
- Deploy step now needs zero storage permissions; build step uses bucket-scoped `storage.objectAdmin` on `gs://<PROJECT>_cloudbuild` only

## Final IAM scope on the deployer SA after this lands
| role | scope |
| --- | --- |
| `roles/run.admin` | one Cloud Run service |
| `roles/iam.serviceAccountUser` | one runtime SA |
| `roles/cloudbuild.builds.editor` | project (no tighter scoping exists) |
| `roles/artifactregistry.writer` | one AR repo |
| `roles/storage.objectAdmin` | one staging bucket |

## Test plan
- [ ] Merge → trigger **Deploy devnet paymaster** workflow from main
- [ ] Build step pushes image to `<region>-docker.pkg.dev/<project>/cloud-run-source-deploy/kora-devnet-paymaster:<sha>`
- [ ] Deploy step rolls a new revision pointing at that image
- [ ] `solana program show` against the live URL behaves as expected
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/solana-foundation/kora/pull/455" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
