### PR TITLE
ci(deploy): route Cloud Build logs to a regional user-owned bucket

### DIFF
--- a/.github/workflows/deploy-devnet-paymaster.yml
+++ b/.github/workflows/deploy-devnet-paymaster.yml
@@ -47,7 +47,8 @@ jobs:
           gcloud builds submit examples/devnet-deploy-paymaster/ \
             --tag "$IMAGE" \
             --project="$PROJECT" \
-            --gcs-source-staging-dir="gs://${PROJECT}_cloudbuild/source"
+            --gcs-source-staging-dir="gs://${PROJECT}_cloudbuild/source" \
+            --default-buckets-behavior=regional-user-owned-bucket
           echo "image=$IMAGE" >> "$GITHUB_OUTPUT"
 
       - id: deploy


### PR DESCRIPTION
## Summary
- Custom build SAs cannot stream logs from the project's default `_cloudbuild_logs` bucket
- Build itself succeeds, but `gcloud builds submit` exits non-zero because it can't tail logs back
- `--default-buckets-behavior=regional-user-owned-bucket` makes Cloud Build write logs to a per-region user-owned bucket the deployer SA can read

Refs: https://cloud.google.com/build/docs/securing-builds/store-manage-build-logs

## Test plan
- [ ] Trigger the workflow from this branch (requires Doppler service identity to accept feature-branch sub claims) → confirm both build and deploy steps complete
- [ ] After merge, retrigger from main as the canonical deploy
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/solana-foundation/kora/pull/457" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
