### PR TITLE
fix(validator): skip empty key vars

### DIFF
--- a/crates/lib/src/config.rs
+++ b/crates/lib/src/config.rs
@@ -696,6 +696,17 @@ impl Default for AuthConfig {
     }
 }
 
+impl AuthConfig {
+    pub(crate) fn normalize_optional_secret(value: Option<String>) -> Option<String> {
+        value.filter(|value| !value.is_empty())
+    }
+
+    pub(crate) fn has_auth(&self) -> bool {
+        self.api_key.as_deref().is_some_and(|key| !key.is_empty())
+            || self.hmac_secret.as_deref().is_some_and(|key| !key.is_empty())
+    }
+}
+
 impl Config {
     pub fn load_config<P: AsRef<Path>>(path: P) -> Result<Config, KoraError> {
         let contents = fs::read_to_string(path).map_err(|e| {

--- a/crates/lib/src/rpc_server/server.rs
+++ b/crates/lib/src/rpc_server/server.rs
@@ -1,4 +1,5 @@
 use crate::{
+    config::AuthConfig,
     constant::{X_API_KEY, X_HMAC_SIGNATURE, X_RECAPTCHA_TOKEN, X_TIMESTAMP},
     metrics::run_metrics_server_if_required,
     rpc_server::{
@@ -34,7 +35,8 @@ pub struct ServerHandles {
 
 // We'll always prioritize the environment variable over the config value
 fn get_value_by_priority(env_var: &str, config_value: Option<String>) -> Option<String> {
-    std::env::var(env_var).ok().or(config_value)
+    AuthConfig::normalize_optional_secret(std::env::var(env_var).ok())
+        .or_else(|| AuthConfig::normalize_optional_secret(config_value))
 }
 
 pub async fn run_rpc_server(rpc: KoraRpc, port: u16) -> Result<ServerHandles, anyhow::Error> {
@@ -280,6 +282,25 @@ mod tests {
         let env_var_name = "TEST_ENV_VAR_MISSING_UNIQUE_ABC789";
 
         let result = get_value_by_priority(env_var_name, None);
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn test_get_value_by_priority_empty_env_var_falls_back_to_config() {
+        let env_var_name = "TEST_ENV_VAR_EMPTY_ENV_UNIQUE_DEF456";
+        env::set_var(env_var_name, "");
+
+        let result = get_value_by_priority(env_var_name, Some("config_value".to_string()));
+        assert_eq!(result, Some("config_value".to_string()));
+
+        env::remove_var(env_var_name);
+    }
+
+    #[test]
+    fn test_get_value_by_priority_empty_config_value_is_ignored() {
+        let env_var_name = "TEST_ENV_VAR_EMPTY_CONFIG_UNIQUE_GHI789";
+
+        let result = get_value_by_priority(env_var_name, Some("".to_string()));
         assert_eq!(result, None);
     }
 

--- a/crates/lib/src/validator/config_validator.rs
+++ b/crates/lib/src/validator/config_validator.rs
@@ -692,8 +692,7 @@ impl ConfigValidator {
                 }
 
                 // Warn about dangerous configurations with fixed pricing
-                let has_auth =
-                    config.kora.auth.api_key.is_some() || config.kora.auth.hmac_secret.is_some();
+                let has_auth = config.kora.auth.has_auth();
                 if !has_auth {
                     warnings.push(
                         "⚠️  SECURITY: Fixed pricing with NO authentication enabled. \
@@ -723,7 +722,7 @@ impl ConfigValidator {
         };
 
         // General authentication warning
-        let has_auth = config.kora.auth.api_key.is_some() || config.kora.auth.hmac_secret.is_some();
+        let has_auth = config.kora.auth.has_auth();
         if !has_auth {
             warnings.push(
                 "⚠️  SECURITY: No authentication configured (neither api_key nor hmac_secret). \


### PR DESCRIPTION
The changes in this PR would cause empty keys to be treated as not present, and would follow the path of issuing warnings when those keys are absent.