### PR TITLE
ci: gate doppler fetch for fork PRs

### DIFF
--- a/.github/workflows/rust-unit.yml
+++ b/.github/workflows/rust-unit.yml
@@ -50,7 +50,9 @@ jobs:
       - name: Setup Solana CLI
         uses: ./.github/actions/setup-solana
 
-      - uses: dopplerhq/secrets-fetch-action@v2.0.0
+      - name: Fetch Doppler secrets
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: dopplerhq/secrets-fetch-action@v2.0.0
         with:
           auth-method: oidc
           doppler-identity-id: ${{ vars.DOPPLER_SERVICE_IDENTITY_ID }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -68,7 +68,9 @@ jobs:
       - name: Setup Solana CLI
         uses: ./.github/actions/setup-solana
 
-      - uses: dopplerhq/secrets-fetch-action@v2.0.0
+      - name: Fetch Doppler secrets
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: dopplerhq/secrets-fetch-action@v2.0.0
         with:
           auth-method: oidc
           doppler-identity-id: ${{ vars.DOPPLER_SERVICE_IDENTITY_ID }}


### PR DESCRIPTION
## Summary
- Gate Doppler secret fetching in Rust unit and integration workflows to pushes and same-repo PRs
- Keep non-secret Rust CI running for fork PRs instead of failing before tests start
- Leave secret-backed external live coverage in the existing manual fork workflow

## Test Plan
- git diff --check
- ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/workflows/rust.yml .github/workflows/rust-unit.yml
- cargo test --lib --workspace --exclude tests --quiet
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/solana-foundation/kora/pull/462" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


## 📊 Unit Test Coverage
![Coverage](https://img.shields.io/badge/coverage-85.8%25-green)

**Unit Test Coverage: 85.8%**

[View Detailed Coverage Report](https://github.com/solana-foundation/kora/actions/runs/25113279796)