### PR TITLE
Support Openfort backend wallet signer

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,11 @@ PRIVY_APP_ID=your-privy-app-id
 PRIVY_APP_SECRET=your-privy-app-secret
 PRIVY_WALLET_ID=your-privy-wallet-id
 
+# Openfort Signer
+OPENFORT_SECRET_KEY_1=sk_test_or_sk_live_...
+OPENFORT_ACCOUNT_ID_1=acc_<uuid>
+OPENFORT_WALLET_SECRET_1=<base64-encoded PKCS#8 DER from the Openfort dashboard>
+
 # Grafana
 GF_SECURITY_ADMIN_PASSWORD=your_secure_password_here
 GF_SECURITY_ADMIN_USER=admin

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -192,6 +192,9 @@ cargo run -p kora --bin kora -- rpc start --signers-config path/to/turnkey-signe
 # Run with Privy signer
 cargo run -p kora --bin kora -- rpc start --signers-config path/to/privy-signers.toml
 
+# Run with Openfort signer
+cargo run -p kora --bin kora -- rpc start --signers-config path/to/openfort-signers.toml
+
 # Run with Vault signer  
 cargo run -p kora --bin kora -- rpc start \
   --signers-config path/to/vault-signers.toml
@@ -307,6 +310,7 @@ A Claude skill is available at `.claude/skills/release/SKILL.md` that automates 
   - `VaultSigner` - HashiCorp Vault integration
   - `TurnkeySigner` - Turnkey API integration  
   - `PrivySigner` - Privy API integration
+  - `OpenfortSigner` - Openfort backend wallet API integration
   - Unified `KoraSigner` enum with trait implementation
   - optionally, `--no-signer` flag to run Kora without a signer
 
@@ -383,6 +387,7 @@ cargo run -p kora --bin kora --features docs -- openapi -o openapi.json
 
 - **kora-turnkey** - Turnkey key management API integration (separate crate)
 - **kora-privy** - Privy wallet API integration (separate crate)  
+- **OpenfortSigner** - Openfort backend wallet API integration (via solana-keychain)
 - **VaultSigner** - HashiCorp Vault integration (built into kora-lib)
 - Remote signers integrate via HTTP APIs to external services
 
@@ -601,9 +606,9 @@ pub trait VersionedTransactionExt {
 
 - **Trait-based design** - All signers implement unified `Signer` trait
 - **State management** - Global signer state with thread-safe access via `get_signer()`
-- **Multiple backends** - Runtime selection between Memory, Vault, Turnkey, Privy
+- **Multiple backends** - Runtime selection between Memory, Vault, Turnkey, Privy, Openfort
 - **Initialization** - Lazy initialization with validation on first use
-- **API Integration** - Turnkey and Privy use HTTP APIs for remote signing
+- **API Integration** - Turnkey, Privy, and Openfort use HTTP APIs for remote signing
 
 ## Code Style & Best Practices
 
@@ -630,7 +635,7 @@ Kora is designed for high-performance concurrent operations:
 All I/O operations and external API calls are async:
 
 - **RPC Client Operations**: Solana RPC calls are async to avoid blocking
-- **Remote Signer APIs**: Turnkey and Privy API calls are async HTTP requests
+- **Remote Signer APIs**: Turnkey, Privy, and Openfort API calls are async HTTP requests
 - **Database Operations**: Token cache operations are async
 - **Error Propagation**: Use `?` operator with async functions
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6187,9 +6187,9 @@ dependencies = [
 
 [[package]]
 name = "solana-keychain"
-version = "1.0.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bbe21603449eb0ff097c81be4c0547898db2d9f3bc59eb4f9afa853aeab1b1f"
+checksum = "60a9fc1ac28499fc3c913776c70bcf9a5373505b94e42d8b0f17ca2c57a47052"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -6213,6 +6213,7 @@ dependencies = [
  "sha2",
  "solana-sdk",
  "solana-shred-version",
+ "solana-signature",
  "thiserror 2.0.17",
  "tokio",
  "uuid",

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@
 
 - **Language**: Rust with TypeScript SDK
 - **Protocol**: JSON-RPC 2.0  
-- **Signers**: Solana Private Key, Turnkey, Privy
+- **Signers**: Solana Private Key, Turnkey, Privy, Openfort
 - **Authentication**: API Key, HMAC, or none
 - **Deployment**: Flexible deployment options (Docker, Railway, etc.) 
 
@@ -45,7 +45,7 @@
 - Full Token-2022 support with extension filtering
 - Redis caching for improved performance
 - Rate limiting and spend protection
-- Secure key management (Turnkey, Privy, Vault)
+- Secure key management (Turnkey, Privy, Vault, Openfort)
 - HMAC and API key authentication
 - Prometheus metrics and monitoring
 - Enhanced fee payer protection policies

--- a/crates/lib/Cargo.toml
+++ b/crates/lib/Cargo.toml
@@ -44,7 +44,7 @@ reqwest = { workspace = true }
 spl-token-interface = { workspace = true }
 spl-token-2022-interface = { workspace = true }
 spl-associated-token-account-interface = { workspace = true }
-solana-keychain = { version = "1.0.1", default-features = false, features = [
+solana-keychain = { version = "1.2.0", default-features = false, features = [
     "all",
     "sdk-v3",
 ] }

--- a/crates/lib/src/signer/config.rs
+++ b/crates/lib/src/signer/config.rs
@@ -88,7 +88,9 @@ pub struct OpenfortSignerConfig {
     pub secret_key_env: String,
     /// Env var holding the backend wallet account ID (`acc_<uuid>`).
     pub account_id_env: String,
-    /// Env var holding the PEM PKCS#8 ECDSA P-256 wallet secret from the Openfort dashboard.
+    /// Env var holding the ECDSA P-256 wallet secret from the Openfort dashboard.
+    /// Accepts either a base64-encoded PKCS#8 DER body (single-line, env-var-friendly)
+    /// or a full PEM string (`-----BEGIN PRIVATE KEY-----` ...).
     pub wallet_secret_env: String,
 }
 

--- a/crates/lib/src/signer/config.rs
+++ b/crates/lib/src/signer/config.rs
@@ -81,6 +81,17 @@ pub struct PrivySignerConfig {
     pub wallet_id_env: String,
 }
 
+/// Openfort backend wallet signer configuration
+#[derive(Clone, Serialize, Deserialize)]
+pub struct OpenfortSignerConfig {
+    /// Env var holding the Openfort project secret key (`sk_test_*` / `sk_live_*`).
+    pub secret_key_env: String,
+    /// Env var holding the backend wallet account ID (`acc_<uuid>`).
+    pub account_id_env: String,
+    /// Env var holding the PEM PKCS#8 ECDSA P-256 wallet secret from the Openfort dashboard.
+    pub wallet_secret_env: String,
+}
+
 /// Vault signer configuration
 #[derive(Clone, Serialize, Deserialize)]
 pub struct VaultSignerConfig {
@@ -227,6 +238,11 @@ pub enum SignerTypeConfig {
         #[serde(flatten)]
         config: CrossmintSignerConfig,
     },
+    /// Openfort backend wallet signer configuration
+    Openfort {
+        #[serde(flatten)]
+        config: OpenfortSignerConfig,
+    },
 }
 
 impl SignerPoolConfig {
@@ -340,6 +356,9 @@ impl SignerConfig {
             }
             SignerTypeConfig::Crossmint { config: crossmint_config } => {
                 Self::build_crossmint_signer(crossmint_config, &config.name).await
+            }
+            SignerTypeConfig::Openfort { config: openfort_config } => {
+                Self::build_openfort_signer(openfort_config, &config.name).await
             }
         }
     }
@@ -557,6 +576,22 @@ impl SignerConfig {
         })
     }
 
+    async fn build_openfort_signer(
+        config: &OpenfortSignerConfig,
+        signer_name: &str,
+    ) -> Result<Signer, KoraError> {
+        let secret_key = get_env_var_for_signer(&config.secret_key_env, signer_name)?;
+        let account_id = get_env_var_for_signer(&config.account_id_env, signer_name)?;
+        let wallet_secret = get_env_var_for_signer(&config.wallet_secret_env, signer_name)?;
+
+        Signer::from_openfort(secret_key, account_id, wallet_secret, None).await.map_err(|e| {
+            KoraError::SigningError(format!(
+                "Failed to create Openfort signer '{signer_name}': {}",
+                sanitize_error!(e)
+            ))
+        })
+    }
+
     /// Validate an individual signer configuration
     pub fn validate_individual_signer_config(&self, index: usize) -> Result<(), KoraError> {
         if self.name.is_empty() {
@@ -586,6 +621,9 @@ impl SignerConfig {
             SignerTypeConfig::Dfns { config } => Self::validate_dfns_config(config, &self.name),
             SignerTypeConfig::Crossmint { config } => {
                 Self::validate_crossmint_config(config, &self.name)
+            }
+            SignerTypeConfig::Openfort { config } => {
+                Self::validate_openfort_config(config, &self.name)
             }
         }
     }
@@ -798,6 +836,27 @@ impl SignerConfig {
                 )));
             }
             get_env_var_for_signer(env, signer_name)?;
+        }
+        Ok(())
+    }
+
+    fn validate_openfort_config(
+        config: &OpenfortSignerConfig,
+        signer_name: &str,
+    ) -> Result<(), KoraError> {
+        let env_vars = [
+            ("secret_key_env", &config.secret_key_env),
+            ("account_id_env", &config.account_id_env),
+            ("wallet_secret_env", &config.wallet_secret_env),
+        ];
+
+        for (field_name, env_var) in env_vars {
+            if env_var.is_empty() {
+                return Err(KoraError::ValidationError(format!(
+                    "Openfort signer '{signer_name}' must specify non-empty {field_name}"
+                )));
+            }
+            get_env_var_for_signer(env_var, signer_name)?;
         }
         Ok(())
     }

--- a/crates/lib/src/signer/config.rs
+++ b/crates/lib/src/signer/config.rs
@@ -597,14 +597,15 @@ impl SignerConfig {
             ))
         };
 
-        let mut signer = KeychainOpenfortSigner::from_config(solana_keychain::OpenfortSignerConfig {
-            secret_key,
-            account_id,
-            wallet_secret,
-            api_base_url: config.api_base_url.clone(),
-            http_client_config: None,
-        })
-        .map_err(map_err)?;
+        let mut signer =
+            KeychainOpenfortSigner::from_config(solana_keychain::OpenfortSignerConfig {
+                secret_key,
+                account_id,
+                wallet_secret,
+                api_base_url: config.api_base_url.clone(),
+                http_client_config: None,
+            })
+            .map_err(map_err)?;
         signer.init().await.map_err(map_err)?;
         Ok(Signer::Openfort(signer))
     }

--- a/crates/lib/src/signer/config.rs
+++ b/crates/lib/src/signer/config.rs
@@ -1,6 +1,6 @@
 use crate::{error::KoraError, sanitize_error, signer::utils::get_env_var_for_signer};
 use serde::{Deserialize, Serialize};
-use solana_keychain::Signer;
+use solana_keychain::{OpenfortSigner as KeychainOpenfortSigner, Signer};
 use std::{fmt, fs, path::Path};
 
 /// Configuration for a pool of signers
@@ -92,6 +92,10 @@ pub struct OpenfortSignerConfig {
     /// Accepts either a base64-encoded PKCS#8 DER body (single-line, env-var-friendly)
     /// or a full PEM string (`-----BEGIN PRIVATE KEY-----` ...).
     pub wallet_secret_env: String,
+    /// Optional override for the Openfort API base URL (defaults to `https://api.openfort.io`).
+    /// Useful for pointing at staging or mock endpoints during testing. Must use HTTPS.
+    #[serde(default)]
+    pub api_base_url: Option<String>,
 }
 
 /// Vault signer configuration
@@ -586,12 +590,23 @@ impl SignerConfig {
         let account_id = get_env_var_for_signer(&config.account_id_env, signer_name)?;
         let wallet_secret = get_env_var_for_signer(&config.wallet_secret_env, signer_name)?;
 
-        Signer::from_openfort(secret_key, account_id, wallet_secret, None).await.map_err(|e| {
+        let map_err = |e| {
             KoraError::SigningError(format!(
                 "Failed to create Openfort signer '{signer_name}': {}",
                 sanitize_error!(e)
             ))
+        };
+
+        let mut signer = KeychainOpenfortSigner::from_config(solana_keychain::OpenfortSignerConfig {
+            secret_key,
+            account_id,
+            wallet_secret,
+            api_base_url: config.api_base_url.clone(),
+            http_client_config: None,
         })
+        .map_err(map_err)?;
+        signer.init().await.map_err(map_err)?;
+        Ok(Signer::Openfort(signer))
     }
 
     /// Validate an individual signer configuration

--- a/crates/lib/src/signer/mod.rs
+++ b/crates/lib/src/signer/mod.rs
@@ -7,8 +7,8 @@ pub mod signer;
 pub mod utils;
 
 pub use config::{
-    MemorySignerConfig, PrivySignerConfig, SelectionStrategy, SignerConfig, SignerPoolConfig,
-    SignerTypeConfig, TurnkeySignerConfig, VaultSignerConfig,
+    MemorySignerConfig, OpenfortSignerConfig, PrivySignerConfig, SelectionStrategy, SignerConfig,
+    SignerPoolConfig, SignerTypeConfig, TurnkeySignerConfig, VaultSignerConfig,
 };
 pub use keypair_util::KeypairUtil;
 pub use pool::{SignerInfo, SignerPool};

--- a/crates/lib/src/tests/config_mock.rs
+++ b/crates/lib/src/tests/config_mock.rs
@@ -10,8 +10,9 @@ use crate::{
     fee::price::PriceConfig,
     oracle::PriceSource,
     signer::config::{
-        MemorySignerConfig, PrivySignerConfig, SelectionStrategy, SignerConfig, SignerPoolConfig,
-        SignerPoolSettings, SignerTypeConfig, TurnkeySignerConfig, VaultSignerConfig,
+        MemorySignerConfig, OpenfortSignerConfig, PrivySignerConfig, SelectionStrategy,
+        SignerConfig, SignerPoolConfig, SignerPoolSettings, SignerTypeConfig, TurnkeySignerConfig,
+        VaultSignerConfig,
     },
     usage_limit::{UsageLimitConfig, UsageLimitRuleConfig},
 };
@@ -854,6 +855,25 @@ impl SignerPoolConfigBuilder {
             weight,
             config: SignerTypeConfig::Privy {
                 config: PrivySignerConfig { app_id_env, app_secret_env, wallet_id_env },
+            },
+        };
+        self.config.signers.push(signer);
+        self
+    }
+
+    pub fn with_openfort_signer(
+        mut self,
+        name: String,
+        secret_key_env: String,
+        account_id_env: String,
+        wallet_secret_env: String,
+        weight: Option<u32>,
+    ) -> Self {
+        let signer = SignerConfig {
+            name,
+            weight,
+            config: SignerTypeConfig::Openfort {
+                config: OpenfortSignerConfig { secret_key_env, account_id_env, wallet_secret_env },
             },
         };
         self.config.signers.push(signer);

--- a/crates/lib/src/tests/config_mock.rs
+++ b/crates/lib/src/tests/config_mock.rs
@@ -873,7 +873,12 @@ impl SignerPoolConfigBuilder {
             name,
             weight,
             config: SignerTypeConfig::Openfort {
-                config: OpenfortSignerConfig { secret_key_env, account_id_env, wallet_secret_env },
+                config: OpenfortSignerConfig {
+                    secret_key_env,
+                    account_id_env,
+                    wallet_secret_env,
+                    api_base_url: None,
+                },
             },
         };
         self.config.signers.push(signer);

--- a/sdks/ts/package.json
+++ b/sdks/ts/package.json
@@ -14,6 +14,7 @@
     "test:integration": "pnpm test integration.test.ts",
     "test:integration:auth": "ENABLE_AUTH=true pnpm test integration.test.ts",
     "test:integration:free": "FREE_PRICING=true pnpm test integration.test.ts",
+    "test:integration:openfort": "KORA_SIGNER_TYPE=openfort pnpm test integration.test.ts",
     "test:integration:privy": "KORA_SIGNER_TYPE=privy pnpm test integration.test.ts",
     "test:integration:turnkey": "KORA_SIGNER_TYPE=turnkey pnpm test integration.test.ts",
     "test:unit": "pnpm test unit.test.ts kit-client.test.ts plugin.test.ts",

--- a/sdks/ts/test/setup.ts
+++ b/sdks/ts/test/setup.ts
@@ -75,6 +75,12 @@ export function loadEnvironmentVariables() {
                     throw new Error('PRIVY_PUBLIC_KEY must be set when using Privy signer');
                 }
                 break;
+            case 'openfort':
+                koraAddress = process.env.OPENFORT_PUBLIC_KEY;
+                if (!koraAddress) {
+                    throw new Error('OPENFORT_PUBLIC_KEY must be set when using Openfort signer');
+                }
+                break;
             case 'memory':
             default:
                 koraAddress = DEFAULTS.KORA_ADDRESS;

--- a/signers.example.toml
+++ b/signers.example.toml
@@ -56,6 +56,8 @@ type = "openfort"
 secret_key_env = "OPENFORT_SECRET_KEY_1"
 account_id_env = "OPENFORT_ACCOUNT_ID_1"
 wallet_secret_env = "OPENFORT_WALLET_SECRET_1"
+# Optional: override the Openfort API base URL (defaults to https://api.openfort.io). Must be HTTPS.
+# api_base_url = "https://staging.openfort.io"
 weight = 1
 
 # Environment Variables Required:

--- a/signers.example.toml
+++ b/signers.example.toml
@@ -49,6 +49,15 @@ key_name_env = "VAULT_KEY_NAME_1"
 pubkey_env = "VAULT_PUBKEY_1"
 weight = 1
 
+# Openfort backend wallet signer example
+[[signers]]
+name = "openfort_signer_1"
+type = "openfort"
+secret_key_env = "OPENFORT_SECRET_KEY_1"
+account_id_env = "OPENFORT_ACCOUNT_ID_1"
+wallet_secret_env = "OPENFORT_WALLET_SECRET_1"
+weight = 1
+
 # Environment Variables Required:
 # 
 # Memory Signers:
@@ -72,6 +81,12 @@ weight = 1
 # export VAULT_TOKEN_1="your_vault_token"
 # export VAULT_KEY_NAME_1="your_vault_key_name"
 # export VAULT_PUBKEY_1="your_vault_public_key_base58"
+#
+# Openfort Signer:
+# export OPENFORT_SECRET_KEY_1="sk_test_or_sk_live_..."
+# export OPENFORT_ACCOUNT_ID_1="acc_<uuid>"
+# export OPENFORT_WALLET_SECRET_1="<base64-encoded PKCS#8 DER from the Openfort dashboard>"
+# (a full PEM string is also accepted, but the bare base64 body is easier to put in env vars)
 
 # Usage:
 # kora rpc start --signers-config signers.toml

--- a/signers.example.toml
+++ b/signers.example.toml
@@ -86,7 +86,6 @@ weight = 1
 # export OPENFORT_SECRET_KEY_1="sk_test_or_sk_live_..."
 # export OPENFORT_ACCOUNT_ID_1="acc_<uuid>"
 # export OPENFORT_WALLET_SECRET_1="<base64-encoded PKCS#8 DER from the Openfort dashboard>"
-# (a full PEM string is also accepted, but the bare base64 body is easier to put in env vars)
 
 # Usage:
 # kora rpc start --signers-config signers.toml

--- a/tests/src/common/fixtures/signers-openfort.toml
+++ b/tests/src/common/fixtures/signers-openfort.toml
@@ -1,0 +1,10 @@
+[signer_pool]
+strategy = "round_robin"
+
+[[signers]]
+name = "openfort_signer"
+type = "openfort"
+secret_key_env = "OPENFORT_SECRET_KEY"
+account_id_env = "OPENFORT_ACCOUNT_ID"
+wallet_secret_env = "OPENFORT_WALLET_SECRET"
+weight = 1

--- a/tests/src/test_runner/commands.rs
+++ b/tests/src/test_runner/commands.rs
@@ -87,6 +87,7 @@ impl TestCommandHelper {
             "typescript_free" => "test:integration:free",
             "typescript_turnkey" => "test:integration:turnkey",
             "typescript_privy" => "test:integration:privy",
+            "typescript_openfort" => "test:integration:openfort",
             _ => return Err(format!("Unknown TypeScript test: {test_name}").into()),
         };
 

--- a/tests/src/test_runner/output.rs
+++ b/tests/src/test_runner/output.rs
@@ -67,11 +67,11 @@ impl TestPhaseColor {
             Self::Payment => "\x1b[33m",     // Yellow
             Self::MultiSigner => "\x1b[35m", // Magenta
             Self::FeePayerPolicy => "\x1b[39m",
-            Self::TypeScriptBasic => "\x1b[36m",   // Cyan
-            Self::TypeScriptAuth => "\x1b[31m",    // Red
-            Self::TypeScriptTurnkey => "\x1b[37m",   // White
-            Self::TypeScriptPrivy => "\x1b[90m",     // Gray
-            Self::TypeScriptOpenfort => "\x1b[95m",  // Bright Magenta
+            Self::TypeScriptBasic => "\x1b[36m",    // Cyan
+            Self::TypeScriptAuth => "\x1b[31m",     // Red
+            Self::TypeScriptTurnkey => "\x1b[37m",  // White
+            Self::TypeScriptPrivy => "\x1b[90m",    // Gray
+            Self::TypeScriptOpenfort => "\x1b[95m", // Bright Magenta
         }
     }
 

--- a/tests/src/test_runner/output.rs
+++ b/tests/src/test_runner/output.rs
@@ -26,6 +26,7 @@ pub enum TestPhaseColor {
     TypeScriptAuth,
     TypeScriptTurnkey,
     TypeScriptPrivy,
+    TypeScriptOpenfort,
 }
 
 impl TestPhaseColor {
@@ -54,6 +55,7 @@ impl TestPhaseColor {
             "typescript_auth" => Self::TypeScriptAuth,
             "typescript_turnkey" => Self::TypeScriptTurnkey,
             "typescript_privy" => Self::TypeScriptPrivy,
+            "typescript_openfort" => Self::TypeScriptOpenfort,
             _ => Self::TypeScriptBasic,
         }
     }
@@ -67,8 +69,9 @@ impl TestPhaseColor {
             Self::FeePayerPolicy => "\x1b[39m",
             Self::TypeScriptBasic => "\x1b[36m",   // Cyan
             Self::TypeScriptAuth => "\x1b[31m",    // Red
-            Self::TypeScriptTurnkey => "\x1b[37m", // White
-            Self::TypeScriptPrivy => "\x1b[90m",   // Gray
+            Self::TypeScriptTurnkey => "\x1b[37m",   // White
+            Self::TypeScriptPrivy => "\x1b[90m",     // Gray
+            Self::TypeScriptOpenfort => "\x1b[95m",  // Bright Magenta
         }
     }
 


### PR DESCRIPTION
Wire up the Openfort backend wallet signer that landed in `solana-keychain` so Kora operators can use Openfort to sign transactions.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/solana-foundation/kora/pull/461" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
