### PR TITLE
fix(validator): enforce fee-payer policy for multisig co-signers

### DIFF
--- a/crates/lib/src/transaction/instruction_util.rs
+++ b/crates/lib/src/transaction/instruction_util.rs
@@ -205,6 +205,7 @@ pub enum ParsedSPLInstructionData {
         account: Pubkey,
         payer: Pubkey,
         owner: Pubkey,
+        multisig_signers: Vec<Pubkey>,
         is_2022: bool,
     },
     SplTokenInitializePausable {
@@ -3206,6 +3207,7 @@ impl IxUtils {
                                     account: instruction.accounts[instruction_indexes::spl_token_reallocate::ACCOUNT_INDEX].pubkey,
                                     payer: instruction.accounts[instruction_indexes::spl_token_reallocate::PAYER_INDEX].pubkey,
                                     owner: instruction.accounts[instruction_indexes::spl_token_reallocate::OWNER_INDEX].pubkey,
+                                    multisig_signers: Self::extract_multisig_signers(instruction, 4),
                                     is_2022: true,
                                 });
                         }

--- a/crates/lib/src/transaction/instruction_util.rs
+++ b/crates/lib/src/transaction/instruction_util.rs
@@ -138,32 +138,38 @@ pub enum ParsedSPLInstructionData {
     // Includes burn and burn with seed
     SplTokenBurn {
         owner: Pubkey,
+        multisig_signers: Vec<Pubkey>,
         is_2022: bool,
     },
     // Includes close account
     SplTokenCloseAccount {
         owner: Pubkey,
+        multisig_signers: Vec<Pubkey>,
         is_2022: bool,
     },
     // Includes approve and approve with seed
     SplTokenApprove {
         owner: Pubkey,
+        multisig_signers: Vec<Pubkey>,
         is_2022: bool,
     },
     // Revoke
     SplTokenRevoke {
         owner: Pubkey,
+        multisig_signers: Vec<Pubkey>,
         is_2022: bool,
     },
     // SetAuthority
     SplTokenSetAuthority {
         authority: Pubkey,
         new_authority: Option<Pubkey>,
+        multisig_signers: Vec<Pubkey>,
         is_2022: bool,
     },
     // MintTo and MintToChecked
     SplTokenMintTo {
         mint_authority: Pubkey,
+        multisig_signers: Vec<Pubkey>,
         is_2022: bool,
     },
     // InitializeMint and InitializeMint2
@@ -185,11 +191,13 @@ pub enum ParsedSPLInstructionData {
     // FreezeAccount
     SplTokenFreezeAccount {
         freeze_authority: Pubkey,
+        multisig_signers: Vec<Pubkey>,
         is_2022: bool,
     },
     // ThawAccount
     SplTokenThawAccount {
         freeze_authority: Pubkey,
+        multisig_signers: Vec<Pubkey>,
         is_2022: bool,
     },
     // Token2022 Reallocate
@@ -2573,6 +2581,7 @@ impl IxUtils {
                                 ParsedSPLInstructionType::SplTokenBurn,
                                 ParsedSPLInstructionData::SplTokenBurn {
                                     owner,
+                                    multisig_signers: Self::extract_multisig_signers(instruction, 3),
                                     is_2022: false,
                                 },
                             );
@@ -2590,6 +2599,7 @@ impl IxUtils {
                                     owner: instruction.accounts
                                         [instruction_indexes::spl_token_burn::OWNER_INDEX]
                                         .pubkey,
+                                    multisig_signers: Self::extract_multisig_signers(instruction, 3),
                                     is_2022: false,
                                 });
                         }
@@ -2603,6 +2613,7 @@ impl IxUtils {
                                     owner: instruction.accounts
                                         [instruction_indexes::spl_token_close_account::OWNER_INDEX]
                                         .pubkey,
+                                    multisig_signers: Self::extract_multisig_signers(instruction, 3),
                                     is_2022: false,
                                 });
                         }
@@ -2619,6 +2630,7 @@ impl IxUtils {
                                     owner: instruction.accounts
                                         [instruction_indexes::spl_token_approve::OWNER_INDEX]
                                         .pubkey,
+                                    multisig_signers: Self::extract_multisig_signers(instruction, 3),
                                     is_2022: false,
                                 });
                         }
@@ -2630,6 +2642,7 @@ impl IxUtils {
                                 .or_default()
                                 .push(ParsedSPLInstructionData::SplTokenApprove {
                                     owner: instruction.accounts[instruction_indexes::spl_token_approve_checked::OWNER_INDEX].pubkey,
+                                    multisig_signers: Self::extract_multisig_signers(instruction, 4),
                                     is_2022: false,
                                 });
                         }
@@ -2646,6 +2659,7 @@ impl IxUtils {
                                     owner: instruction.accounts
                                         [instruction_indexes::spl_token_revoke::OWNER_INDEX]
                                         .pubkey,
+                                    multisig_signers: Self::extract_multisig_signers(instruction, 2),
                                     is_2022: false,
                                 });
                         }
@@ -2661,6 +2675,7 @@ impl IxUtils {
                                 .push(ParsedSPLInstructionData::SplTokenSetAuthority {
                                     authority: instruction.accounts[instruction_indexes::spl_token_set_authority::CURRENT_AUTHORITY_INDEX].pubkey,
                                     new_authority: new_authority.into(),
+                                    multisig_signers: Self::extract_multisig_signers(instruction, 2),
                                     is_2022: false,
                                 });
                         }
@@ -2675,6 +2690,7 @@ impl IxUtils {
                                 .or_default()
                                 .push(ParsedSPLInstructionData::SplTokenMintTo {
                                     mint_authority: instruction.accounts[instruction_indexes::spl_token_mint_to::MINT_AUTHORITY_INDEX].pubkey,
+                                    multisig_signers: Self::extract_multisig_signers(instruction, 3),
                                     is_2022: false,
                                 });
                         }
@@ -2686,6 +2702,7 @@ impl IxUtils {
                                 .or_default()
                                 .push(ParsedSPLInstructionData::SplTokenMintTo {
                                     mint_authority: instruction.accounts[instruction_indexes::spl_token_mint_to_checked::MINT_AUTHORITY_INDEX].pubkey,
+                                    multisig_signers: Self::extract_multisig_signers(instruction, 3),
                                     is_2022: false,
                                 });
                         }
@@ -2792,6 +2809,7 @@ impl IxUtils {
                                 .or_default()
                                 .push(ParsedSPLInstructionData::SplTokenFreezeAccount {
                                     freeze_authority: instruction.accounts[instruction_indexes::spl_token_freeze_account::FREEZE_AUTHORITY_INDEX].pubkey,
+                                    multisig_signers: Self::extract_multisig_signers(instruction, 3),
                                     is_2022: false,
                                 });
                         }
@@ -2803,6 +2821,7 @@ impl IxUtils {
                                 .or_default()
                                 .push(ParsedSPLInstructionData::SplTokenThawAccount {
                                     freeze_authority: instruction.accounts[instruction_indexes::spl_token_thaw_account::FREEZE_AUTHORITY_INDEX].pubkey,
+                                    multisig_signers: Self::extract_multisig_signers(instruction, 3),
                                     is_2022: false,
                                 });
                         }
@@ -2923,6 +2942,7 @@ impl IxUtils {
                                 ParsedSPLInstructionType::SplTokenBurn,
                                 ParsedSPLInstructionData::SplTokenBurn {
                                     owner,
+                                    multisig_signers: Self::extract_multisig_signers(instruction, 3),
                                     is_2022: true,
                                 },
                             );
@@ -2940,6 +2960,7 @@ impl IxUtils {
                                     owner: instruction.accounts
                                         [instruction_indexes::spl_token_burn::OWNER_INDEX]
                                         .pubkey,
+                                    multisig_signers: Self::extract_multisig_signers(instruction, 3),
                                     is_2022: true,
                                 });
                         }
@@ -2953,6 +2974,7 @@ impl IxUtils {
                                     owner: instruction.accounts
                                         [instruction_indexes::spl_token_close_account::OWNER_INDEX]
                                         .pubkey,
+                                    multisig_signers: Self::extract_multisig_signers(instruction, 3),
                                     is_2022: true,
                                 });
                         }
@@ -2969,6 +2991,7 @@ impl IxUtils {
                                     owner: instruction.accounts
                                         [instruction_indexes::spl_token_approve::OWNER_INDEX]
                                         .pubkey,
+                                    multisig_signers: Self::extract_multisig_signers(instruction, 3),
                                     is_2022: true,
                                 });
                         }
@@ -2982,6 +3005,7 @@ impl IxUtils {
                                 .or_default()
                                 .push(ParsedSPLInstructionData::SplTokenApprove {
                                     owner: instruction.accounts[instruction_indexes::spl_token_approve_checked::OWNER_INDEX].pubkey,
+                                    multisig_signers: Self::extract_multisig_signers(instruction, 4),
                                     is_2022: true,
                                 });
                         }
@@ -2998,6 +3022,7 @@ impl IxUtils {
                                     owner: instruction.accounts
                                         [instruction_indexes::spl_token_revoke::OWNER_INDEX]
                                         .pubkey,
+                                    multisig_signers: Self::extract_multisig_signers(instruction, 2),
                                     is_2022: true,
                                 });
                         }
@@ -3013,6 +3038,7 @@ impl IxUtils {
                                 .push(ParsedSPLInstructionData::SplTokenSetAuthority {
                                     authority: instruction.accounts[instruction_indexes::spl_token_set_authority::CURRENT_AUTHORITY_INDEX].pubkey,
                                     new_authority: new_authority.into(),
+                                    multisig_signers: Self::extract_multisig_signers(instruction, 2),
                                     is_2022: true,
                                 });
                         }
@@ -3027,6 +3053,7 @@ impl IxUtils {
                                 .or_default()
                                 .push(ParsedSPLInstructionData::SplTokenMintTo {
                                     mint_authority: instruction.accounts[instruction_indexes::spl_token_mint_to::MINT_AUTHORITY_INDEX].pubkey,
+                                    multisig_signers: Self::extract_multisig_signers(instruction, 3),
                                     is_2022: true,
                                 });
                         }
@@ -3038,6 +3065,7 @@ impl IxUtils {
                                 .or_default()
                                 .push(ParsedSPLInstructionData::SplTokenMintTo {
                                     mint_authority: instruction.accounts[instruction_indexes::spl_token_mint_to_checked::MINT_AUTHORITY_INDEX].pubkey,
+                                    multisig_signers: Self::extract_multisig_signers(instruction, 3),
                                     is_2022: true,
                                 });
                         }
@@ -3150,6 +3178,7 @@ impl IxUtils {
                                 .or_default()
                                 .push(ParsedSPLInstructionData::SplTokenFreezeAccount {
                                     freeze_authority: instruction.accounts[instruction_indexes::spl_token_freeze_account::FREEZE_AUTHORITY_INDEX].pubkey,
+                                    multisig_signers: Self::extract_multisig_signers(instruction, 3),
                                     is_2022: true,
                                 });
                         }
@@ -3161,6 +3190,7 @@ impl IxUtils {
                                 .or_default()
                                 .push(ParsedSPLInstructionData::SplTokenThawAccount {
                                     freeze_authority: instruction.accounts[instruction_indexes::spl_token_thaw_account::FREEZE_AUTHORITY_INDEX].pubkey,
+                                    multisig_signers: Self::extract_multisig_signers(instruction, 3),
                                     is_2022: true,
                                 });
                         }

--- a/crates/lib/src/validator/macros.rs
+++ b/crates/lib/src/validator/macros.rs
@@ -50,6 +50,26 @@ macro_rules! validate_spl {
             }
         }
     };
+    ($self:expr, $instructions:expr, $type:ident, $pattern:pat => { $account:expr, $multisig_signers:expr, $is_2022:expr }, $spl_policy:expr, $token2022_policy:expr, $name_spl:expr, $name_2022:expr) => {
+        for instruction in $instructions.get(&ParsedSPLInstructionType::$type).unwrap_or(&vec![]) {
+            if let $pattern = instruction {
+                let (allowed, name) = if *$is_2022 {
+                    ($token2022_policy, $name_2022)
+                } else {
+                    ($spl_policy, $name_spl)
+                };
+                if (*$account == $self.fee_payer_pubkey
+                    || $multisig_signers.contains(&$self.fee_payer_pubkey))
+                    && !allowed
+                {
+                    return Err(KoraError::InvalidTransaction(format!(
+                        "Fee payer cannot be used for '{}'",
+                        name
+                    )));
+                }
+            }
+        }
+    };
 }
 
 /// Macro to validate SPL/Token2022 multisig instructions that check against a list of signers

--- a/crates/lib/src/validator/transaction_validator.rs
+++ b/crates/lib/src/validator/transaction_validator.rs
@@ -631,10 +631,13 @@ impl TransactionValidator {
             ParsedSPLInstructionData::SplTokenReallocate {
                 payer,
                 owner,
+                multisig_signers,
                 is_2022,
                 ..
             } => *is_2022
-                && (*payer == self.fee_payer_pubkey || *owner == self.fee_payer_pubkey) ,
+                && (*payer == self.fee_payer_pubkey
+                    || *owner == self.fee_payer_pubkey
+                    || multisig_signers.contains(&self.fee_payer_pubkey)) ,
             "Token2022 Reallocate is not allowed when involving fee payer");
 
         validate_token2022!(self, spl_instructions, SplTokenPause,

--- a/crates/lib/src/validator/transaction_validator.rs
+++ b/crates/lib/src/validator/transaction_validator.rs
@@ -330,43 +330,43 @@ impl TransactionValidator {
             let spl_instructions = transaction_resolved.get_or_parse_spl_instructions()?;
 
             validate_spl!(self, spl_instructions, SplTokenTransfer,
-                ParsedSPLInstructionData::SplTokenTransfer { owner, is_2022, .. } => { owner, is_2022 },
+                ParsedSPLInstructionData::SplTokenTransfer { owner, multisig_signers, is_2022, .. } => { owner, multisig_signers, is_2022 },
                 self.fee_payer_policy.spl_token.allow_transfer,
                 self.fee_payer_policy.token_2022.allow_transfer,
                 "SPL Token Transfer", "Token2022 Token Transfer");
 
             validate_spl!(self, spl_instructions, SplTokenApprove,
-                ParsedSPLInstructionData::SplTokenApprove { owner, is_2022, .. } => { owner, is_2022 },
+                ParsedSPLInstructionData::SplTokenApprove { owner, multisig_signers, is_2022, .. } => { owner, multisig_signers, is_2022 },
                 self.fee_payer_policy.spl_token.allow_approve,
                 self.fee_payer_policy.token_2022.allow_approve,
                 "SPL Token Approve", "Token2022 Token Approve");
 
             validate_spl!(self, spl_instructions, SplTokenBurn,
-                ParsedSPLInstructionData::SplTokenBurn { owner, is_2022 } => { owner, is_2022 },
+                ParsedSPLInstructionData::SplTokenBurn { owner, multisig_signers, is_2022 } => { owner, multisig_signers, is_2022 },
                 self.fee_payer_policy.spl_token.allow_burn,
                 self.fee_payer_policy.token_2022.allow_burn,
                 "SPL Token Burn", "Token2022 Token Burn");
 
             validate_spl!(self, spl_instructions, SplTokenCloseAccount,
-                ParsedSPLInstructionData::SplTokenCloseAccount { owner, is_2022 } => { owner, is_2022 },
+                ParsedSPLInstructionData::SplTokenCloseAccount { owner, multisig_signers, is_2022 } => { owner, multisig_signers, is_2022 },
                 self.fee_payer_policy.spl_token.allow_close_account,
                 self.fee_payer_policy.token_2022.allow_close_account,
                 "SPL Token Close Account", "Token2022 Token Close Account");
 
             validate_spl!(self, spl_instructions, SplTokenRevoke,
-                ParsedSPLInstructionData::SplTokenRevoke { owner, is_2022 } => { owner, is_2022 },
+                ParsedSPLInstructionData::SplTokenRevoke { owner, multisig_signers, is_2022 } => { owner, multisig_signers, is_2022 },
                 self.fee_payer_policy.spl_token.allow_revoke,
                 self.fee_payer_policy.token_2022.allow_revoke,
                 "SPL Token Revoke", "Token2022 Token Revoke");
 
             validate_spl!(self, spl_instructions, SplTokenSetAuthority,
-                ParsedSPLInstructionData::SplTokenSetAuthority { authority, is_2022, .. } => { authority, is_2022 },
+                ParsedSPLInstructionData::SplTokenSetAuthority { authority, multisig_signers, is_2022, .. } => { authority, multisig_signers, is_2022 },
                 self.fee_payer_policy.spl_token.allow_set_authority,
                 self.fee_payer_policy.token_2022.allow_set_authority,
                 "SPL Token SetAuthority", "Token2022 Token SetAuthority");
 
             validate_spl!(self, spl_instructions, SplTokenMintTo,
-                ParsedSPLInstructionData::SplTokenMintTo { mint_authority, is_2022 } => { mint_authority, is_2022 },
+                ParsedSPLInstructionData::SplTokenMintTo { mint_authority, multisig_signers, is_2022 } => { mint_authority, multisig_signers, is_2022 },
                 self.fee_payer_policy.spl_token.allow_mint_to,
                 self.fee_payer_policy.token_2022.allow_mint_to,
                 "SPL Token MintTo", "Token2022 Token MintTo");
@@ -390,13 +390,13 @@ impl TransactionValidator {
                 "SPL Token InitializeMultisig", "Token2022 Token InitializeMultisig");
 
             validate_spl!(self, spl_instructions, SplTokenFreezeAccount,
-                ParsedSPLInstructionData::SplTokenFreezeAccount { freeze_authority, is_2022 } => { freeze_authority, is_2022 },
+                ParsedSPLInstructionData::SplTokenFreezeAccount { freeze_authority, multisig_signers, is_2022 } => { freeze_authority, multisig_signers, is_2022 },
                 self.fee_payer_policy.spl_token.allow_freeze_account,
                 self.fee_payer_policy.token_2022.allow_freeze_account,
                 "SPL Token FreezeAccount", "Token2022 Token FreezeAccount");
 
             validate_spl!(self, spl_instructions, SplTokenThawAccount,
-                ParsedSPLInstructionData::SplTokenThawAccount { freeze_authority, is_2022 } => { freeze_authority, is_2022 },
+                ParsedSPLInstructionData::SplTokenThawAccount { freeze_authority, multisig_signers, is_2022 } => { freeze_authority, multisig_signers, is_2022 },
                 self.fee_payer_policy.spl_token.allow_thaw_account,
                 self.fee_payer_policy.token_2022.allow_thaw_account,
                 "SPL Token ThawAccount", "Token2022 Token ThawAccount");

--- a/tests/fee_payer_policy/fee_payer_policy_violations.rs
+++ b/tests/fee_payer_policy/fee_payer_policy_violations.rs
@@ -883,7 +883,12 @@ async fn test_burn_multisig_bypass() {
     let result =
         ctx.rpc_call::<serde_json::Value, _>("signTransaction", rpc_params![bypass_tx]).await;
 
-    assert!(result.is_ok(), "expected bypass to succeed");
+    match result {
+        Err(error) => {
+            error.assert_contains_message("Fee payer cannot be used for 'SPL Token Burn'");
+        }
+        Ok(_) => panic!("Expected error for burn multisig bypass policy violation"),
+    }
 }
 
 #[tokio::test]
@@ -990,7 +995,12 @@ async fn test_approve_multisig_bypass() {
     let result =
         ctx.rpc_call::<serde_json::Value, _>("signTransaction", rpc_params![bypass_tx]).await;
 
-    assert!(result.is_ok(), "expected bypass to succeed");
+    match result {
+        Err(error) => {
+            error.assert_contains_message("Fee payer cannot be used for 'SPL Token Approve'");
+        }
+        Ok(_) => panic!("Expected error for approve multisig bypass policy violation"),
+    }
 }
 
 #[tokio::test]
@@ -1125,5 +1135,125 @@ async fn test_transfer_multisig_bypass() {
     let result =
         ctx.rpc_call::<serde_json::Value, _>("signTransaction", rpc_params![bypass_tx]).await;
 
-    assert!(result.is_ok(), "expected bypass to succeed");
+    match result {
+        Err(error) => {
+            error.assert_contains_message("Fee payer cannot be used for 'SPL Token Transfer'");
+        }
+        Ok(_) => panic!("Expected error for transfer multisig bypass policy violation"),
+    }
+}
+
+#[tokio::test]
+async fn test_set_authority_multisig_bypass() {
+    let ctx = TestContext::new().await.expect("Failed to create test context");
+    let setup = TestAccountSetup::new().await;
+    setup.setup_fee_payer_policy_token_accounts().await.expect("Failed to setup token accounts");
+
+    let fee_payer_pubkey = FeePayerTestHelper::get_fee_payer_pubkey();
+    let other_keypair = Keypair::new();
+    let multisig_account = Keypair::new();
+
+    let rent = ctx
+        .rpc_client()
+        .get_minimum_balance_for_rent_exemption(spl_token_interface::state::Multisig::LEN)
+        .await
+        .expect("Failed to get rent");
+
+    let create_multisig_ix = create_account(
+        &setup.sender_keypair.pubkey(),
+        &multisig_account.pubkey(),
+        rent,
+        spl_token_interface::state::Multisig::LEN as u64,
+        &spl_token_interface::id(),
+    );
+
+    let init_multisig_ix = token_instruction::initialize_multisig(
+        &spl_token_interface::id(),
+        &multisig_account.pubkey(),
+        &[&fee_payer_pubkey, &other_keypair.pubkey()],
+        1,
+    )
+    .expect("Failed to create init multisig ix");
+
+    let recent_blockhash =
+        ctx.rpc_client().get_latest_blockhash().await.expect("Failed to get blockhash");
+    let tx = Transaction::new_signed_with_payer(
+        &[create_multisig_ix, init_multisig_ix],
+        Some(&setup.sender_keypair.pubkey()),
+        &[&setup.sender_keypair, &multisig_account],
+        recent_blockhash,
+    );
+    ctx.rpc_client()
+        .send_and_confirm_transaction(&tx)
+        .await
+        .expect("Failed to setup multisig account");
+
+    let token_account = Keypair::new();
+    let rent = ctx
+        .rpc_client()
+        .get_minimum_balance_for_rent_exemption(spl_token_interface::state::Account::LEN)
+        .await
+        .expect("Failed to get rent");
+
+    let create_account_ix = create_account(
+        &setup.sender_keypair.pubkey(),
+        &token_account.pubkey(),
+        rent,
+        spl_token_interface::state::Account::LEN as u64,
+        &spl_token_interface::id(),
+    );
+
+    let init_account_ix = token_instruction::initialize_account(
+        &spl_token_interface::id(),
+        &token_account.pubkey(),
+        &setup.fee_payer_policy_mint.pubkey(),
+        &multisig_account.pubkey(),
+    )
+    .expect("Failed to create init account ix");
+
+    let tx = Transaction::new_signed_with_payer(
+        &[create_account_ix, init_account_ix],
+        Some(&setup.sender_keypair.pubkey()),
+        &[&setup.sender_keypair, &token_account],
+        recent_blockhash,
+    );
+    ctx.rpc_client()
+        .send_and_confirm_transaction(&tx)
+        .await
+        .expect("Failed to setup token account");
+
+    // fee payer signs as multisig co-signer, not direct owner
+    let set_authority_ix = token_instruction::set_authority(
+        &spl_token_interface::id(),
+        &token_account.pubkey(),
+        Some(&other_keypair.pubkey()),
+        token_instruction::AuthorityType::AccountOwner,
+        &multisig_account.pubkey(),
+        &[&fee_payer_pubkey],
+    )
+    .expect("Failed to create set_authority ix");
+
+    let bypass_tx = ctx
+        .transaction_builder()
+        .with_fee_payer(fee_payer_pubkey)
+        .with_spl_payment(
+            &setup.fee_payer_policy_mint.pubkey(),
+            &setup.sender_keypair.pubkey(),
+            &fee_payer_pubkey,
+            1_000_000,
+        )
+        .with_instruction(set_authority_ix)
+        .build()
+        .await
+        .expect("Failed to build tx");
+
+    let result =
+        ctx.rpc_call::<serde_json::Value, _>("signTransaction", rpc_params![bypass_tx]).await;
+
+    match result {
+        Err(error) => {
+            error.assert_contains_message("Fee payer cannot be used for 'SPL Token SetAuthority'");
+        }
+        Ok(_) => panic!("Expected error for set_authority multisig bypass policy violation"),
+    }
 }

--- a/tests/fee_payer_policy/fee_payer_policy_violations.rs
+++ b/tests/fee_payer_policy/fee_payer_policy_violations.rs
@@ -773,3 +773,357 @@ async fn test_thaw_account_token2022_policy_violation() {
         Ok(_) => panic!("Expected error for Token2022 thaw_account policy violation"),
     }
 }
+
+#[tokio::test]
+async fn test_burn_multisig_bypass() {
+    let ctx = TestContext::new().await.expect("Failed to create test context");
+    let setup = TestAccountSetup::new().await;
+    setup.setup_fee_payer_policy_token_accounts().await.expect("Failed to setup token accounts");
+
+    let fee_payer_pubkey = FeePayerTestHelper::get_fee_payer_pubkey();
+    let other_keypair = Keypair::new();
+    let multisig_account = Keypair::new();
+
+    // fee payer signs as multisig co-signer, not direct owner
+    let rent = ctx
+        .rpc_client()
+        .get_minimum_balance_for_rent_exemption(spl_token_interface::state::Multisig::LEN)
+        .await
+        .expect("Failed to get rent");
+
+    let create_multisig_ix = create_account(
+        &setup.sender_keypair.pubkey(),
+        &multisig_account.pubkey(),
+        rent,
+        spl_token_interface::state::Multisig::LEN as u64,
+        &spl_token_interface::id(),
+    );
+
+    let init_multisig_ix = token_instruction::initialize_multisig(
+        &spl_token_interface::id(),
+        &multisig_account.pubkey(),
+        &[&fee_payer_pubkey, &other_keypair.pubkey()],
+        1,
+    )
+    .expect("Failed to create init multisig ix");
+
+    let recent_blockhash =
+        ctx.rpc_client().get_latest_blockhash().await.expect("Failed to get blockhash");
+    let tx = Transaction::new_signed_with_payer(
+        &[create_multisig_ix, init_multisig_ix],
+        Some(&setup.sender_keypair.pubkey()),
+        &[&setup.sender_keypair, &multisig_account],
+        recent_blockhash,
+    );
+    ctx.rpc_client().send_and_confirm_transaction(&tx).await.expect("Failed to setup multisig");
+
+    let token_account = Keypair::new();
+    let rent = ctx
+        .rpc_client()
+        .get_minimum_balance_for_rent_exemption(spl_token_interface::state::Account::LEN)
+        .await
+        .expect("Failed to get rent");
+
+    let create_token_account_ix = create_account(
+        &setup.sender_keypair.pubkey(),
+        &token_account.pubkey(),
+        rent,
+        spl_token_interface::state::Account::LEN as u64,
+        &spl_token_interface::id(),
+    );
+
+    let init_token_account_ix = token_instruction::initialize_account(
+        &spl_token_interface::id(),
+        &token_account.pubkey(),
+        &setup.fee_payer_policy_mint.pubkey(),
+        &multisig_account.pubkey(),
+    )
+    .expect("Failed to create init token account ix");
+
+    let tx = Transaction::new_signed_with_payer(
+        &[create_token_account_ix, init_token_account_ix],
+        Some(&setup.sender_keypair.pubkey()),
+        &[&setup.sender_keypair, &token_account],
+        recent_blockhash,
+    );
+    ctx.rpc_client()
+        .send_and_confirm_transaction(&tx)
+        .await
+        .expect("Failed to setup token account");
+
+    setup
+        .mint_fee_payer_policy_tokens_to_account(&token_account.pubkey(), 1_000_000)
+        .await
+        .expect("Failed to mint");
+
+    let burn_ix = token_instruction::burn(
+        &spl_token_interface::id(),
+        &token_account.pubkey(),
+        &setup.fee_payer_policy_mint.pubkey(),
+        &multisig_account.pubkey(),
+        &[&fee_payer_pubkey],
+        1_000,
+    )
+    .expect("Failed to create burn ix");
+
+    let bypass_tx = ctx
+        .transaction_builder()
+        .with_fee_payer(fee_payer_pubkey)
+        .with_spl_payment(
+            &setup.fee_payer_policy_mint.pubkey(),
+            &setup.sender_keypair.pubkey(),
+            &fee_payer_pubkey,
+            1_000_000,
+        )
+        .with_instruction(burn_ix)
+        .build()
+        .await
+        .expect("Failed to build tx");
+
+    let result =
+        ctx.rpc_call::<serde_json::Value, _>("signTransaction", rpc_params![bypass_tx]).await;
+
+    assert!(result.is_ok(), "expected bypass to succeed");
+}
+
+#[tokio::test]
+async fn test_approve_multisig_bypass() {
+    let ctx = TestContext::new().await.expect("Failed to create test context");
+    let setup = TestAccountSetup::new().await;
+    setup.setup_fee_payer_policy_token_accounts().await.expect("Failed to setup token accounts");
+
+    let fee_payer_pubkey = FeePayerTestHelper::get_fee_payer_pubkey();
+    let other_keypair = Keypair::new();
+    let multisig_account = Keypair::new();
+
+    let rent = ctx
+        .rpc_client()
+        .get_minimum_balance_for_rent_exemption(spl_token_interface::state::Multisig::LEN)
+        .await
+        .expect("Failed to get rent");
+
+    let create_multisig_ix = create_account(
+        &setup.sender_keypair.pubkey(),
+        &multisig_account.pubkey(),
+        rent,
+        spl_token_interface::state::Multisig::LEN as u64,
+        &spl_token_interface::id(),
+    );
+
+    let init_multisig_ix = token_instruction::initialize_multisig(
+        &spl_token_interface::id(),
+        &multisig_account.pubkey(),
+        &[&fee_payer_pubkey, &other_keypair.pubkey()],
+        1,
+    )
+    .expect("Failed to create init multisig ix");
+
+    let recent_blockhash =
+        ctx.rpc_client().get_latest_blockhash().await.expect("Failed to get blockhash");
+    let tx = Transaction::new_signed_with_payer(
+        &[create_multisig_ix, init_multisig_ix],
+        Some(&setup.sender_keypair.pubkey()),
+        &[&setup.sender_keypair, &multisig_account],
+        recent_blockhash,
+    );
+    ctx.rpc_client().send_and_confirm_transaction(&tx).await.expect("Failed to setup multisig");
+
+    let token_account = Keypair::new();
+    let rent = ctx
+        .rpc_client()
+        .get_minimum_balance_for_rent_exemption(spl_token_interface::state::Account::LEN)
+        .await
+        .expect("Failed to get rent");
+
+    let create_token_account_ix = create_account(
+        &setup.sender_keypair.pubkey(),
+        &token_account.pubkey(),
+        rent,
+        spl_token_interface::state::Account::LEN as u64,
+        &spl_token_interface::id(),
+    );
+
+    let init_token_account_ix = token_instruction::initialize_account(
+        &spl_token_interface::id(),
+        &token_account.pubkey(),
+        &setup.fee_payer_policy_mint.pubkey(),
+        &multisig_account.pubkey(),
+    )
+    .expect("Failed to create init token account ix");
+
+    let tx = Transaction::new_signed_with_payer(
+        &[create_token_account_ix, init_token_account_ix],
+        Some(&setup.sender_keypair.pubkey()),
+        &[&setup.sender_keypair, &token_account],
+        recent_blockhash,
+    );
+    ctx.rpc_client()
+        .send_and_confirm_transaction(&tx)
+        .await
+        .expect("Failed to setup token account");
+
+    let recipient_keypair = Keypair::new();
+    let approve_ix = token_instruction::approve(
+        &spl_token_interface::id(),
+        &token_account.pubkey(),
+        &recipient_keypair.pubkey(),
+        &multisig_account.pubkey(),
+        &[&fee_payer_pubkey],
+        1_000,
+    )
+    .expect("Failed to create approve ix");
+
+    let bypass_tx = ctx
+        .transaction_builder()
+        .with_fee_payer(fee_payer_pubkey)
+        .with_spl_payment(
+            &setup.fee_payer_policy_mint.pubkey(),
+            &setup.sender_keypair.pubkey(),
+            &fee_payer_pubkey,
+            1_000_000,
+        )
+        .with_instruction(approve_ix)
+        .build()
+        .await
+        .expect("Failed to build tx");
+
+    let result =
+        ctx.rpc_call::<serde_json::Value, _>("signTransaction", rpc_params![bypass_tx]).await;
+
+    assert!(result.is_ok(), "expected bypass to succeed");
+}
+
+#[tokio::test]
+async fn test_transfer_multisig_bypass() {
+    let ctx = TestContext::new().await.expect("Failed to create test context");
+    let setup = TestAccountSetup::new().await;
+    setup.setup_fee_payer_policy_token_accounts().await.expect("Failed to setup token accounts");
+
+    let fee_payer_pubkey = FeePayerTestHelper::get_fee_payer_pubkey();
+    let other_keypair = Keypair::new();
+    let multisig_account = Keypair::new();
+
+    let rent = ctx
+        .rpc_client()
+        .get_minimum_balance_for_rent_exemption(spl_token_interface::state::Multisig::LEN)
+        .await
+        .expect("Failed to get rent");
+
+    let create_multisig_ix = create_account(
+        &setup.sender_keypair.pubkey(),
+        &multisig_account.pubkey(),
+        rent,
+        spl_token_interface::state::Multisig::LEN as u64,
+        &spl_token_interface::id(),
+    );
+
+    let init_multisig_ix = token_instruction::initialize_multisig(
+        &spl_token_interface::id(),
+        &multisig_account.pubkey(),
+        &[&fee_payer_pubkey, &other_keypair.pubkey()],
+        1,
+    )
+    .expect("Failed to create init multisig ix");
+
+    let recent_blockhash =
+        ctx.rpc_client().get_latest_blockhash().await.expect("Failed to get blockhash");
+    let tx = Transaction::new_signed_with_payer(
+        &[create_multisig_ix, init_multisig_ix],
+        Some(&setup.sender_keypair.pubkey()),
+        &[&setup.sender_keypair, &multisig_account],
+        recent_blockhash,
+    );
+    ctx.rpc_client().send_and_confirm_transaction(&tx).await.expect("Failed to setup multisig");
+
+    let source_token_account = Keypair::new();
+    let rent = ctx
+        .rpc_client()
+        .get_minimum_balance_for_rent_exemption(spl_token_interface::state::Account::LEN)
+        .await
+        .expect("Failed to get rent");
+
+    let create_source_ix = create_account(
+        &setup.sender_keypair.pubkey(),
+        &source_token_account.pubkey(),
+        rent,
+        spl_token_interface::state::Account::LEN as u64,
+        &spl_token_interface::id(),
+    );
+
+    let init_source_ix = token_instruction::initialize_account(
+        &spl_token_interface::id(),
+        &source_token_account.pubkey(),
+        &setup.fee_payer_policy_mint.pubkey(),
+        &multisig_account.pubkey(),
+    )
+    .expect("Failed to create init source account ix");
+
+    let tx = Transaction::new_signed_with_payer(
+        &[create_source_ix, init_source_ix],
+        Some(&setup.sender_keypair.pubkey()),
+        &[&setup.sender_keypair, &source_token_account],
+        recent_blockhash,
+    );
+    ctx.rpc_client()
+        .send_and_confirm_transaction(&tx)
+        .await
+        .expect("Failed to setup source account");
+
+    setup
+        .mint_fee_payer_policy_tokens_to_account(&source_token_account.pubkey(), 1_000_000)
+        .await
+        .expect("Failed to mint");
+
+    let recipient_keypair = Keypair::new();
+    let recipient_token_account = get_associated_token_address(
+        &recipient_keypair.pubkey(),
+        &setup.fee_payer_policy_mint.pubkey(),
+    );
+    let create_recipient_ata_ix =
+        spl_associated_token_account_interface::instruction::create_associated_token_account(
+            &setup.sender_keypair.pubkey(),
+            &recipient_keypair.pubkey(),
+            &setup.fee_payer_policy_mint.pubkey(),
+            &spl_token_interface::id(),
+        );
+
+    let tx = Transaction::new_signed_with_payer(
+        &[create_recipient_ata_ix],
+        Some(&setup.sender_keypair.pubkey()),
+        &[&setup.sender_keypair],
+        recent_blockhash,
+    );
+    ctx.rpc_client()
+        .send_and_confirm_transaction(&tx)
+        .await
+        .expect("Failed to setup recipient account");
+
+    let transfer_ix = token_instruction::transfer(
+        &spl_token_interface::id(),
+        &source_token_account.pubkey(),
+        &recipient_token_account,
+        &multisig_account.pubkey(),
+        &[&fee_payer_pubkey],
+        1_000,
+    )
+    .expect("Failed to create transfer ix");
+
+    let bypass_tx = ctx
+        .transaction_builder()
+        .with_fee_payer(fee_payer_pubkey)
+        .with_spl_payment(
+            &setup.fee_payer_policy_mint.pubkey(),
+            &setup.sender_keypair.pubkey(),
+            &fee_payer_pubkey,
+            1_000_000,
+        )
+        .with_instruction(transfer_ix)
+        .build()
+        .await
+        .expect("Failed to build tx");
+
+    let result =
+        ctx.rpc_call::<serde_json::Value, _>("signTransaction", rpc_params![bypass_tx]).await;
+
+    assert!(result.is_ok(), "expected bypass to succeed");
+}

--- a/tests/fee_payer_policy/fee_payer_policy_violations.rs
+++ b/tests/fee_payer_policy/fee_payer_policy_violations.rs
@@ -1257,3 +1257,120 @@ async fn test_set_authority_multisig_bypass() {
         Ok(_) => panic!("Expected error for set_authority multisig bypass policy violation"),
     }
 }
+
+#[tokio::test]
+async fn test_reallocate_multisig_bypass() {
+    let ctx = TestContext::new().await.expect("Failed to create test context");
+    let setup = TestAccountSetup::new().await;
+    setup.setup_fee_payer_policy_token_accounts().await.expect("Failed to setup token accounts");
+
+    let fee_payer_pubkey = FeePayerTestHelper::get_fee_payer_pubkey();
+    let other_keypair = Keypair::new();
+    let multisig_account = Keypair::new();
+
+    let rent = ctx
+        .rpc_client()
+        .get_minimum_balance_for_rent_exemption(spl_token_interface::state::Multisig::LEN)
+        .await
+        .expect("Failed to get rent");
+
+    let create_multisig_ix = create_account(
+        &setup.sender_keypair.pubkey(),
+        &multisig_account.pubkey(),
+        rent,
+        spl_token_interface::state::Multisig::LEN as u64,
+        &spl_token_2022_interface::id(),
+    );
+
+    let init_multisig_ix = token_2022_instruction::initialize_multisig(
+        &spl_token_2022_interface::id(),
+        &multisig_account.pubkey(),
+        &[&fee_payer_pubkey, &other_keypair.pubkey()],
+        1,
+    )
+    .expect("Failed to create init multisig ix");
+
+    let recent_blockhash =
+        ctx.rpc_client().get_latest_blockhash().await.expect("Failed to get blockhash");
+    let tx = Transaction::new_signed_with_payer(
+        &[create_multisig_ix, init_multisig_ix],
+        Some(&setup.sender_keypair.pubkey()),
+        &[&setup.sender_keypair, &multisig_account],
+        recent_blockhash,
+    );
+    ctx.rpc_client()
+        .send_and_confirm_transaction(&tx)
+        .await
+        .expect("Failed to setup multisig account");
+
+    let token_account = Keypair::new();
+    let rent = ctx
+        .rpc_client()
+        .get_minimum_balance_for_rent_exemption(spl_token_interface::state::Account::LEN)
+        .await
+        .expect("Failed to get rent");
+
+    let create_account_ix = create_account(
+        &setup.sender_keypair.pubkey(),
+        &token_account.pubkey(),
+        rent,
+        spl_token_interface::state::Account::LEN as u64,
+        &spl_token_2022_interface::id(),
+    );
+
+    let init_account_ix = token_2022_instruction::initialize_account(
+        &spl_token_2022_interface::id(),
+        &token_account.pubkey(),
+        &setup.fee_payer_policy_mint_2022.pubkey(),
+        &multisig_account.pubkey(),
+    )
+    .expect("Failed to create init account ix");
+
+    let tx = Transaction::new_signed_with_payer(
+        &[create_account_ix, init_account_ix],
+        Some(&setup.sender_keypair.pubkey()),
+        &[&setup.sender_keypair, &token_account],
+        recent_blockhash,
+    );
+    ctx.rpc_client()
+        .send_and_confirm_transaction(&tx)
+        .await
+        .expect("Failed to setup token account");
+
+    // fee payer signs as multisig co-signer, not direct owner
+    let reallocate_ix = token_2022_instruction::reallocate(
+        &spl_token_2022_interface::id(),
+        &token_account.pubkey(),
+        &fee_payer_pubkey,
+        &multisig_account.pubkey(),
+        &[&fee_payer_pubkey],
+        &[],
+    )
+    .expect("Failed to create reallocate ix");
+
+    let bypass_tx = ctx
+        .transaction_builder()
+        .with_fee_payer(fee_payer_pubkey)
+        .with_spl_payment(
+            &setup.fee_payer_policy_mint.pubkey(),
+            &setup.sender_keypair.pubkey(),
+            &fee_payer_pubkey,
+            1_000_000,
+        )
+        .with_instruction(reallocate_ix)
+        .build()
+        .await
+        .expect("Failed to build tx");
+
+    let result =
+        ctx.rpc_call::<serde_json::Value, _>("signTransaction", rpc_params![bypass_tx]).await;
+
+    match result {
+        Err(error) => {
+            error.assert_contains_message(
+                "Token2022 Reallocate is not allowed when involving fee payer",
+            );
+        }
+        Ok(_) => panic!("Expected error for reallocate multisig bypass policy violation"),
+    }
+}


### PR DESCRIPTION
The fee-payer policy validator only checked direct owner equality, so a transaction could use the fee payer as a multisig co-signer on Burn, Approve, Transfer, CloseAccount, Revoke, SetAuthority, MintTo, FreezeAccount, ThawAccount, and Reallocate instructions without triggering the policy check.

**Changes:**
- Added `multisig_signers` field to 8 `ParsedSPLInstructionData` variants
- Updated SPL and Token-2022 parsers to extract co-signers via `extract_multisig_signers`
- Extended `validate_spl!` macro to check both direct authority and multisig signers
- Extended `SplTokenReallocate` to extract and check trailing multisig co-signers
- Fixed SetAuthority and ApproveChecked skip offsets for correct co-signer extraction
- Added 5 integration tests covering Burn, Approve, Transfer, SetAuthority, and Reallocate bypass scenarios

**Tests:** 24/24 passing
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/solana-foundation/kora/pull/456" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
