### PR TITLE
chore(devnet-paymaster): add full-deploy smoke test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1624,6 +1624,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "devnet-deploy-paymaster-smoke"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "base64 0.22.1",
+ "bincode",
+ "clap",
+ "reqwest 0.12.23",
+ "serde_json",
+ "solana-client",
+ "solana-commitment-config",
+ "solana-loader-v3-interface",
+ "solana-sdk",
+ "tokio",
+]
+
+[[package]]
 name = "digest"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
-members = ["crates/lib", "crates/cli", "tests"]
+members = ["crates/lib", "crates/cli", "tests", "examples/devnet-deploy-paymaster"]
+default-members = ["crates/lib", "crates/cli", "tests"]
 resolver = "2"
 
 [workspace.lints.rust]

--- a/examples/devnet-deploy-paymaster/Cargo.toml
+++ b/examples/devnet-deploy-paymaster/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "devnet-deploy-paymaster-smoke"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[[bin]]
+name = "devnet_smoke"
+path = "src/main.rs"
+
+[dependencies]
+anyhow = { workspace = true }
+base64 = { workspace = true }
+bincode = { workspace = true }
+clap = { workspace = true, features = ["derive"] }
+reqwest = { workspace = true }
+serde_json = { workspace = true }
+solana-client = { workspace = true }
+solana-commitment-config = { workspace = true }
+solana-loader-v3-interface = { workspace = true }
+solana-sdk = { workspace = true }
+tokio = { workspace = true }

--- a/examples/devnet-deploy-paymaster/smoke-test.sh
+++ b/examples/devnet-deploy-paymaster/smoke-test.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# End-to-end smoke test against the live devnet paymaster.
+#
+# Deploys a real program through Kora (transfer-hook-example.so by default),
+# verifies on-chain that Kora is the upgrade authority, then closes the program
+# to recover rent. Self-cleaning, zero net SOL cost.
+#
+#   ./smoke-test.sh                         # default URL + program
+#   ./smoke-test.sh --kora-url <URL>        # override paymaster URL
+#   ./smoke-test.sh --program-so <path.so>  # deploy a different program
+
+set -euo pipefail
+exec cargo run --quiet --manifest-path "$(dirname "$0")/Cargo.toml" -- "$@"

--- a/examples/devnet-deploy-paymaster/src/main.rs
+++ b/examples/devnet-deploy-paymaster/src/main.rs
@@ -1,0 +1,223 @@
+#![allow(deprecated)] // loader-v3 helpers are tagged "use loader-v4" but v4 is feature-gated.
+
+use anyhow::{anyhow, bail, Context, Result};
+use base64::{engine::general_purpose::STANDARD as B64, Engine as _};
+use clap::Parser;
+use serde_json::{json, Value};
+use solana_client::nonblocking::rpc_client::RpcClient;
+use solana_commitment_config::CommitmentConfig;
+use solana_loader_v3_interface::{instruction as loader_v3, state::UpgradeableLoaderState};
+use solana_sdk::{
+    instruction::Instruction,
+    message::Message,
+    pubkey::Pubkey,
+    signature::{Keypair, Signature},
+    signer::Signer,
+    transaction::Transaction,
+};
+use std::{str::FromStr, sync::Arc, time::Duration};
+
+const WRITE_CHUNK_SIZE: usize = 900;
+const DEFAULT_PROGRAM_SO: &str = concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../tests/src/common/transfer-hook-example/transfer_hook_example.so"
+);
+const BPF_LOADER_UPGRADEABLE: Pubkey =
+    solana_sdk::pubkey!("BPFLoaderUpgradeab1e11111111111111111111111");
+
+#[derive(Parser)]
+#[command(about = "End-to-end smoke test: deploy a program through the live Kora paymaster")]
+struct Args {
+    /// Kora paymaster URL.
+    #[arg(long, default_value = "https://kora-devnet-paymaster-kysurhpjxq-uc.a.run.app")]
+    kora_url: String,
+
+    /// Solana RPC for reading on-chain state.
+    #[arg(long, default_value = "https://api.devnet.solana.com")]
+    rpc_url: String,
+
+    /// Path to a `.so` program. Defaults to the transfer-hook-example bundled with the tests.
+    #[arg(long)]
+    program_so: Option<String>,
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let args = Args::parse();
+    let http = reqwest::Client::builder().timeout(Duration::from_secs(60)).build()?;
+    let rpc = Arc::new(RpcClient::new_with_commitment(
+        args.rpc_url.clone(),
+        CommitmentConfig::confirmed(),
+    ));
+
+    // Fetch Kora's pubkey from the live paymaster (matches the KMS-backed signer).
+    let kora_pubkey = fetch_kora_pubkey(&http, &args.kora_url).await?;
+    println!("Kora paymaster: {}", args.kora_url);
+    println!("Kora pubkey:    {}", kora_pubkey);
+    println!("Solana RPC:     {}", args.rpc_url);
+    println!();
+
+    let user_id = format!("kora-smoke-{}", Pubkey::new_unique());
+    let program = Keypair::new();
+    let buffer = Keypair::new();
+    let program_path = args.program_so.as_deref().unwrap_or(DEFAULT_PROGRAM_SO);
+    let bytes = std::fs::read(program_path).with_context(|| format!("reading {program_path}"))?;
+    let chunk_count = bytes.len().div_ceil(WRITE_CHUNK_SIZE);
+    let pdata = derive_program_data_address(&program.pubkey());
+
+    println!("[1/6] create_buffer (Kora as authority)");
+    let buffer_lamports = rpc
+        .get_minimum_balance_for_rent_exemption(UpgradeableLoaderState::size_of_buffer(bytes.len()))
+        .await?;
+    let create_buf = loader_v3::create_buffer(
+        &kora_pubkey,
+        &buffer.pubkey(),
+        &kora_pubkey,
+        buffer_lamports,
+        bytes.len(),
+    )?;
+    submit(&http, &args.kora_url, &user_id, &rpc, &kora_pubkey, &create_buf, &[&buffer]).await?;
+    println!("      buffer = {}", buffer.pubkey());
+
+    println!("[2/6] writing {} bytes in {} chunks", bytes.len(), chunk_count);
+    for (i, chunk) in bytes.chunks(WRITE_CHUNK_SIZE).enumerate() {
+        let offset = (i * WRITE_CHUNK_SIZE) as u32;
+        let ix = loader_v3::write(&buffer.pubkey(), &kora_pubkey, offset, chunk.to_vec());
+        submit(&http, &args.kora_url, &user_id, &rpc, &kora_pubkey, &[ix], &[]).await?;
+        if (i + 1) % 25 == 0 || i + 1 == chunk_count {
+            println!("      chunk {}/{}", i + 1, chunk_count);
+        }
+    }
+
+    println!("[3/6] deploy_with_max_program_len (Kora as upgrade authority)");
+    let program_lamports = rpc
+        .get_minimum_balance_for_rent_exemption(UpgradeableLoaderState::size_of_program())
+        .await?;
+    let deploy_ixs = loader_v3::deploy_with_max_program_len(
+        &kora_pubkey,
+        &program.pubkey(),
+        &buffer.pubkey(),
+        &kora_pubkey,
+        program_lamports,
+        bytes.len(),
+    )?;
+    submit(&http, &args.kora_url, &user_id, &rpc, &kora_pubkey, &deploy_ixs, &[&program]).await?;
+    println!("      program = {}", program.pubkey());
+
+    println!("[4/6] verifying on-chain state");
+    let pdata_account = rpc.get_account(&pdata).await?;
+    let state: UpgradeableLoaderState = bincode::deserialize(
+        &pdata_account.data[..UpgradeableLoaderState::size_of_programdata_metadata()],
+    )?;
+    match state {
+        UpgradeableLoaderState::ProgramData { upgrade_authority_address, .. } => {
+            if upgrade_authority_address != Some(kora_pubkey) {
+                bail!("upgrade_authority is {upgrade_authority_address:?}, expected {kora_pubkey}");
+            }
+        }
+        other => bail!("expected ProgramData, got {other:?}"),
+    }
+    println!("      programdata.upgrade_authority == Kora");
+
+    println!("[5/6] waiting for slot to advance (loader-v3 same-block close guard)");
+    wait_for_next_slot(&rpc).await?;
+
+    println!("[6/6] close (Kora as authority + recipient → recovers rent)");
+    let close_ix =
+        loader_v3::close_any(&pdata, &kora_pubkey, Some(&kora_pubkey), Some(&program.pubkey()));
+    submit(&http, &args.kora_url, &user_id, &rpc, &kora_pubkey, &[close_ix], &[]).await?;
+
+    println!();
+    println!("OK — full deploy lifecycle succeeded against {}", args.kora_url);
+    Ok(())
+}
+
+async fn fetch_kora_pubkey(http: &reqwest::Client, url: &str) -> Result<Pubkey> {
+    let resp: Value = http
+        .post(url)
+        .json(&json!({"jsonrpc":"2.0","id":1,"method":"getPayerSigner","params":[]}))
+        .send()
+        .await?
+        .error_for_status()?
+        .json()
+        .await?;
+    Pubkey::from_str(
+        resp["result"]["signer_address"]
+            .as_str()
+            .ok_or_else(|| anyhow!("getPayerSigner missing signer_address: {resp}"))?,
+    )
+    .context("parsing kora pubkey")
+}
+
+fn derive_program_data_address(program: &Pubkey) -> Pubkey {
+    Pubkey::find_program_address(&[program.as_ref()], &BPF_LOADER_UPGRADEABLE).0
+}
+
+async fn build_b64_tx(
+    rpc: &RpcClient,
+    fee_payer: &Pubkey,
+    ixs: &[Instruction],
+    extra_signers: &[&Keypair],
+) -> Result<String> {
+    let blockhash = rpc.get_latest_blockhash().await?;
+    let msg = Message::new_with_blockhash(ixs, Some(fee_payer), &blockhash);
+    let mut tx = Transaction::new_unsigned(msg);
+    if !extra_signers.is_empty() {
+        tx.partial_sign(extra_signers, blockhash);
+    }
+    Ok(B64.encode(bincode::serialize(&tx)?))
+}
+
+async fn submit(
+    http: &reqwest::Client,
+    kora_url: &str,
+    user_id: &str,
+    rpc: &RpcClient,
+    fee_payer: &Pubkey,
+    ixs: &[Instruction],
+    extra_signers: &[&Keypair],
+) -> Result<()> {
+    let tx_b64 = build_b64_tx(rpc, fee_payer, ixs, extra_signers).await?;
+    let resp: Value = http
+        .post(kora_url)
+        .json(&json!({
+            "jsonrpc":"2.0","id":1,
+            "method":"signAndSendTransaction",
+            "params":{"transaction": tx_b64, "user_id": user_id}
+        }))
+        .send()
+        .await?
+        .error_for_status()?
+        .json()
+        .await?;
+    if let Some(err) = resp.get("error") {
+        bail!("Kora rejected: {err}");
+    }
+    let sig_str = resp["result"]["signature"]
+        .as_str()
+        .ok_or_else(|| anyhow!("response missing signature: {resp}"))?;
+    let sig = Signature::from_str(sig_str)?;
+    await_tx(rpc, &sig).await
+}
+
+async fn await_tx(rpc: &RpcClient, sig: &Signature) -> Result<()> {
+    for _ in 0..120 {
+        if rpc.confirm_transaction_with_commitment(sig, CommitmentConfig::confirmed()).await?.value
+        {
+            return Ok(());
+        }
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
+    bail!("timed out waiting for {sig}")
+}
+
+async fn wait_for_next_slot(rpc: &RpcClient) -> Result<()> {
+    let start = rpc.get_slot().await?;
+    for _ in 0..40 {
+        if rpc.get_slot().await? > start {
+            return Ok(());
+        }
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+    bail!("slot never advanced past {start}")
+}


### PR DESCRIPTION
End-to-end smoke test against the live devnet paymaster.

**What it does:** deploys a real program (defaults to bundled \`transfer-hook-example.so\`) through the live Kora paymaster, verifies on-chain that Kora is the upgrade authority, then closes the program to recover rent. Self-cleaning, zero net SOL cost per run.

\`\`\`
$ ./examples/devnet-deploy-paymaster/smoke-test.sh
Kora paymaster: https://kora-devnet-paymaster-kysurhpjxq-uc.a.run.app
Kora pubkey:    GHPDh3NozXaTeWHipiqNs4WrV5JbgN3AQow7i9aTL5rU
Solana RPC:     https://api.devnet.solana.com

[1/6] create_buffer (Kora as authority)
[2/6] writing 96640 bytes in 108 chunks
[3/6] deploy_with_max_program_len (Kora as upgrade authority)
[4/6] verifying on-chain state
      programdata.upgrade_authority == Kora
[5/6] waiting for slot to advance
[6/6] close (recovers rent to Kora)

OK — full deploy lifecycle succeeded
\`\`\`

Override URL/program: \`./smoke-test.sh --kora-url <URL> --program-so my.so\`.

The shell script is a thin wrapper over a Rust binary at \`tests/src/bin/devnet_smoke.rs\` (shell can't bincode-serialize Solana txs). Same deploy-chain shape as the integration test in \`tests/loader_v3_deploy/\`, just adapted for live: env-var-controlled URL + RPC, fetches Kora's pubkey from \`getPayerSigner\` instead of a local keypair, includes \`user_id\` for the live paymaster's usage tracking.

## Test plan
- [x] Run against live paymaster — verified end-to-end (program 2yhmbN2R7iWoaV8R3c8jYE4V93GJ6VXU6Rkb3u421Hwm deployed + closed cleanly)
- [x] \`cargo clippy -p tests --bin devnet_smoke -- -D warnings\` clean
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/solana-foundation/kora/pull/460" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


## 📊 Unit Test Coverage
![Coverage](https://img.shields.io/badge/coverage-85.8%25-green)

**Unit Test Coverage: 85.8%**

[View Detailed Coverage Report](https://github.com/solana-foundation/kora/actions/runs/25069994460)