### PR TITLE
fix(transaction): support SyncNative in CPI inner instruction reconstruction

### DIFF
--- a/crates/lib/src/transaction/instruction_util.rs
+++ b/crates/lib/src/transaction/instruction_util.rs
@@ -498,6 +498,7 @@ pub const PARSED_DATA_FIELD_FREEZE_ACCOUNT: &str = "freezeAccount";
 pub const PARSED_DATA_FIELD_THAW_ACCOUNT: &str = "thawAccount";
 pub const PARSED_DATA_FIELD_GET_ACCOUNT_DATA_SIZE: &str = "getAccountDataSize";
 pub const PARSED_DATA_FIELD_INITIALIZE_IMMUTABLE_OWNER: &str = "initializeImmutableOwner";
+pub const PARSED_DATA_FIELD_SYNC_NATIVE: &str = "syncNative";
 pub const PARSED_DATA_FIELD_EXTENSION_TYPES: &str = "extensionTypes";
 
 // Additional field names for new instructions
@@ -1823,6 +1824,22 @@ impl IxUtils {
                 } else {
                     spl_token_2022_interface::instruction::TokenInstruction::InitializeImmutableOwner
                         .pack()
+                };
+
+                Ok(CompiledInstruction {
+                    program_id_index,
+                    accounts: vec![account_idx],
+                    data,
+                })
+            }
+            PARSED_DATA_FIELD_SYNC_NATIVE => {
+                let account = Self::get_field_as_pubkey(info, PARSED_DATA_FIELD_ACCOUNT)?;
+                let account_idx = Self::get_account_index(account_keys_hashmap, &account)?;
+
+                let data = if is_spl_token_program {
+                    spl_token_interface::instruction::TokenInstruction::SyncNative.pack()
+                } else {
+                    spl_token_2022_interface::instruction::TokenInstruction::SyncNative.pack()
                 };
 
                 Ok(CompiledInstruction {
@@ -3740,6 +3757,28 @@ mod tests {
         Ok(parsed)
     }
 
+    fn create_parsed_spl_token_sync_native(
+        account: &Pubkey,
+    ) -> Result<solana_transaction_status_client_types::ParsedInstruction, Box<dyn std::error::Error>>
+    {
+        let solana_instruction =
+            spl_token_interface::instruction::sync_native(&spl_token_interface::ID, account)?;
+
+        let message = Message::new(&[solana_instruction], None);
+        let compiled_instruction = &message.instructions[0];
+
+        let account_keys_for_parsing = AccountKeys::new(&message.account_keys, None);
+
+        let parsed = parse_instruction::parse(
+            &spl_token_interface::ID,
+            compiled_instruction,
+            &account_keys_for_parsing,
+            None,
+        )?;
+
+        Ok(parsed)
+    }
+
     fn create_parsed_spl_token_approve(
         source: &Pubkey,
         delegate: &Pubkey,
@@ -5453,6 +5492,31 @@ mod tests {
         let compiled = result.unwrap();
         assert_eq!(compiled.program_id_index, 0);
         assert_eq!(compiled.accounts, vec![1, 2, 3]); // account, destination, authority indices
+        assert_eq!(compiled.data, instruction.data);
+    }
+
+    #[test]
+    fn test_reconstruct_spl_token_sync_native_instruction() {
+        let account = Pubkey::new_unique();
+        let token_program_id = spl_token_interface::ID;
+        let account_keys = vec![token_program_id, account];
+
+        let instruction =
+            spl_token_interface::instruction::sync_native(&spl_token_interface::ID, &account)
+                .expect("Failed to create sync_native instruction");
+
+        let solana_parsed = create_parsed_spl_token_sync_native(&account)
+            .expect("Failed to create parsed instruction");
+
+        let result = IxUtils::reconstruct_spl_token_instruction(
+            &solana_parsed,
+            &IxUtils::build_account_keys_hashmap(&account_keys),
+        );
+
+        assert!(result.is_ok(), "syncNative CPI should reconstruct: {:?}", result.err());
+        let compiled = result.unwrap();
+        assert_eq!(compiled.program_id_index, 0);
+        assert_eq!(compiled.accounts, vec![1]);
         assert_eq!(compiled.data, instruction.data);
     }
 


### PR DESCRIPTION
## Summary

  When an outer program CPIs into `SPLToken.SyncNative` (or
  `Token-2022.SyncNative`), Kora's inner-instruction reconstruction has no
  match arm for the `"syncNative"` instruction type and rejects the
  transaction with:

  > `InvalidTransaction: Unrecognized SPL Token instruction type 'syncNative' in CPI — cannot validate fee payer policy`

  This blocks the standard wrap-SOL sequence
  (`createATA → System.transfer → SPLToken.syncNative`), which is required
  by **smart wallets / account-abstraction wallets** any time they touch
  SOL in DeFi. Smart wallets cannot pay SOL fees themselves and therefore
  always rely on a paymaster like Kora — so this issue is a hard blocker
  for the entire smart-wallet category, not a niche case.

  Closes #467.

  ## Why this is safe

  - `SyncNative` takes a single account (the WSOL token account being
    synced) and has **no authority/signer parameter**. There is nothing for
    fee-payer-policy to gate on — the fee payer cannot be drained or
    abused via this instruction.
  - After reconstruction, the existing `_ => {}` catch-all in
    `parse_token_instructions` already handles `TokenInstruction::SyncNative`
    as a no-op for fee-payer-policy validation, so no downstream changes
    are needed.
  - The change mirrors the existing handling pattern for
    `GetAccountDataSize` and `InitializeImmutableOwner` — other
    policy-neutral instructions already in the whitelist.

  ## Changes

  - Add `PARSED_DATA_FIELD_SYNC_NATIVE = "syncNative"` constant.
  - Add match arm in `reconstruct_spl_token_instruction` that builds a
    `CompiledInstruction` for both `spl_token_interface` and
    `spl_token_2022_interface`.
  - Add helper `create_parsed_spl_token_sync_native` and unit test
    `test_reconstruct_spl_token_sync_native_instruction` covering the
    previously-failing reconstruction path.

  Diff: **1 file, +64 lines**.

  ## Test plan

  - [x] `cargo fmt --check` clean
  - [x] `cargo clippy -p kora-lib --lib --tests -- -D warnings` clean
  - [x] New unit test passes
  - [x] All 53 `transaction::instruction_util` tests pass — no regression
  - [x] All 106 `transaction::*` tests pass — no regression
  - [x] Verified locally against a Kora node configured to mirror the
        production allowed-programs / fee-payer-policy of an active
        smart-wallet deployment — the previously-failing wrap-SOL flow
        now passes validation.