### PR TITLE
Caching for exchange rates

### DIFF
--- a/crates/lib/src/cache.rs
+++ b/crates/lib/src/cache.rs
@@ -10,7 +10,7 @@ use tokio::sync::{Mutex, OnceCell};
 use crate::{
     config::Config,
     error::KoraError,
-    oracle::{get_price_oracle, RetryingPriceOracle, TokenPrice},
+    oracle::{get_price_oracle, PriceSource, RetryingPriceOracle, TokenPrice},
     sanitize_error,
 };
 
@@ -37,7 +37,7 @@ static CACHE_POOL: OnceCell<Option<Pool>> = OnceCell::const_new();
 /// Process-wide price oracle. Held as an `Arc` so the inner `reqwest::Client`
 /// (and its connection pool) is reused across all cache misses instead of
 /// being rebuilt per request.
-static PRICE_ORACLE: OnceCell<Arc<RetryingPriceOracle>> = OnceCell::const_new();
+static PRICE_ORACLE: OnceCell<(PriceSource, Arc<RetryingPriceOracle>)> = OnceCell::const_new();
 
 /// Per-mint locks used to coalesce concurrent oracle fetches for the same
 /// price key (singleflight). Without this, a TTL expiry under load triggers
@@ -379,16 +379,29 @@ impl CacheUtil {
     async fn get_price_oracle_singleton(
         config: &Config,
     ) -> Result<Arc<RetryingPriceOracle>, KoraError> {
-        let oracle = PRICE_ORACLE
+        let requested = &config.validation.price_source;
+        let (initialized, oracle) = PRICE_ORACLE
             .get_or_try_init(|| async {
-                let inner = get_price_oracle(config.validation.price_source.clone())?;
-                Ok::<_, KoraError>(Arc::new(RetryingPriceOracle::new(
-                    PRICE_ORACLE_MAX_RETRIES,
-                    PRICE_ORACLE_BASE_DELAY,
-                    inner,
-                )))
+                let source = config.validation.price_source.clone();
+                let inner = get_price_oracle(source.clone())?;
+                Ok::<_, KoraError>((
+                    source,
+                    Arc::new(RetryingPriceOracle::new(
+                        PRICE_ORACLE_MAX_RETRIES,
+                        PRICE_ORACLE_BASE_DELAY,
+                        inner,
+                    )),
+                ))
             })
             .await?;
+        if initialized != requested {
+            log::warn!(
+                "Price oracle already initialized with {:?}; ignoring request for {:?}. \
+                 The price_source is fixed for the lifetime of the process.",
+                initialized,
+                requested
+            );
+        }
         Ok(oracle.clone())
     }
 

--- a/crates/lib/src/cache.rs
+++ b/crates/lib/src/cache.rs
@@ -440,9 +440,17 @@ impl CacheUtil {
     async fn set_prices_in_cache(
         pool: &Pool,
         prices: &HashMap<String, TokenPrice>,
+    async fn set_prices_in_cache(
+        pool: &Pool,
+        prices: &HashMap<String, TokenPrice>,
         ttl: u64,
     ) -> Result<(), KoraError> {
+        if prices.is_empty() {
+            return Ok(());
+        }
+
         let mut conn = Self::get_connection(pool).await?;
+        let mut pipe = redis::pipe();
 
         for (mint, price) in prices {
             let serialized = serde_json::to_string(price).map_err(|e| {
@@ -452,21 +460,15 @@ impl CacheUtil {
                 ))
             })?;
             let key = Self::get_price_key(mint);
-            if let Err(e) = conn.set_ex::<_, _, ()>(&key, serialized, ttl).await.map_err(|e| {
-                KoraError::InternalServerError(format!(
-                    "Failed to set price in cache: {}",
-                    sanitize_error!(e)
-                ))
-            }) {
-                log::warn!("Failed to cache price for {mint}: {e}");
-            }
+            pipe.set_ex(&key, serialized, ttl);
+        }
+
+        if let Err(e) = pipe.query_async::<()>(&mut conn).await {
+            log::warn!("Failed to cache prices in batch: {}", sanitize_error!(e));
         }
 
         Ok(())
     }
-
-    /// Get token prices for the given mints, using Redis cache when available.
-    ///
     /// On cache miss, fetches only the missing mints from the configured price
     /// oracle (Jupiter or Mock) and writes the results back with `price_ttl`.
     /// Falls back to a direct oracle call when caching is disabled or unreachable.

--- a/crates/lib/src/cache.rs
+++ b/crates/lib/src/cache.rs
@@ -453,9 +453,6 @@ impl CacheUtil {
     async fn set_prices_in_cache(
         pool: &Pool,
         prices: &HashMap<String, TokenPrice>,
-    async fn set_prices_in_cache(
-        pool: &Pool,
-        prices: &HashMap<String, TokenPrice>,
         ttl: u64,
     ) -> Result<(), KoraError> {
         if prices.is_empty() {
@@ -466,12 +463,16 @@ impl CacheUtil {
         let mut pipe = redis::pipe();
 
         for (mint, price) in prices {
-            let serialized = serde_json::to_string(price).map_err(|e| {
-                KoraError::InternalServerError(format!(
-                    "Failed to serialize price for {mint}: {}",
-                    sanitize_error!(e)
-                ))
-            })?;
+            let serialized = match serde_json::to_string(price) {
+                Ok(s) => s,
+                Err(e) => {
+                    log::warn!(
+                        "Failed to serialize price for {mint}: {}",
+                        sanitize_error!(e)
+                    );
+                    continue;
+                }
+            };
             let key = Self::get_price_key(mint);
             pipe.set_ex(&key, serialized, ttl);
         }
@@ -482,6 +483,9 @@ impl CacheUtil {
 
         Ok(())
     }
+
+    /// Get token prices for the given mints, using Redis cache when available.
+    ///
     /// On cache miss, fetches only the missing mints from the configured price
     /// oracle (Jupiter or Mock) and writes the results back with `price_ttl`.
     /// Falls back to a direct oracle call when caching is disabled or unreachable.

--- a/crates/lib/src/cache.rs
+++ b/crates/lib/src/cache.rs
@@ -4,10 +4,15 @@ use serde::{Deserialize, Serialize};
 use solana_client::nonblocking::rpc_client::RpcClient;
 use solana_commitment_config::CommitmentConfig;
 use solana_sdk::{account::Account, hash::Hash, pubkey::Pubkey};
-use std::str::FromStr;
+use std::{collections::HashMap, str::FromStr, time::Duration};
 use tokio::sync::OnceCell;
 
-use crate::{config::Config, error::KoraError, sanitize_error};
+use crate::{
+    config::Config,
+    error::KoraError,
+    oracle::{get_price_oracle, RetryingPriceOracle, TokenPrice},
+    sanitize_error,
+};
 
 #[cfg(not(test))]
 use crate::state::get_config;
@@ -17,9 +22,14 @@ use crate::tests::config_mock::mock_state::get_config;
 
 const ACCOUNT_CACHE_KEY: &str = "account";
 const BLOCKHASH_CACHE_KEY: &str = "kora:blockhash";
+const PRICE_CACHE_KEY_PREFIX: &str = "kora:price";
 /// TTL for cached blockhash in seconds. Blockhashes are valid for ~60s,
 /// but we use a short TTL to keep the hash fresh.
 const BLOCKHASH_TTL: u64 = 5;
+/// Number of retries for the underlying price oracle on cache misses.
+const PRICE_ORACLE_MAX_RETRIES: u32 = 3;
+/// Base delay for the price oracle retry loop.
+const PRICE_ORACLE_BASE_DELAY: Duration = Duration::from_secs(1);
 
 /// Global cache pool instance
 static CACHE_POOL: OnceCell<Option<Pool>> = OnceCell::const_new();
@@ -343,6 +353,146 @@ impl CacheUtil {
 
         Ok(())
     }
+
+    fn get_price_key(mint_address: &str) -> String {
+        format!("{PRICE_CACHE_KEY_PREFIX}:{mint_address}")
+    }
+
+    /// Build a `RetryingPriceOracle` for the configured price source.
+    fn build_price_oracle(config: &Config) -> Result<RetryingPriceOracle, KoraError> {
+        Ok(RetryingPriceOracle::new(
+            PRICE_ORACLE_MAX_RETRIES,
+            PRICE_ORACLE_BASE_DELAY,
+            get_price_oracle(config.validation.price_source.clone())?,
+        ))
+    }
+
+    /// Read cached prices for the given mints from Redis. Mints with no entry
+    /// (or whose entry fails to deserialize) are returned in `misses`.
+    async fn get_prices_from_cache(
+        pool: &Pool,
+        mint_addresses: &[String],
+    ) -> Result<(HashMap<String, TokenPrice>, Vec<String>), KoraError> {
+        let mut conn = Self::get_connection(pool).await?;
+
+        let keys: Vec<String> = mint_addresses.iter().map(|m| Self::get_price_key(m)).collect();
+
+        // MGET returns Vec<Option<String>> aligned with the input keys.
+        let raw: Vec<Option<String>> = conn.mget(&keys).await.map_err(|e| {
+            KoraError::InternalServerError(format!(
+                "Failed to get prices from cache: {}",
+                sanitize_error!(e)
+            ))
+        })?;
+
+        let mut hits = HashMap::new();
+        let mut misses = Vec::new();
+
+        for (mint, value) in mint_addresses.iter().zip(raw) {
+            match value.as_deref().map(serde_json::from_str::<TokenPrice>) {
+                Some(Ok(price)) => {
+                    hits.insert(mint.clone(), price);
+                }
+                Some(Err(e)) => {
+                    log::warn!("Failed to deserialize cached price for {mint}: {e}");
+                    misses.push(mint.clone());
+                }
+                None => misses.push(mint.clone()),
+            }
+        }
+
+        Ok((hits, misses))
+    }
+
+    /// Write fetched prices back to Redis with `price_ttl`.
+    async fn set_prices_in_cache(
+        pool: &Pool,
+        prices: &HashMap<String, TokenPrice>,
+        ttl: u64,
+    ) -> Result<(), KoraError> {
+        let mut conn = Self::get_connection(pool).await?;
+
+        for (mint, price) in prices {
+            let serialized = serde_json::to_string(price).map_err(|e| {
+                KoraError::InternalServerError(format!(
+                    "Failed to serialize price for {mint}: {}",
+                    sanitize_error!(e)
+                ))
+            })?;
+            let key = Self::get_price_key(mint);
+            if let Err(e) = conn.set_ex::<_, _, ()>(&key, serialized, ttl).await.map_err(|e| {
+                KoraError::InternalServerError(format!(
+                    "Failed to set price in cache: {}",
+                    sanitize_error!(e)
+                ))
+            }) {
+                log::warn!("Failed to cache price for {mint}: {e}");
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Get token prices for the given mints, using Redis cache when available.
+    ///
+    /// On cache miss, fetches only the missing mints from the configured price
+    /// oracle (Jupiter or Mock) and writes the results back with `price_ttl`.
+    /// Falls back to a direct oracle call when caching is disabled or unreachable.
+    pub async fn get_or_fetch_token_prices(
+        config: &Config,
+        mint_addresses: &[String],
+    ) -> Result<HashMap<String, TokenPrice>, KoraError> {
+        if mint_addresses.is_empty() {
+            return Ok(HashMap::new());
+        }
+
+        // If cache is disabled or pool not initialized, go straight to the oracle.
+        if !Self::is_cache_enabled(config) {
+            return Self::build_price_oracle(config)?.get_token_prices(mint_addresses).await;
+        }
+
+        let pool = match CACHE_POOL.get() {
+            Some(Some(pool)) => pool,
+            _ => return Self::build_price_oracle(config)?.get_token_prices(mint_addresses).await,
+        };
+
+        // Try cache first; on errors, fall through to a full live fetch.
+        let (mut hits, misses) = match Self::get_prices_from_cache(pool, mint_addresses).await {
+            Ok(result) => result,
+            Err(e) => {
+                log::warn!("Failed to read prices from cache, falling back to oracle: {e}");
+                return Self::build_price_oracle(config)?.get_token_prices(mint_addresses).await;
+            }
+        };
+
+        if misses.is_empty() {
+            return Ok(hits);
+        }
+
+        let fetched = Self::build_price_oracle(config)?.get_token_prices(&misses).await?;
+
+        if let Err(e) = Self::set_prices_in_cache(pool, &fetched, config.kora.cache.price_ttl).await
+        {
+            log::warn!("Failed to cache fetched prices: {e}");
+        }
+
+        hits.extend(fetched);
+        Ok(hits)
+    }
+
+    /// Get a single token price, using Redis cache when available.
+    pub async fn get_or_fetch_token_price(
+        config: &Config,
+        mint_address: &str,
+    ) -> Result<TokenPrice, KoraError> {
+        let prices = Self::get_or_fetch_token_prices(config, &[mint_address.to_string()]).await?;
+
+        prices.get(mint_address).cloned().ok_or_else(|| {
+            KoraError::InternalServerError(format!(
+                "Failed to fetch token price for {mint_address}"
+            ))
+        })
+    }
 }
 
 #[cfg(test)]
@@ -390,6 +540,36 @@ mod tests {
         let pubkey = Pubkey::new_unique();
         let key = CacheUtil::get_account_key(&pubkey);
         assert_eq!(key, format!("account:{pubkey}"));
+    }
+
+    #[tokio::test]
+    async fn test_get_price_key_format() {
+        let mint = Pubkey::new_unique().to_string();
+        let key = CacheUtil::get_price_key(&mint);
+        assert_eq!(key, format!("kora:price:{mint}"));
+    }
+
+    #[tokio::test]
+    async fn test_get_or_fetch_token_prices_empty_returns_empty() {
+        let _m = ConfigMockBuilder::new().with_cache_enabled(false).build_and_setup();
+        let config = get_config().unwrap();
+
+        let prices = CacheUtil::get_or_fetch_token_prices(&config, &[]).await.unwrap();
+        assert!(prices.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_get_or_fetch_token_prices_cache_disabled_falls_back_to_oracle() {
+        let _m = ConfigMockBuilder::new().with_cache_enabled(false).build_and_setup();
+        let config = get_config().unwrap();
+
+        let mint = Pubkey::new_unique().to_string();
+        let prices = CacheUtil::get_or_fetch_token_prices(&config, std::slice::from_ref(&mint))
+            .await
+            .unwrap();
+
+        // Mock oracle (default in ConfigMockBuilder) always returns a price for any mint.
+        assert!(prices.contains_key(&mint));
     }
 
     #[tokio::test]

--- a/crates/lib/src/cache.rs
+++ b/crates/lib/src/cache.rs
@@ -46,8 +46,7 @@ static PRICE_ORACLE: OnceCell<Arc<RetryingPriceOracle>> = OnceCell::const_new();
 /// The map grows by one entry per distinct mint ever queried. In practice the
 /// set is bounded by `allowed_tokens` / `allowed_spl_paid_tokens`, so we
 /// don't bother evicting entries.
-static PRICE_FETCH_LOCKS: OnceCell<Mutex<HashMap<String, Arc<Mutex<()>>>>> =
-    OnceCell::const_new();
+static PRICE_FETCH_LOCKS: OnceCell<Mutex<HashMap<String, Arc<Mutex<()>>>>> = OnceCell::const_new();
 
 /// Cached account data with metadata
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -395,9 +394,7 @@ impl CacheUtil {
 
     /// Get (or insert) the lock that serializes oracle fetches for `mint`.
     async fn get_price_fetch_lock(mint: &str) -> Arc<Mutex<()>> {
-        let map_cell = PRICE_FETCH_LOCKS
-            .get_or_init(|| async { Mutex::new(HashMap::new()) })
-            .await;
+        let map_cell = PRICE_FETCH_LOCKS.get_or_init(|| async { Mutex::new(HashMap::new()) }).await;
         let mut map = map_cell.lock().await;
         map.entry(mint.to_string()).or_insert_with(|| Arc::new(Mutex::new(()))).clone()
     }
@@ -547,16 +544,14 @@ impl CacheUtil {
 
         // Re-read the cache while holding the locks: prior leaders may have
         // populated some keys while we waited.
-        let (mut hits, still_missing) = match Self::get_prices_from_cache(pool, &sorted_misses).await
-        {
-            Ok(result) => result,
-            Err(e) => {
-                log::warn!(
-                    "Failed to re-read prices from cache after lock acquisition: {e}"
-                );
-                (HashMap::new(), sorted_misses)
-            }
-        };
+        let (mut hits, still_missing) =
+            match Self::get_prices_from_cache(pool, &sorted_misses).await {
+                Ok(result) => result,
+                Err(e) => {
+                    log::warn!("Failed to re-read prices from cache after lock acquisition: {e}");
+                    (HashMap::new(), sorted_misses)
+                }
+            };
 
         if !still_missing.is_empty() {
             let oracle = Self::get_price_oracle_singleton(config).await?;

--- a/crates/lib/src/cache.rs
+++ b/crates/lib/src/cache.rs
@@ -4,8 +4,8 @@ use serde::{Deserialize, Serialize};
 use solana_client::nonblocking::rpc_client::RpcClient;
 use solana_commitment_config::CommitmentConfig;
 use solana_sdk::{account::Account, hash::Hash, pubkey::Pubkey};
-use std::{collections::HashMap, str::FromStr, time::Duration};
-use tokio::sync::OnceCell;
+use std::{collections::HashMap, str::FromStr, sync::Arc, time::Duration};
+use tokio::sync::{Mutex, OnceCell};
 
 use crate::{
     config::Config,
@@ -33,6 +33,21 @@ const PRICE_ORACLE_BASE_DELAY: Duration = Duration::from_secs(1);
 
 /// Global cache pool instance
 static CACHE_POOL: OnceCell<Option<Pool>> = OnceCell::const_new();
+
+/// Process-wide price oracle. Held as an `Arc` so the inner `reqwest::Client`
+/// (and its connection pool) is reused across all cache misses instead of
+/// being rebuilt per request.
+static PRICE_ORACLE: OnceCell<Arc<RetryingPriceOracle>> = OnceCell::const_new();
+
+/// Per-mint locks used to coalesce concurrent oracle fetches for the same
+/// price key (singleflight). Without this, a TTL expiry under load triggers
+/// N parallel Jupiter requests for the same mint instead of one.
+///
+/// The map grows by one entry per distinct mint ever queried. In practice the
+/// set is bounded by `allowed_tokens` / `allowed_spl_paid_tokens`, so we
+/// don't bother evicting entries.
+static PRICE_FETCH_LOCKS: OnceCell<Mutex<HashMap<String, Arc<Mutex<()>>>>> =
+    OnceCell::const_new();
 
 /// Cached account data with metadata
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -358,13 +373,33 @@ impl CacheUtil {
         format!("{PRICE_CACHE_KEY_PREFIX}:{mint_address}")
     }
 
-    /// Build a `RetryingPriceOracle` for the configured price source.
-    fn build_price_oracle(config: &Config) -> Result<RetryingPriceOracle, KoraError> {
-        Ok(RetryingPriceOracle::new(
-            PRICE_ORACLE_MAX_RETRIES,
-            PRICE_ORACLE_BASE_DELAY,
-            get_price_oracle(config.validation.price_source.clone())?,
-        ))
+    /// Return the process-wide `RetryingPriceOracle`, building it on first use.
+    ///
+    /// Initialization is fallible (Jupiter requires `JUPITER_API_KEY`); on
+    /// failure the cell is left empty so a later call can retry.
+    async fn get_price_oracle_singleton(
+        config: &Config,
+    ) -> Result<Arc<RetryingPriceOracle>, KoraError> {
+        let oracle = PRICE_ORACLE
+            .get_or_try_init(|| async {
+                let inner = get_price_oracle(config.validation.price_source.clone())?;
+                Ok::<_, KoraError>(Arc::new(RetryingPriceOracle::new(
+                    PRICE_ORACLE_MAX_RETRIES,
+                    PRICE_ORACLE_BASE_DELAY,
+                    inner,
+                )))
+            })
+            .await?;
+        Ok(oracle.clone())
+    }
+
+    /// Get (or insert) the lock that serializes oracle fetches for `mint`.
+    async fn get_price_fetch_lock(mint: &str) -> Arc<Mutex<()>> {
+        let map_cell = PRICE_FETCH_LOCKS
+            .get_or_init(|| async { Mutex::new(HashMap::new()) })
+            .await;
+        let mut map = map_cell.lock().await;
+        map.entry(mint.to_string()).or_insert_with(|| Arc::new(Mutex::new(()))).clone()
     }
 
     /// Read cached prices for the given mints from Redis. Mints with no entry
@@ -451,12 +486,20 @@ impl CacheUtil {
         // If cache is disabled globally, pool not initialized, or price caching
         // is opted out via `price_ttl = 0`, go straight to the oracle.
         if !Self::is_cache_enabled(config) || config.kora.cache.price_ttl == 0 {
-            return Self::build_price_oracle(config)?.get_token_prices(mint_addresses).await;
+            return Self::get_price_oracle_singleton(config)
+                .await?
+                .get_token_prices(mint_addresses)
+                .await;
         }
 
         let pool = match CACHE_POOL.get() {
             Some(Some(pool)) => pool,
-            _ => return Self::build_price_oracle(config)?.get_token_prices(mint_addresses).await,
+            _ => {
+                return Self::get_price_oracle_singleton(config)
+                    .await?
+                    .get_token_prices(mint_addresses)
+                    .await;
+            }
         };
 
         // Try cache first; on errors, fall through to a full live fetch.
@@ -464,7 +507,10 @@ impl CacheUtil {
             Ok(result) => result,
             Err(e) => {
                 log::warn!("Failed to read prices from cache, falling back to oracle: {e}");
-                return Self::build_price_oracle(config)?.get_token_prices(mint_addresses).await;
+                return Self::get_price_oracle_singleton(config)
+                    .await?
+                    .get_token_prices(mint_addresses)
+                    .await;
             }
         };
 
@@ -472,14 +518,58 @@ impl CacheUtil {
             return Ok(hits);
         }
 
-        let fetched = Self::build_price_oracle(config)?.get_token_prices(&misses).await?;
+        let fetched = Self::fetch_misses_with_singleflight(config, pool, misses).await?;
+        hits.extend(fetched);
+        Ok(hits)
+    }
 
-        if let Err(e) = Self::set_prices_in_cache(pool, &fetched, config.kora.cache.price_ttl).await
-        {
-            log::warn!("Failed to cache fetched prices: {e}");
+    /// Fetch the given mints from the oracle while coalescing concurrent
+    /// requests for the same key.
+    ///
+    /// Per-mint locks are acquired in sorted order so concurrent batch
+    /// requests with overlapping mint sets queue deterministically rather
+    /// than deadlocking. After the locks are held, the cache is re-read so
+    /// requests that lost the race read whatever the leader just wrote.
+    async fn fetch_misses_with_singleflight(
+        config: &Config,
+        pool: &Pool,
+        misses: Vec<String>,
+    ) -> Result<HashMap<String, TokenPrice>, KoraError> {
+        let mut sorted_misses = misses;
+        sorted_misses.sort();
+        sorted_misses.dedup();
+
+        let mut guards = Vec::with_capacity(sorted_misses.len());
+        for mint in &sorted_misses {
+            let lock = Self::get_price_fetch_lock(mint).await;
+            guards.push(lock.lock_owned().await);
         }
 
-        hits.extend(fetched);
+        // Re-read the cache while holding the locks: prior leaders may have
+        // populated some keys while we waited.
+        let (mut hits, still_missing) = match Self::get_prices_from_cache(pool, &sorted_misses).await
+        {
+            Ok(result) => result,
+            Err(e) => {
+                log::warn!(
+                    "Failed to re-read prices from cache after lock acquisition: {e}"
+                );
+                (HashMap::new(), sorted_misses)
+            }
+        };
+
+        if !still_missing.is_empty() {
+            let oracle = Self::get_price_oracle_singleton(config).await?;
+            let fetched = oracle.get_token_prices(&still_missing).await?;
+            if let Err(e) =
+                Self::set_prices_in_cache(pool, &fetched, config.kora.cache.price_ttl).await
+            {
+                log::warn!("Failed to cache fetched prices: {e}");
+            }
+            hits.extend(fetched);
+        }
+
+        drop(guards);
         Ok(hits)
     }
 

--- a/crates/lib/src/cache.rs
+++ b/crates/lib/src/cache.rs
@@ -438,6 +438,8 @@ impl CacheUtil {
     /// On cache miss, fetches only the missing mints from the configured price
     /// oracle (Jupiter or Mock) and writes the results back with `price_ttl`.
     /// Falls back to a direct oracle call when caching is disabled or unreachable.
+    /// Setting `price_ttl = 0` disables price caching independently of the
+    /// global cache switch (so account caching can stay on).
     pub async fn get_or_fetch_token_prices(
         config: &Config,
         mint_addresses: &[String],
@@ -446,8 +448,9 @@ impl CacheUtil {
             return Ok(HashMap::new());
         }
 
-        // If cache is disabled or pool not initialized, go straight to the oracle.
-        if !Self::is_cache_enabled(config) {
+        // If cache is disabled globally, pool not initialized, or price caching
+        // is opted out via `price_ttl = 0`, go straight to the oracle.
+        if !Self::is_cache_enabled(config) || config.kora.cache.price_ttl == 0 {
             return Self::build_price_oracle(config)?.get_token_prices(mint_addresses).await;
         }
 
@@ -569,6 +572,27 @@ mod tests {
             .unwrap();
 
         // Mock oracle (default in ConfigMockBuilder) always returns a price for any mint.
+        assert!(prices.contains_key(&mint));
+    }
+
+    #[tokio::test]
+    async fn test_get_or_fetch_token_prices_zero_ttl_bypasses_cache() {
+        // Cache enabled globally (so account caching would still run), but
+        // price_ttl = 0 should opt price lookups out of Redis entirely.
+        let _m = ConfigMockBuilder::new()
+            .with_cache_enabled(true)
+            .with_cache_url(Some("redis://localhost:6379".to_string()))
+            .build_and_setup();
+
+        let mut config = get_config().unwrap();
+        config.kora.cache.price_ttl = 0;
+
+        let mint = Pubkey::new_unique().to_string();
+        // No real Redis is needed: the zero-ttl branch must short-circuit before any pool access.
+        let prices = CacheUtil::get_or_fetch_token_prices(&config, std::slice::from_ref(&mint))
+            .await
+            .unwrap();
+
         assert!(prices.contains_key(&mint));
     }
 

--- a/crates/lib/src/cache.rs
+++ b/crates/lib/src/cache.rs
@@ -368,8 +368,12 @@ impl CacheUtil {
         Ok(())
     }
 
-    fn get_price_key(mint_address: &str) -> String {
-        format!("{PRICE_CACHE_KEY_PREFIX}:{mint_address}")
+    /// Cache key for a token price. Includes the `PriceSource` so entries
+    /// written by one oracle (e.g. Mock) are not served when the node is
+    /// reconfigured to a different source (e.g. Jupiter) against the same
+    /// Redis instance.
+    fn get_price_key(mint_address: &str, source: &PriceSource) -> String {
+        format!("{PRICE_CACHE_KEY_PREFIX}:{}:{mint_address}", source.as_cache_key())
     }
 
     /// Return the process-wide `RetryingPriceOracle`, building it on first use.
@@ -414,13 +418,21 @@ impl CacheUtil {
 
     /// Read cached prices for the given mints from Redis. Mints with no entry
     /// (or whose entry fails to deserialize) are returned in `misses`.
+    ///
+    /// When `min_fresh_block_id` is `Some`, any cached price with a `block_id`
+    /// at or below that slot is treated as a miss so the caller refetches a
+    /// fresh price instead of letting downstream staleness validation reject
+    /// the request.
     async fn get_prices_from_cache(
         pool: &Pool,
+        source: &PriceSource,
         mint_addresses: &[String],
+        min_fresh_block_id: Option<u64>,
     ) -> Result<(HashMap<String, TokenPrice>, Vec<String>), KoraError> {
         let mut conn = Self::get_connection(pool).await?;
 
-        let keys: Vec<String> = mint_addresses.iter().map(|m| Self::get_price_key(m)).collect();
+        let keys: Vec<String> =
+            mint_addresses.iter().map(|m| Self::get_price_key(m, source)).collect();
 
         // MGET returns Vec<Option<String>> aligned with the input keys.
         let raw: Vec<Option<String>> = conn.mget(&keys).await.map_err(|e| {
@@ -436,7 +448,11 @@ impl CacheUtil {
         for (mint, value) in mint_addresses.iter().zip(raw) {
             match value.as_deref().map(serde_json::from_str::<TokenPrice>) {
                 Some(Ok(price)) => {
-                    hits.insert(mint.clone(), price);
+                    if Self::is_cached_price_stale(&price, min_fresh_block_id) {
+                        misses.push(mint.clone());
+                    } else {
+                        hits.insert(mint.clone(), price);
+                    }
                 }
                 Some(Err(e)) => {
                     log::warn!("Failed to deserialize cached price for {mint}: {e}");
@@ -452,6 +468,7 @@ impl CacheUtil {
     /// Write fetched prices back to Redis with `price_ttl`.
     async fn set_prices_in_cache(
         pool: &Pool,
+        source: &PriceSource,
         prices: &HashMap<String, TokenPrice>,
         ttl: u64,
     ) -> Result<(), KoraError> {
@@ -466,14 +483,11 @@ impl CacheUtil {
             let serialized = match serde_json::to_string(price) {
                 Ok(s) => s,
                 Err(e) => {
-                    log::warn!(
-                        "Failed to serialize price for {mint}: {}",
-                        sanitize_error!(e)
-                    );
+                    log::warn!("Failed to serialize price for {mint}: {}", sanitize_error!(e));
                     continue;
                 }
             };
-            let key = Self::get_price_key(mint);
+            let key = Self::get_price_key(mint, source);
             pipe.set_ex(&key, serialized, ttl);
         }
 
@@ -484,6 +498,37 @@ impl CacheUtil {
         Ok(())
     }
 
+    /// Returns `true` if a cached price's `block_id` is at or below the
+    /// minimum-fresh slot, meaning the cached value would fail downstream
+    /// staleness validation and should be refetched. Cached prices missing a
+    /// `block_id` are treated as fresh here; the validation layer enforces
+    /// the missing-block_id case.
+    fn is_cached_price_stale(price: &TokenPrice, min_fresh_block_id: Option<u64>) -> bool {
+        match (min_fresh_block_id, price.block_id) {
+            (Some(threshold), Some(block_id)) => block_id <= threshold,
+            _ => false,
+        }
+    }
+
+    /// Compute the minimum `block_id` a cached price must have to be considered
+    /// fresh. Returns `None` when staleness validation is disabled
+    /// (`max_price_staleness_slots == 0`), so the cache layer doesn't pay for
+    /// an extra `get_slot` RPC.
+    async fn min_fresh_price_block_id(
+        rpc_client: &RpcClient,
+        config: &Config,
+    ) -> Result<Option<u64>, KoraError> {
+        let max_staleness = config.validation.max_price_staleness_slots;
+        if max_staleness == 0 {
+            return Ok(None);
+        }
+        let current_slot = rpc_client
+            .get_slot()
+            .await
+            .map_err(|e| KoraError::RpcError(format!("Failed to get current slot: {e}")))?;
+        Ok(Some(current_slot.saturating_sub(max_staleness)))
+    }
+
     /// Get token prices for the given mints, using Redis cache when available.
     ///
     /// On cache miss, fetches only the missing mints from the configured price
@@ -491,7 +536,13 @@ impl CacheUtil {
     /// Falls back to a direct oracle call when caching is disabled or unreachable.
     /// Setting `price_ttl = 0` disables price caching independently of the
     /// global cache switch (so account caching can stay on).
+    ///
+    /// When `validation.max_price_staleness_slots > 0`, cached prices whose
+    /// `block_id` is older than the threshold are treated as misses and
+    /// refetched, so a stale-but-cached price is replaced transparently
+    /// instead of being served to the staleness validator only to be rejected.
     pub async fn get_or_fetch_token_prices(
+        rpc_client: &RpcClient,
         config: &Config,
         mint_addresses: &[String],
     ) -> Result<HashMap<String, TokenPrice>, KoraError> {
@@ -518,23 +569,30 @@ impl CacheUtil {
             }
         };
 
+        let min_fresh_block_id = Self::min_fresh_price_block_id(rpc_client, config).await?;
+        let source = &config.validation.price_source;
+
         // Try cache first; on errors, fall through to a full live fetch.
-        let (mut hits, misses) = match Self::get_prices_from_cache(pool, mint_addresses).await {
-            Ok(result) => result,
-            Err(e) => {
-                log::warn!("Failed to read prices from cache, falling back to oracle: {e}");
-                return Self::get_price_oracle_singleton(config)
-                    .await?
-                    .get_token_prices(mint_addresses)
-                    .await;
-            }
-        };
+        let (mut hits, misses) =
+            match Self::get_prices_from_cache(pool, source, mint_addresses, min_fresh_block_id)
+                .await
+            {
+                Ok(result) => result,
+                Err(e) => {
+                    log::warn!("Failed to read prices from cache, falling back to oracle: {e}");
+                    return Self::get_price_oracle_singleton(config)
+                        .await?
+                        .get_token_prices(mint_addresses)
+                        .await;
+                }
+            };
 
         if misses.is_empty() {
             return Ok(hits);
         }
 
-        let fetched = Self::fetch_misses_with_singleflight(config, pool, misses).await?;
+        let fetched =
+            Self::fetch_misses_with_singleflight(config, pool, misses, min_fresh_block_id).await?;
         hits.extend(fetched);
         Ok(hits)
     }
@@ -550,6 +608,7 @@ impl CacheUtil {
         config: &Config,
         pool: &Pool,
         misses: Vec<String>,
+        min_fresh_block_id: Option<u64>,
     ) -> Result<HashMap<String, TokenPrice>, KoraError> {
         let mut sorted_misses = misses;
         sorted_misses.sort();
@@ -561,10 +620,14 @@ impl CacheUtil {
             guards.push(lock.lock_owned().await);
         }
 
+        let source = &config.validation.price_source;
+
         // Re-read the cache while holding the locks: prior leaders may have
         // populated some keys while we waited.
         let (mut hits, still_missing) =
-            match Self::get_prices_from_cache(pool, &sorted_misses).await {
+            match Self::get_prices_from_cache(pool, source, &sorted_misses, min_fresh_block_id)
+                .await
+            {
                 Ok(result) => result,
                 Err(e) => {
                     log::warn!("Failed to re-read prices from cache after lock acquisition: {e}");
@@ -576,7 +639,7 @@ impl CacheUtil {
             let oracle = Self::get_price_oracle_singleton(config).await?;
             let fetched = oracle.get_token_prices(&still_missing).await?;
             if let Err(e) =
-                Self::set_prices_in_cache(pool, &fetched, config.kora.cache.price_ttl).await
+                Self::set_prices_in_cache(pool, source, &fetched, config.kora.cache.price_ttl).await
             {
                 log::warn!("Failed to cache fetched prices: {e}");
             }
@@ -589,10 +652,13 @@ impl CacheUtil {
 
     /// Get a single token price, using Redis cache when available.
     pub async fn get_or_fetch_token_price(
+        rpc_client: &RpcClient,
         config: &Config,
         mint_address: &str,
     ) -> Result<TokenPrice, KoraError> {
-        let prices = Self::get_or_fetch_token_prices(config, &[mint_address.to_string()]).await?;
+        let prices =
+            Self::get_or_fetch_token_prices(rpc_client, config, &[mint_address.to_string()])
+                .await?;
 
         prices.get(mint_address).cloned().ok_or_else(|| {
             KoraError::InternalServerError(format!(
@@ -652,16 +718,20 @@ mod tests {
     #[tokio::test]
     async fn test_get_price_key_format() {
         let mint = Pubkey::new_unique().to_string();
-        let key = CacheUtil::get_price_key(&mint);
-        assert_eq!(key, format!("kora:price:{mint}"));
+        let jupiter_key = CacheUtil::get_price_key(&mint, &PriceSource::Jupiter);
+        let mock_key = CacheUtil::get_price_key(&mint, &PriceSource::Mock);
+        assert_eq!(jupiter_key, format!("kora:price:jupiter:{mint}"));
+        assert_eq!(mock_key, format!("kora:price:mock:{mint}"));
+        assert_ne!(jupiter_key, mock_key);
     }
 
     #[tokio::test]
     async fn test_get_or_fetch_token_prices_empty_returns_empty() {
         let _m = ConfigMockBuilder::new().with_cache_enabled(false).build_and_setup();
         let config = get_config().unwrap();
+        let rpc_client = RpcMockBuilder::new().build();
 
-        let prices = CacheUtil::get_or_fetch_token_prices(&config, &[]).await.unwrap();
+        let prices = CacheUtil::get_or_fetch_token_prices(&rpc_client, &config, &[]).await.unwrap();
         assert!(prices.is_empty());
     }
 
@@ -669,11 +739,13 @@ mod tests {
     async fn test_get_or_fetch_token_prices_cache_disabled_falls_back_to_oracle() {
         let _m = ConfigMockBuilder::new().with_cache_enabled(false).build_and_setup();
         let config = get_config().unwrap();
+        let rpc_client = RpcMockBuilder::new().build();
 
         let mint = Pubkey::new_unique().to_string();
-        let prices = CacheUtil::get_or_fetch_token_prices(&config, std::slice::from_ref(&mint))
-            .await
-            .unwrap();
+        let prices =
+            CacheUtil::get_or_fetch_token_prices(&rpc_client, &config, std::slice::from_ref(&mint))
+                .await
+                .unwrap();
 
         // Mock oracle (default in ConfigMockBuilder) always returns a price for any mint.
         assert!(prices.contains_key(&mint));
@@ -690,12 +762,14 @@ mod tests {
 
         let mut config = get_config().unwrap();
         config.kora.cache.price_ttl = 0;
+        let rpc_client = RpcMockBuilder::new().build();
 
         let mint = Pubkey::new_unique().to_string();
         // No real Redis is needed: the zero-ttl branch must short-circuit before any pool access.
-        let prices = CacheUtil::get_or_fetch_token_prices(&config, std::slice::from_ref(&mint))
-            .await
-            .unwrap();
+        let prices =
+            CacheUtil::get_or_fetch_token_prices(&rpc_client, &config, std::slice::from_ref(&mint))
+                .await
+                .unwrap();
 
         assert!(prices.contains_key(&mint));
     }

--- a/crates/lib/src/config.rs
+++ b/crates/lib/src/config.rs
@@ -8,7 +8,7 @@ use utoipa::ToSchema;
 use crate::{
     bundle::JitoConfig,
     constant::{
-        DEFAULT_CACHE_ACCOUNT_TTL, DEFAULT_CACHE_DEFAULT_TTL,
+        DEFAULT_CACHE_ACCOUNT_TTL, DEFAULT_CACHE_DEFAULT_TTL, DEFAULT_CACHE_PRICE_TTL,
         DEFAULT_FEE_PAYER_BALANCE_METRICS_EXPIRY_SECONDS, DEFAULT_MAX_REQUEST_BODY_SIZE,
         DEFAULT_MAX_TIMESTAMP_AGE, DEFAULT_METRICS_ENDPOINT, DEFAULT_METRICS_PORT,
         DEFAULT_METRICS_SCRAPE_INTERVAL, DEFAULT_PROTECTED_METHODS,
@@ -564,6 +564,13 @@ pub struct CacheConfig {
     pub default_ttl: u64,
     /// TTL for account data cache in seconds
     pub account_ttl: u64,
+    /// TTL for token price data cache in seconds
+    #[serde(default = "default_price_ttl")]
+    pub price_ttl: u64,
+}
+
+fn default_price_ttl() -> u64 {
+    DEFAULT_CACHE_PRICE_TTL
 }
 
 impl Default for CacheConfig {
@@ -573,6 +580,7 @@ impl Default for CacheConfig {
             enabled: false,
             default_ttl: DEFAULT_CACHE_DEFAULT_TTL,
             account_ttl: DEFAULT_CACHE_ACCOUNT_TTL,
+            price_ttl: DEFAULT_CACHE_PRICE_TTL,
         }
     }
 }
@@ -1081,6 +1089,7 @@ allow_create = true
         assert!(!config.kora.cache.enabled);
         assert_eq!(config.kora.cache.default_ttl, 300);
         assert_eq!(config.kora.cache.account_ttl, 60);
+        assert_eq!(config.kora.cache.price_ttl, 30);
     }
 
     #[test]

--- a/crates/lib/src/config.rs
+++ b/crates/lib/src/config.rs
@@ -565,12 +565,8 @@ pub struct CacheConfig {
     /// TTL for account data cache in seconds
     pub account_ttl: u64,
     /// TTL for token price data cache in seconds
-    #[serde(default = "default_price_ttl")]
+    #[serde(default)]
     pub price_ttl: u64,
-}
-
-fn default_price_ttl() -> u64 {
-    DEFAULT_CACHE_PRICE_TTL
 }
 
 impl Default for CacheConfig {

--- a/crates/lib/src/config.rs
+++ b/crates/lib/src/config.rs
@@ -1085,7 +1085,7 @@ allow_create = true
         assert!(!config.kora.cache.enabled);
         assert_eq!(config.kora.cache.default_ttl, 300);
         assert_eq!(config.kora.cache.account_ttl, 60);
-        assert_eq!(config.kora.cache.price_ttl, 30);
+        assert_eq!(config.kora.cache.price_ttl, 0);
     }
 
     #[test]

--- a/crates/lib/src/constant.rs
+++ b/crates/lib/src/constant.rs
@@ -49,6 +49,7 @@ pub const DEFAULT_METRICS_SCRAPE_INTERVAL: u64 = 60;
 // Cache
 pub const DEFAULT_CACHE_DEFAULT_TTL: u64 = 300; // 5 minutes
 pub const DEFAULT_CACHE_ACCOUNT_TTL: u64 = 60; // 1 minute for account data
+pub const DEFAULT_CACHE_PRICE_TTL: u64 = 30; // 30 seconds for token price data
 pub const DEFAULT_FEE_PAYER_BALANCE_METRICS_EXPIRY_SECONDS: u64 = 30; // 30 seconds
 
 pub const DEFAULT_USAGE_LIMIT_MAX_TRANSACTIONS: u64 = 0; // 0 = unlimited

--- a/crates/lib/src/constant.rs
+++ b/crates/lib/src/constant.rs
@@ -49,7 +49,7 @@ pub const DEFAULT_METRICS_SCRAPE_INTERVAL: u64 = 60;
 // Cache
 pub const DEFAULT_CACHE_DEFAULT_TTL: u64 = 300; // 5 minutes
 pub const DEFAULT_CACHE_ACCOUNT_TTL: u64 = 60; // 1 minute for account data
-pub const DEFAULT_CACHE_PRICE_TTL: u64 = 30; // 30 seconds for token price data
+pub const DEFAULT_CACHE_PRICE_TTL: u64 = 0; // 0 disables price caching
 pub const DEFAULT_FEE_PAYER_BALANCE_METRICS_EXPIRY_SECONDS: u64 = 30; // 30 seconds
 
 pub const DEFAULT_USAGE_LIMIT_MAX_TRANSACTIONS: u64 = 0; // 0 = unlimited

--- a/crates/lib/src/oracle/oracle.rs
+++ b/crates/lib/src/oracle/oracle.rs
@@ -27,6 +27,17 @@ pub enum PriceSource {
     Mock,
 }
 
+impl PriceSource {
+    /// Stable lowercase identifier used in cache keys; changing these values
+    /// invalidates existing Redis entries.
+    pub fn as_cache_key(&self) -> &'static str {
+        match self {
+            PriceSource::Jupiter => "jupiter",
+            PriceSource::Mock => "mock",
+        }
+    }
+}
+
 #[automock]
 #[async_trait::async_trait]
 pub trait PriceOracle {

--- a/crates/lib/src/tests/config_mock.rs
+++ b/crates/lib/src/tests/config_mock.rs
@@ -108,6 +108,7 @@ impl ConfigMockBuilder {
                         enabled: true,
                         default_ttl: 300,
                         account_ttl: 60,
+                        price_ttl: 30,
                     },
                     usage_limit: UsageLimitConfig::default(),
                     plugins: PluginsConfig::default(),
@@ -376,6 +377,7 @@ impl KoraConfigBuilder {
                     enabled: true,
                     default_ttl: 300,
                     account_ttl: 60,
+                    price_ttl: 30,
                 },
                 usage_limit: UsageLimitConfig::default(),
                 plugins: PluginsConfig::default(),
@@ -436,6 +438,7 @@ impl CacheConfigBuilder {
                 enabled: true,
                 default_ttl: 300,
                 account_ttl: 60,
+                price_ttl: 30,
             },
         }
     }
@@ -464,8 +467,21 @@ impl CacheConfigBuilder {
         self
     }
 
+    pub fn with_price_ttl(mut self, ttl: u64) -> Self {
+        self.config.price_ttl = ttl;
+        self
+    }
+
     pub fn disabled() -> Self {
-        Self { config: CacheConfig { url: None, enabled: false, default_ttl: 0, account_ttl: 0 } }
+        Self {
+            config: CacheConfig {
+                url: None,
+                enabled: false,
+                default_ttl: 0,
+                account_ttl: 0,
+                price_ttl: 0,
+            },
+        }
     }
 }
 

--- a/crates/lib/src/token/token.rs
+++ b/crates/lib/src/token/token.rs
@@ -2,7 +2,7 @@ use crate::{
     config::{Config, TransferHookPolicy},
     constant,
     error::KoraError,
-    oracle::{get_price_oracle, RetryingPriceOracle, TokenPrice},
+    oracle::TokenPrice,
     token::{
         interface::TokenMint,
         spl_token::TokenProgram,
@@ -25,7 +25,6 @@ use spl_associated_token_account_interface::program::id as ata_program_id;
 use std::{
     collections::{HashMap, HashSet},
     str::FromStr,
-    time::Duration,
 };
 
 #[cfg(test)]
@@ -421,15 +420,8 @@ impl TokenUtil {
     ) -> Result<(TokenPrice, u8), KoraError> {
         let decimals = Self::get_mint_decimals(config, rpc_client, mint).await?;
 
-        let oracle = RetryingPriceOracle::new(
-            3,
-            Duration::from_secs(1),
-            get_price_oracle(config.validation.price_source.clone())?,
-        );
-
-        // Get token price in SOL directly
-        let token_price = oracle
-            .get_token_price(&mint.to_string())
+        // Get token price in SOL directly (cached when Redis is enabled).
+        let token_price = CacheUtil::get_or_fetch_token_price(config, &mint.to_string())
             .await
             .map_err(|e| KoraError::RpcError(format!("Failed to fetch token price: {e}")))?;
 
@@ -568,13 +560,7 @@ impl TokenUtil {
         let mint_addresses: Vec<String> =
             mint_to_transfers.keys().map(|mint| mint.to_string()).collect();
 
-        let oracle = RetryingPriceOracle::new(
-            3,
-            Duration::from_secs(1),
-            get_price_oracle(config.validation.price_source.clone())?,
-        );
-
-        let prices = oracle.get_token_prices(&mint_addresses).await?;
+        let prices = CacheUtil::get_or_fetch_token_prices(config, &mint_addresses).await?;
 
         let current_slot = if config.validation.max_price_staleness_slots > 0 {
             Some(

--- a/crates/lib/src/token/token.rs
+++ b/crates/lib/src/token/token.rs
@@ -421,9 +421,10 @@ impl TokenUtil {
         let decimals = Self::get_mint_decimals(config, rpc_client, mint).await?;
 
         // Get token price in SOL directly (cached when Redis is enabled).
-        let token_price = CacheUtil::get_or_fetch_token_price(config, &mint.to_string())
-            .await
-            .map_err(|e| KoraError::RpcError(format!("Failed to fetch token price: {e}")))?;
+        let token_price =
+            CacheUtil::get_or_fetch_token_price(rpc_client, config, &mint.to_string())
+                .await
+                .map_err(|e| KoraError::RpcError(format!("Failed to fetch token price: {e}")))?;
 
         Self::check_price_staleness(rpc_client, config, &token_price, "", None).await?;
 
@@ -560,7 +561,8 @@ impl TokenUtil {
         let mint_addresses: Vec<String> =
             mint_to_transfers.keys().map(|mint| mint.to_string()).collect();
 
-        let prices = CacheUtil::get_or_fetch_token_prices(config, &mint_addresses).await?;
+        let prices =
+            CacheUtil::get_or_fetch_token_prices(rpc_client, config, &mint_addresses).await?;
 
         let current_slot = if config.validation.max_price_staleness_slots > 0 {
             Some(

--- a/kora.toml
+++ b/kora.toml
@@ -34,6 +34,7 @@ enabled = false                    # Enable/disable caching (set to true with ur
 url = "redis://localhost:6379"    # Redis connection URL (uncomment and set when enabling cache)
 default_ttl = 300                  # Default TTL in seconds (5 minutes)
 account_ttl = 60                   # Account data TTL in seconds (1 minute)
+price_ttl = 30                     # Token price TTL in seconds (30 seconds)
 
 # Enable/disable specific RPC methods
 [kora.enabled_methods]

--- a/kora.toml
+++ b/kora.toml
@@ -34,7 +34,7 @@ enabled = false                    # Enable/disable caching (set to true with ur
 url = "redis://localhost:6379"    # Redis connection URL (uncomment and set when enabling cache)
 default_ttl = 300                  # Default TTL in seconds (5 minutes)
 account_ttl = 60                   # Account data TTL in seconds (1 minute)
-price_ttl = 30                     # Token price TTL in seconds (30 seconds)
+price_ttl = 30                     # Token price TTL in seconds (set to 0 to disable price caching while keeping account caching on)
 
 # Enable/disable specific RPC methods
 [kora.enabled_methods]

--- a/kora.toml
+++ b/kora.toml
@@ -30,7 +30,7 @@ fail_if_transaction_size_overflow = true  # Reject transaction if adding asserti
 
 # Cache configuration for Redis-based caching
 [kora.cache]
-enabled = false                    # Enable/disable caching (set to true with url to enable)
+enabled = true                    # Enable/disable caching (set to true with url to enable)
 url = "redis://localhost:6379"    # Redis connection URL (uncomment and set when enabling cache)
 default_ttl = 300                  # Default TTL in seconds (5 minutes)
 account_ttl = 60                   # Account data TTL in seconds (1 minute)

--- a/kora.toml
+++ b/kora.toml
@@ -30,7 +30,7 @@ fail_if_transaction_size_overflow = true  # Reject transaction if adding asserti
 
 # Cache configuration for Redis-based caching
 [kora.cache]
-enabled = true                    # Enable/disable caching (set to true with url to enable)
+enabled = false                    # Enable/disable caching (set to true with url to enable)
 url = "redis://localhost:6379"    # Redis connection URL (uncomment and set when enabling cache)
 default_ttl = 300                  # Default TTL in seconds (5 minutes)
 account_ttl = 60                   # Account data TTL in seconds (1 minute)

--- a/kora.toml
+++ b/kora.toml
@@ -34,7 +34,7 @@ enabled = false                    # Enable/disable caching (set to true with ur
 url = "redis://localhost:6379"    # Redis connection URL (uncomment and set when enabling cache)
 default_ttl = 300                  # Default TTL in seconds (5 minutes)
 account_ttl = 60                   # Account data TTL in seconds (1 minute)
-price_ttl = 30                     # Token price TTL in seconds (set to 0 to disable price caching while keeping account caching on)
+price_ttl = 0                     # Token price TTL in seconds (set to 0 to disable price caching while keeping account caching on)
 
 # Enable/disable specific RPC methods
 [kora.enabled_methods]


### PR DESCRIPTION
# What
This PR adds Redis caching for token prices used during fee calculation.

# Why
Price oracle API calls (e.g. Jupiter) can be expensive and add latency. For back-to-back requests like `signTransaction` or `signAndSendTransaction` landing within seconds of each other, the price doesn't change meaningfully — refetching it every time is wasteful.

# How
Token prices are stored in Redis with a configurable TTL (`price_ttl`, default 30s). On a cache miss, only the missing mints are fetched from the oracle and written back. A per-mint singleflight lock prevents concurrent requests from triggering duplicate oracle calls for the same token. The price oracle is initialized once as a process-wide singleton so its HTTP connection pool is reused. Setting `price_ttl = 0` disables price caching independently of the global cache toggle, so account caching can remain on.
