### PR TITLE
feat(validator): cross-cluster mint validation

### DIFF
--- a/crates/lib/src/config.rs
+++ b/crates/lib/src/config.rs
@@ -115,6 +115,10 @@ impl SplTokenConfig {
             SplTokenConfig::Allowlist(v) => v.as_slice(),
         }
     }
+
+    pub fn iter(&self) -> std::slice::Iter<'_, String> {
+        self.into_iter()
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
@@ -146,6 +150,22 @@ pub struct ValidationConfig {
     /// Default: empty (no restriction).
     #[serde(default)]
     pub require_one_of_programs: Vec<String>,
+    /// When true, checks configured mint addresses against other known clusters
+    /// and warns if a mint is found on a different cluster than the one connected.
+    /// Disabled by default: the check contacts public RPC endpoints, which may be undesirable
+    /// for operators who want to keep their mint addresses private.
+    #[serde(default)]
+    pub cross_cluster_check: bool,
+    #[serde(default = "default_cross_cluster_endpoints")]
+    pub cross_cluster_endpoints: Vec<String>,
+}
+
+fn default_cross_cluster_endpoints() -> Vec<String> {
+    vec![
+        "https://api.mainnet-beta.solana.com".to_string(),
+        "https://api.devnet.solana.com".to_string(),
+        "https://api.testnet.solana.com".to_string(),
+    ]
 }
 
 impl ValidationConfig {

--- a/crates/lib/src/tests/config_mock.rs
+++ b/crates/lib/src/tests/config_mock.rs
@@ -97,6 +97,8 @@ impl ConfigMockBuilder {
                     allow_durable_transactions: false,
                     max_price_staleness_slots: 0,
                     require_one_of_programs: vec![],
+                    cross_cluster_check: false,
+                    cross_cluster_endpoints: vec![],
                 },
                 kora: KoraConfig {
                     rate_limit: 100,
@@ -309,6 +311,8 @@ impl ValidationConfigBuilder {
                 allow_durable_transactions: false,
                 max_price_staleness_slots: 0,
                 require_one_of_programs: vec![],
+                cross_cluster_check: false,
+                cross_cluster_endpoints: vec![],
             },
         }
     }

--- a/crates/lib/src/validator/config_validator.rs
+++ b/crates/lib/src/validator/config_validator.rs
@@ -32,6 +32,14 @@ use spl_token_interface::ID as SPL_TOKEN_PROGRAM_ID;
 
 const MIN_SIGN_TIMEOUT_SECONDS: u64 = 1;
 const HIGH_SIGN_MAX_RETRIES_WARNING_THRESHOLD: u32 = 10;
+const CROSS_CLUSTER_TIMEOUT_SECS: u64 = 5;
+
+enum ProbeOutcome {
+    Found(Vec<String>),
+    NotFound,
+    /// RPC error or timeout cannot conclude the mint is absent on this cluster.
+    Failed,
+}
 
 pub struct ConfigValidator {}
 
@@ -88,6 +96,129 @@ impl ConfigValidator {
                     token_str
                 ));
             }
+        }
+    }
+
+    pub async fn check_cross_cluster_mints(
+        rpc_client: &RpcClient,
+        tokens: &[String],
+        endpoints: &[String],
+        warnings: &mut Vec<String>,
+    ) {
+        let pubkeys: Vec<(String, Pubkey)> = tokens
+            .iter()
+            .filter_map(|t| Pubkey::from_str(t).ok().map(|pk| (t.clone(), pk)))
+            .collect();
+
+        if pubkeys.is_empty() {
+            return;
+        }
+
+        let pks: Vec<Pubkey> = pubkeys.iter().map(|(_, pk)| *pk).collect();
+        let accounts = match rpc_client.get_multiple_accounts(&pks).await {
+            Ok(a) => a,
+            Err(_) => {
+                warnings.push(
+                    "cross-cluster check skipped (could not reach connected cluster)".to_string(),
+                );
+                return;
+            }
+        };
+
+        let missing: Vec<String> = pubkeys
+            .iter()
+            .zip(accounts.iter())
+            .filter_map(|((addr, _), acct)| acct.is_none().then_some(addr.clone()))
+            .collect();
+
+        if missing.is_empty() {
+            return;
+        }
+
+        let probe_futures: Vec<_> = endpoints
+            .iter()
+            .map(|rpc_url| {
+                let missing = missing.clone();
+                let url = rpc_url.clone();
+                async move {
+                    let client = RpcClient::new(url.clone());
+                    let missing_pks: Vec<Pubkey> =
+                        missing.iter().filter_map(|addr| Pubkey::from_str(addr).ok()).collect();
+
+                    let result = tokio::time::timeout(
+                        std::time::Duration::from_secs(CROSS_CLUSTER_TIMEOUT_SECS),
+                        client.get_multiple_accounts(&missing_pks),
+                    )
+                    .await;
+
+                    match result {
+                        Ok(Ok(accounts)) => {
+                            let found: Vec<String> = missing
+                                .iter()
+                                .zip(accounts.iter())
+                                .filter_map(|(addr, acct)| acct.is_some().then_some(addr.clone()))
+                                .collect();
+                            if found.is_empty() {
+                                (url, ProbeOutcome::NotFound)
+                            } else {
+                                (url, ProbeOutcome::Found(found))
+                            }
+                        }
+                        Ok(Err(_)) => (url, ProbeOutcome::Failed),
+                        Err(_) => (url, ProbeOutcome::Failed),
+                    }
+                }
+            })
+            .collect();
+
+        let probe_results = futures::future::join_all(probe_futures).await;
+        Self::emit_cluster_warnings(&missing, &probe_results, warnings);
+    }
+
+    fn emit_cluster_warnings(
+        missing: &[String],
+        probe_results: &[(String, ProbeOutcome)],
+        warnings: &mut Vec<String>,
+    ) {
+        for mint_addr in missing {
+            let found_on: Vec<&str> = probe_results
+                .iter()
+                .filter_map(|(cluster_name, outcome)| match outcome {
+                    ProbeOutcome::Found(mints) if mints.contains(mint_addr) => {
+                        Some(cluster_name.as_str())
+                    }
+                    _ => None,
+                })
+                .collect();
+
+            let conclusive: Vec<&str> = probe_results
+                .iter()
+                .filter_map(|(name, outcome)| match outcome {
+                    ProbeOutcome::Found(_) | ProbeOutcome::NotFound => Some(name.as_str()),
+                    ProbeOutcome::Failed => None,
+                })
+                .collect();
+
+            let warning = if !found_on.is_empty() {
+                format!(
+                    "mint {} not found on the connected cluster\n  found on: {}\n  possible cluster mismatch",
+                    mint_addr,
+                    found_on.join(", ")
+                )
+            } else if conclusive.is_empty() {
+                format!(
+                    "mint {} not found on the connected cluster\n  cross-cluster check inconclusive (all probes failed or timed out)",
+                    mint_addr,
+                )
+            } else {
+                format!(
+                    "mint {} not found on the connected cluster or on: {}",
+                    mint_addr,
+                    conclusive.join(", ")
+                )
+            };
+
+            warnings.push(warning);
         }
     }
 
@@ -818,6 +949,25 @@ impl ConfigValidator {
             }
         }
 
+        if config.validation.cross_cluster_check {
+            let mut all_tokens: Vec<String> = config
+                .validation
+                .allowed_tokens
+                .iter()
+                .chain(config.validation.allowed_spl_paid_tokens.iter())
+                .cloned()
+                .collect();
+            all_tokens.sort_unstable();
+            all_tokens.dedup();
+            Self::check_cross_cluster_mints(
+                rpc_client,
+                &all_tokens,
+                &config.validation.cross_cluster_endpoints,
+                &mut warnings,
+            )
+            .await;
+        }
+
         // Validate signers configuration if provided
         if let Some(path) = signers_config_path {
             match SignerPoolConfig::load_config(path.as_ref()) {
@@ -960,6 +1110,8 @@ mod tests {
                 allow_durable_transactions: false,
                 max_price_staleness_slots: 0,
                 require_one_of_programs: vec![],
+                cross_cluster_check: false,
+                cross_cluster_endpoints: vec![],
             },
             kora: KoraConfig::default(),
             metrics: MetricsConfig::default(),
@@ -1005,6 +1157,8 @@ mod tests {
                 allow_durable_transactions: false,
                 max_price_staleness_slots: 0,
                 require_one_of_programs: vec![],
+                cross_cluster_check: false,
+                cross_cluster_endpoints: vec![],
             },
             kora: KoraConfig::default(),
             metrics: MetricsConfig::default(),
@@ -1052,6 +1206,8 @@ mod tests {
                 allow_durable_transactions: false,
                 max_price_staleness_slots: 0,
                 require_one_of_programs: vec![],
+                cross_cluster_check: false,
+                cross_cluster_endpoints: vec![],
             },
             kora: KoraConfig::default(),
             metrics: MetricsConfig::default(),
@@ -1099,6 +1255,8 @@ mod tests {
                 allow_durable_transactions: false,
                 max_price_staleness_slots: 0,
                 require_one_of_programs: vec![],
+                cross_cluster_check: false,
+                cross_cluster_endpoints: vec![],
             },
             kora: KoraConfig::default(),
             metrics: MetricsConfig::default(),
@@ -1135,6 +1293,8 @@ mod tests {
                 allow_durable_transactions: false,
                 max_price_staleness_slots: 0,
                 require_one_of_programs: vec![],
+                cross_cluster_check: false,
+                cross_cluster_endpoints: vec![],
             },
             kora: KoraConfig {
                 rate_limit: 0, // Should warn
@@ -1303,6 +1463,8 @@ mod tests {
                 allow_durable_transactions: false,
                 max_price_staleness_slots: 0,
                 require_one_of_programs: vec![],
+                cross_cluster_check: false,
+                cross_cluster_endpoints: vec![],
             },
             kora: KoraConfig::default(),
             metrics: MetricsConfig::default(),
@@ -1342,6 +1504,8 @@ mod tests {
                 allow_durable_transactions: false,
                 max_price_staleness_slots: 0,
                 require_one_of_programs: vec![],
+                cross_cluster_check: false,
+                cross_cluster_endpoints: vec![],
             },
             kora: KoraConfig::default(),
             metrics: MetricsConfig::default(),
@@ -1378,6 +1542,8 @@ mod tests {
                 allow_durable_transactions: false,
                 max_price_staleness_slots: 0,
                 require_one_of_programs: vec![],
+                cross_cluster_check: false,
+                cross_cluster_endpoints: vec![],
             },
             kora: KoraConfig::default(),
             metrics: MetricsConfig::default(),
@@ -1494,6 +1660,8 @@ mod tests {
                 allow_durable_transactions: false,
                 max_price_staleness_slots: 0,
                 require_one_of_programs: vec![],
+                cross_cluster_check: false,
+                cross_cluster_endpoints: vec![],
             },
             metrics: MetricsConfig::default(),
             kora: KoraConfig::default(),
@@ -1541,6 +1709,8 @@ mod tests {
                 allow_durable_transactions: false,
                 max_price_staleness_slots: 0,
                 require_one_of_programs: vec![],
+                cross_cluster_check: false,
+                cross_cluster_endpoints: vec![],
             },
             metrics: MetricsConfig::default(),
             kora: KoraConfig::default(),
@@ -1585,6 +1755,8 @@ mod tests {
                 allow_durable_transactions: false,
                 max_price_staleness_slots: 0,
                 require_one_of_programs: vec![],
+                cross_cluster_check: false,
+                cross_cluster_endpoints: vec![],
             },
             metrics: MetricsConfig::default(),
             kora: KoraConfig::default(),
@@ -1638,6 +1810,8 @@ mod tests {
                 allow_durable_transactions: false,
                 max_price_staleness_slots: 0,
                 require_one_of_programs: vec![],
+                cross_cluster_check: false,
+                cross_cluster_endpoints: vec![],
             },
             metrics: MetricsConfig::default(),
             kora: KoraConfig::default(),
@@ -1676,6 +1850,8 @@ mod tests {
                 allow_durable_transactions: false,
                 max_price_staleness_slots: 0,
                 require_one_of_programs: vec![],
+                cross_cluster_check: false,
+                cross_cluster_endpoints: vec![],
             },
             metrics: MetricsConfig::default(),
             kora: KoraConfig::default(),
@@ -1719,6 +1895,8 @@ mod tests {
                 allow_durable_transactions: false,
                 max_price_staleness_slots: 0,
                 require_one_of_programs: vec![],
+                cross_cluster_check: false,
+                cross_cluster_endpoints: vec![],
             },
             metrics: MetricsConfig::default(),
             kora: KoraConfig::default(),
@@ -1760,6 +1938,8 @@ mod tests {
                 allow_durable_transactions: false,
                 max_price_staleness_slots: 0,
                 require_one_of_programs: vec![],
+                cross_cluster_check: false,
+                cross_cluster_endpoints: vec![],
             },
             metrics: MetricsConfig::default(),
             kora: KoraConfig::default(),
@@ -1794,6 +1974,8 @@ mod tests {
                 allow_durable_transactions: false,
                 max_price_staleness_slots: 0,
                 require_one_of_programs: vec![],
+                cross_cluster_check: false,
+                cross_cluster_endpoints: vec![],
             },
             metrics: MetricsConfig::default(),
             kora: KoraConfig::default(),
@@ -1817,6 +1999,8 @@ mod tests {
                 allow_durable_transactions: false,
                 max_price_staleness_slots: 0,
                 require_one_of_programs: vec![],
+                cross_cluster_check: false,
+                cross_cluster_endpoints: vec![],
             },
             metrics: MetricsConfig::default(),
             kora: KoraConfig::default(),
@@ -1883,6 +2067,8 @@ mod tests {
                 allow_durable_transactions: false,
                 max_price_staleness_slots: 0,
                 require_one_of_programs: vec![],
+                cross_cluster_check: false,
+                cross_cluster_endpoints: vec![],
             },
             metrics: MetricsConfig::default(),
             kora: KoraConfig::default(),
@@ -1918,6 +2104,8 @@ mod tests {
                 allow_durable_transactions: false,
                 max_price_staleness_slots: 0,
                 require_one_of_programs: vec![],
+                cross_cluster_check: false,
+                cross_cluster_endpoints: vec![],
             },
             metrics: MetricsConfig::default(),
             kora: KoraConfig::default(),
@@ -1953,6 +2141,8 @@ mod tests {
                 allow_durable_transactions: false,
                 max_price_staleness_slots: 0,
                 require_one_of_programs: vec![],
+                cross_cluster_check: false,
+                cross_cluster_endpoints: vec![],
             },
             metrics: MetricsConfig::default(),
             kora: KoraConfig::default(),
@@ -1994,6 +2184,8 @@ mod tests {
                 allow_durable_transactions: false,
                 max_price_staleness_slots: 0,
                 require_one_of_programs: vec![],
+                cross_cluster_check: false,
+                cross_cluster_endpoints: vec![],
             },
             metrics: MetricsConfig::default(),
             kora: KoraConfig::default(),
@@ -2031,6 +2223,8 @@ mod tests {
                 allow_durable_transactions: false,
                 max_price_staleness_slots: 0,
                 require_one_of_programs: vec![],
+                cross_cluster_check: false,
+                cross_cluster_endpoints: vec![],
             },
             metrics: MetricsConfig::default(),
             kora: KoraConfig::default(),
@@ -2072,6 +2266,8 @@ mod tests {
                 allow_durable_transactions: false,
                 max_price_staleness_slots: 0,
                 require_one_of_programs: vec![],
+                cross_cluster_check: false,
+                cross_cluster_endpoints: vec![],
             },
             metrics: MetricsConfig::default(),
             kora: KoraConfig::default(),
@@ -2258,6 +2454,8 @@ mod tests {
                 allow_durable_transactions: false,
                 max_price_staleness_slots: 0,
                 require_one_of_programs: vec![],
+                cross_cluster_check: false,
+                cross_cluster_endpoints: vec![],
             },
             metrics: MetricsConfig::default(),
             kora: KoraConfig::default(),
@@ -2576,6 +2774,8 @@ mod tests {
                 allow_durable_transactions: true, // Enabled - should warn
                 max_price_staleness_slots: 0,
                 require_one_of_programs: vec![],
+                cross_cluster_check: false,
+                cross_cluster_endpoints: vec![],
             },
             kora: KoraConfig::default(),
             metrics: MetricsConfig::default(),
@@ -2616,6 +2816,8 @@ mod tests {
                 allow_durable_transactions: false, // Disabled - should not warn
                 max_price_staleness_slots: 0,
                 require_one_of_programs: vec![],
+                cross_cluster_check: false,
+                cross_cluster_endpoints: vec![],
             },
             kora: KoraConfig::default(),
             metrics: MetricsConfig::default(),
@@ -2657,6 +2859,8 @@ mod tests {
                 allow_durable_transactions: false,
                 max_price_staleness_slots: 0,
                 require_one_of_programs: vec![],
+                cross_cluster_check: false,
+                cross_cluster_endpoints: vec![],
             },
             kora: KoraConfig::default(),
             metrics: MetricsConfig::default(),
@@ -2697,6 +2901,8 @@ mod tests {
                 allow_durable_transactions: false,
                 max_price_staleness_slots: 0,
                 require_one_of_programs: vec![],
+                cross_cluster_check: false,
+                cross_cluster_endpoints: vec![],
             },
             kora: KoraConfig {
                 lighthouse: LighthouseConfig {
@@ -2745,6 +2951,8 @@ mod tests {
                 allow_durable_transactions: false,
                 max_price_staleness_slots: 0,
                 require_one_of_programs: vec![],
+                cross_cluster_check: false,
+                cross_cluster_endpoints: vec![],
             },
             kora: KoraConfig {
                 lighthouse: LighthouseConfig {
@@ -2793,6 +3001,8 @@ mod tests {
                 allow_durable_transactions: false,
                 max_price_staleness_slots: 0,
                 require_one_of_programs: vec![],
+                cross_cluster_check: false,
+                cross_cluster_endpoints: vec![],
             },
             kora: KoraConfig {
                 lighthouse: LighthouseConfig {
@@ -2911,5 +3121,67 @@ mod tests {
         assert_eq!(warnings.len(), 2);
         assert!(warnings.iter().any(|w| w.contains("Vote Program")));
         assert!(warnings.iter().any(|w| w.contains(&custom)));
+    }
+
+    #[test]
+    fn test_missing_mint_triggers_warning() {
+        let mint = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v".to_string();
+        let probe_results: Vec<(String, ProbeOutcome)> = vec![
+            ("devnet".into(), ProbeOutcome::NotFound),
+            ("testnet".into(), ProbeOutcome::Failed),
+        ];
+        let mut warnings = Vec::new();
+        ConfigValidator::emit_cluster_warnings(&[mint.clone()], &probe_results, &mut warnings);
+
+        assert_eq!(warnings.len(), 1);
+        assert!(
+            warnings[0].contains(&mint)
+                && warnings[0].contains("not found on the connected cluster or on:"),
+            "unexpected warning: {}",
+            warnings[0]
+        );
+    }
+
+    #[test]
+    fn test_all_probes_failed() {
+        let mint = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v".to_string();
+        let probe_results: Vec<(String, ProbeOutcome)> =
+            vec![("devnet".into(), ProbeOutcome::Failed), ("testnet".into(), ProbeOutcome::Failed)];
+        let mut warnings = Vec::new();
+        ConfigValidator::emit_cluster_warnings(&[mint.clone()], &probe_results, &mut warnings);
+
+        assert_eq!(warnings.len(), 1);
+        assert!(
+            warnings[0].contains(&mint) && warnings[0].contains("cross-cluster check inconclusive"),
+            "unexpected warning: {}",
+            warnings[0]
+        );
+    }
+
+    #[test]
+    fn test_existing_mint_no_warning() {
+        let probe_results: Vec<(String, ProbeOutcome)> = vec![];
+        let mut warnings = Vec::new();
+        ConfigValidator::emit_cluster_warnings(&[], &probe_results, &mut warnings);
+
+        assert!(warnings.is_empty());
+    }
+
+    #[test]
+    fn test_mint_found_on_other_cluster_warning() {
+        let mint = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v".to_string();
+        let probe_results: Vec<(String, ProbeOutcome)> = vec![
+            ("devnet".into(), ProbeOutcome::Found(vec![mint.clone()])),
+            ("testnet".into(), ProbeOutcome::NotFound),
+        ];
+        let mut warnings = Vec::new();
+        ConfigValidator::emit_cluster_warnings(&[mint.clone()], &probe_results, &mut warnings);
+
+        assert_eq!(warnings.len(), 1);
+        let w = &warnings[0];
+        assert!(w.contains(&mint), "mint address missing from warning");
+        assert!(w.contains("found on:"), "expected 'found on:' in warning");
+        assert!(w.contains("devnet"), "expected cluster name in warning");
+        assert!(w.contains("possible cluster mismatch"), "expected mismatch note");
     }
 }

--- a/kora.toml
+++ b/kora.toml
@@ -53,6 +53,12 @@ max_allowed_lamports = 1000000
 max_signatures = 10
 price_source = "Mock"
 allow_durable_transactions = false
+cross_cluster_check = false
+cross_cluster_endpoints = [
+    "https://api.mainnet-beta.solana.com",
+    "https://api.devnet.solana.com",
+    "https://api.testnet.solana.com",
+]
 
 allowed_programs = [
     "11111111111111111111111111111111",              # System Program


### PR DESCRIPTION
Warns the operator if a configured mint is not found on the connected cluster.

Probes configured endpoints concurrently (5s timeout). Possible outcomes:
- mint found on another cluster reports which one, flags possible cluster mismatch
- mint confirmed absent on all probed clusters lists checked clusters
- all probes failed or timed out warns that check was inconclusive
- connected cluster unreachable warns that check was skipped

Opt-in via `cross_cluster_check = true` in kora.toml disabled by default to avoid sending mint addresses to public RPC endpoints. Probe endpoints are configurable with public Solana clusters as defaults.