### PR TITLE
ci(deploy): submit builds with --async + poll instead of streaming logs

### DIFF
--- a/.github/workflows/deploy-devnet-paymaster.yml
+++ b/.github/workflows/deploy-devnet-paymaster.yml
@@ -43,12 +43,31 @@ jobs:
           PROJECT: ${{ env.GCP_PROJECT_ID }}
           SERVICE: ${{ env.CLOUD_RUN_SERVICE }}
         run: |
+          set -euo pipefail
           IMAGE="${REGION}-docker.pkg.dev/${PROJECT}/cloud-run-source-deploy/${SERVICE}:${GITHUB_SHA::12}"
-          gcloud builds submit examples/devnet-deploy-paymaster/ \
+
+          # --async + poll: log streaming needs Project Viewer/Owner; scoped SA isn't.
+          BUILD_ID=$(gcloud builds submit examples/devnet-deploy-paymaster/ \
             --tag "$IMAGE" \
             --project="$PROJECT" \
             --gcs-source-staging-dir="gs://${PROJECT}_cloudbuild/source" \
-            --default-buckets-behavior=regional-user-owned-bucket
+            --async --format='value(id)')
+          [ -n "$BUILD_ID" ] || { echo "empty build id"; exit 1; }
+          echo "Submitted $BUILD_ID"
+          echo "Logs: https://console.cloud.google.com/cloud-build/builds/$BUILD_ID?project=$PROJECT"
+
+          STATUS=
+          for i in $(seq 1 80); do
+            STATUS=$(gcloud builds describe "$BUILD_ID" --project="$PROJECT" --format='value(status)')
+            echo "  $i/80: $STATUS"
+            case "$STATUS" in
+              SUCCESS) break ;;
+              FAILURE|TIMEOUT|CANCELLED|EXPIRED|INTERNAL_ERROR) exit 1 ;;
+            esac
+            sleep 30
+          done
+          [ "$STATUS" = "SUCCESS" ] || { echo "timed out polling $BUILD_ID"; exit 1; }
+
           echo "image=$IMAGE" >> "$GITHUB_OUTPUT"
 
       - id: deploy


### PR DESCRIPTION
## Summary
- Default `gcloud builds submit` tails logs from the project's default log bucket — requires Project Viewer/Owner on the caller, which our scoped deployer SA isn't
- Switching to `--async` returns immediately with the build ID; we then poll `gcloud builds describe` until SUCCESS / terminal failure
- `describe` only hits the metadata API (`cloudbuild.builds.get`) which our SA already has via `cloudbuild.builds.editor` — no log-bucket perms required

## Verification
Verified by impersonating the deployer SA locally: `gcloud builds describe` against the last build returns `SUCCESS` cleanly with no log-bucket access in the call path.

## Test plan
- [ ] Trigger workflow from this branch (Doppler service identity now accepts feature-branch sub claims) → confirm build + deploy go end-to-end
- [ ] Merge → retrigger from main as the canonical deploy

Refs: https://cloud.google.com/sdk/gcloud/reference/builds/submit#--async
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/solana-foundation/kora/pull/458" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
