### PR TITLE
ci: broaden miri coverage

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -44,6 +44,8 @@ jobs:
 
   miri:
     runs-on: ubuntu-latest
+    env:
+      MIRIFLAGS: -Zmiri-disable-isolation -Zmiri-ignore-leaks
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@nightly
@@ -55,5 +57,4 @@ jobs:
             ~/.cache/org.rust-lang.miri
           key: miri-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
       - run: cargo +nightly miri setup
-      - run: cargo +nightly miri test -p kora-lib --lib bundle::helper::tests
-      - run: cargo +nightly miri test -p kora-lib --lib error::tests
+      - run: cargo +nightly miri test -p kora-lib --lib

--- a/crates/lib/src/admin/token_util.rs
+++ b/crates/lib/src/admin/token_util.rs
@@ -326,6 +326,7 @@ mod tests {
         sync::{Arc, Mutex},
     };
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_find_missing_atas_no_spl_tokens() {
         let _m = ConfigMockBuilder::new()
@@ -345,6 +346,7 @@ mod tests {
         assert!(result.is_empty(), "Should return empty vec when no SPL tokens configured");
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_find_missing_atas_with_spl_tokens() {
         let allowed_spl_tokens = [Pubkey::new_unique(), Pubkey::new_unique()];
@@ -389,6 +391,7 @@ mod tests {
         assert_eq!(atas.len(), 1, "Should return 1 missing ATAs");
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_find_missing_atas_detects_existing_token2022_ata() {
         let token2022_mint = Pubkey::new_unique();
@@ -449,6 +452,7 @@ mod tests {
         );
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_create_atas_for_signer_calls_rpc_correctly() {
         let _m = ConfigMockBuilder::new().build_and_setup();
@@ -508,6 +512,7 @@ mod tests {
         }
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_initialize_atas_when_all_tokens_are_allowed() {
         let _m = ConfigMockBuilder::new()

--- a/crates/lib/src/bundle/jito/client.rs
+++ b/crates/lib/src/bundle/jito/client.rs
@@ -482,6 +482,7 @@ mod tests {
     use crate::tests::transaction_mock::create_mock_encoded_transaction;
     use mockito::{Matcher, Server};
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_send_bundle_success() {
         let mut server = Server::new_async().await;
@@ -507,6 +508,7 @@ mod tests {
         assert_eq!(result.unwrap(), "bundle-uuid-12345");
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_send_bundle_http_error() {
         let mut server = Server::new_async().await;
@@ -528,6 +530,7 @@ mod tests {
         assert!(result.is_err());
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_send_bundle_rpc_error() {
         let mut server = Server::new_async().await;
@@ -550,6 +553,7 @@ mod tests {
         assert!(result.is_err());
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_get_bundle_statuses_success() {
         let mut server = Server::new_async().await;
@@ -571,6 +575,7 @@ mod tests {
         assert!(result.is_ok());
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_simulate_bundle_success() {
         let mut server = Server::new_async().await;
@@ -607,6 +612,7 @@ mod tests {
         assert_eq!(simulation.transaction_results[0].units_consumed, Some(42));
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_simulate_bundle_success_with_transaction_results_shape() {
         let mut server = Server::new_async().await;
@@ -644,6 +650,7 @@ mod tests {
         assert_eq!(simulation.transaction_results[0].units_consumed, Some(84));
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_simulate_bundle_execution_failure() {
         let mut server = Server::new_async().await;
@@ -675,6 +682,7 @@ mod tests {
         assert!(err.contains("failed log"));
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_simulate_bundle_summary_failure_without_transaction_results() {
         let mut server = Server::new_async().await;
@@ -705,6 +713,7 @@ mod tests {
         assert!(err.contains("Bundle simulation failed"));
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_simulate_bundle_with_config_includes_second_param() {
         let mut server = Server::new_async().await;
@@ -755,6 +764,7 @@ mod tests {
         assert!(result.is_ok());
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_send_bundle_invalid_uuid_response() {
         let mut server = Server::new_async().await;
@@ -777,6 +787,7 @@ mod tests {
         assert!(result.is_err());
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_send_bundle_empty_result() {
         let mut server = Server::new_async().await;
@@ -799,6 +810,7 @@ mod tests {
         assert!(result.is_err());
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_send_bundle_multiple_transactions() {
         let mut server = Server::new_async().await;
@@ -826,6 +838,7 @@ mod tests {
         assert_eq!(result.unwrap(), "multi-tx-bundle-uuid");
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_send_bundle_malformed_json_response() {
         let mut server = Server::new_async().await;
@@ -848,6 +861,7 @@ mod tests {
         assert!(result.is_err());
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_get_bundle_statuses_empty_uuids() {
         let mut server = Server::new_async().await;
@@ -871,6 +885,7 @@ mod tests {
         assert!(result.is_ok());
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_get_bundle_statuses_multiple_uuids() {
         let mut server = Server::new_async().await;
@@ -901,6 +916,7 @@ mod tests {
         assert!(result.is_ok());
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_jito_bundle_client_dispatches_to_mock() {
         let config = JitoConfig {
@@ -919,6 +935,7 @@ mod tests {
         assert!(uuid.starts_with("mock-bundle-"), "Expected mock UUID prefix");
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_jito_bundle_client_dispatches_to_real() {
         let config = JitoConfig {
@@ -930,6 +947,7 @@ mod tests {
         assert!(matches!(client, JitoBundleClient::Live(_)));
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_mock_client_get_bundle_statuses() {
         let config = JitoConfig {
@@ -946,6 +964,7 @@ mod tests {
         assert_eq!(statuses["value"][0]["status"], "Landed");
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_mock_client_simulate_bundle() {
         let config = JitoConfig {

--- a/crates/lib/src/cache.rs
+++ b/crates/lib/src/cache.rs
@@ -676,6 +676,7 @@ mod tests {
         config_mock::ConfigMockBuilder,
     };
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_is_cache_enabled_disabled() {
         let _m = ConfigMockBuilder::new().with_cache_enabled(false).build_and_setup();
@@ -684,6 +685,7 @@ mod tests {
         assert!(!CacheUtil::is_cache_enabled(&config));
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_is_cache_enabled_no_url() {
         let _m = ConfigMockBuilder::new()
@@ -696,6 +698,7 @@ mod tests {
         assert!(!CacheUtil::is_cache_enabled(&config));
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_is_cache_enabled_with_url() {
         let _m = ConfigMockBuilder::new()
@@ -708,6 +711,7 @@ mod tests {
         assert!(CacheUtil::is_cache_enabled(&config));
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_get_account_key_format() {
         let pubkey = Pubkey::new_unique();
@@ -715,6 +719,7 @@ mod tests {
         assert_eq!(key, format!("account:{pubkey}"));
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_get_price_key_format() {
         let mint = Pubkey::new_unique().to_string();
@@ -789,6 +794,7 @@ mod tests {
         assert_eq!(account.owner, expected_account.owner);
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_get_account_from_rpc_error() {
         let pubkey = Pubkey::new_unique();
@@ -805,6 +811,7 @@ mod tests {
         }
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_get_account_cache_disabled_fallback_to_rpc() {
         let _m = ConfigMockBuilder::new().with_cache_enabled(false).build_and_setup();
@@ -822,6 +829,7 @@ mod tests {
         assert_eq!(account.lamports, expected_account.lamports);
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_get_account_force_refresh_bypasses_cache() {
         let _m = ConfigMockBuilder::new()
@@ -842,6 +850,7 @@ mod tests {
         assert_eq!(account.lamports, expected_account.lamports);
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_get_or_fetch_blockhash_cache_disabled() {
         let _m = ConfigMockBuilder::new().with_cache_enabled(false).build_and_setup();
@@ -856,6 +865,7 @@ mod tests {
         assert_ne!(hash, Hash::default(), "Blockhash should not be the default hash");
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_fetch_blockhash_from_rpc_success() {
         let rpc_client = RpcMockBuilder::new().with_blockhash().build();

--- a/crates/lib/src/fee/fee.rs
+++ b/crates/lib/src/fee/fee.rs
@@ -863,6 +863,7 @@ mod tests {
         .await
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_estimate_kora_fee_free_rejects_mutable_transfer_hook_authority() {
         let result = estimate_free_fee_with_mutable_transfer_hook(
@@ -877,6 +878,7 @@ mod tests {
         assert!(msg.contains("Mutable transfer-hook authority found on mint account"));
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_estimate_kora_fee_free_allows_mutable_transfer_hook_authority_for_immediate_sign_and_send(
     ) {
@@ -892,6 +894,7 @@ mod tests {
         assert_eq!(calculation.total_fee_lamports, 0);
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_estimate_kora_fee_free_rejects_mutable_transfer_hook_authority_when_policy_is_deny_all(
     ) {
@@ -907,6 +910,7 @@ mod tests {
         assert!(msg.contains("Mutable transfer-hook authority found on mint account"));
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_estimate_kora_fee_free_allows_mutable_transfer_hook_authority_when_policy_is_allow_all(
     ) {
@@ -922,6 +926,7 @@ mod tests {
         assert_eq!(calculation.total_fee_lamports, 0);
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_estimate_kora_fee_free_allows_immutable_transfer_hook_authority() {
         let mut config = ConfigMockBuilder::new().with_cache_enabled(false).build();
@@ -973,6 +978,7 @@ mod tests {
         assert_eq!(calculation.total_fee_lamports, 0);
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_estimate_kora_fee_free_rejects_mutable_transfer_hook_authority_for_transfer_checked_with_fee(
     ) {
@@ -1065,6 +1071,7 @@ mod tests {
             .unwrap());
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_calculate_fee_payer_outflow_transfer() {
         setup_or_get_test_config();
@@ -1127,6 +1134,7 @@ mod tests {
         assert_eq!(outflow, 0, "Transfer from other account should not affect outflow");
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_calculate_fee_payer_outflow_transfer_with_seed() {
         setup_or_get_test_config();
@@ -1187,6 +1195,7 @@ mod tests {
         );
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_calculate_fee_payer_outflow_create_account() {
         setup_or_get_test_config();
@@ -1232,6 +1241,7 @@ mod tests {
         assert_eq!(outflow, 0, "CreateAccount funded by other account should not affect outflow");
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_calculate_fee_payer_outflow_create_account_with_seed() {
         setup_or_get_test_config();
@@ -1268,6 +1278,7 @@ mod tests {
         );
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_calculate_fee_payer_outflow_nonce_withdraw() {
         setup_or_get_test_config();
@@ -1367,6 +1378,7 @@ mod tests {
         );
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_calculate_fee_payer_outflow_alt_close_lookup_table() {
         let _m = ConfigMockBuilder::new().with_cache_enabled(false).build_and_setup();
@@ -1443,6 +1455,7 @@ mod tests {
         );
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_estimate_kora_fee_margin_includes_alt_close_outflow() {
         let mut config = ConfigMockBuilder::new().with_cache_enabled(false).build();
@@ -1485,6 +1498,7 @@ mod tests {
         );
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_calculate_fee_payer_outflow_multiple_instructions() {
         setup_or_get_test_config();
@@ -1518,6 +1532,7 @@ mod tests {
         );
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_calculate_fee_payer_outflow_non_system_program() {
         setup_or_get_test_config();
@@ -1546,6 +1561,7 @@ mod tests {
         assert_eq!(outflow, 0, "Non-system program should not affect outflow");
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_calculate_fee_payer_outflow_ata_idempotent_without_inner_create() {
         let _m = ConfigMockBuilder::new().build_and_setup();
@@ -1587,6 +1603,7 @@ mod tests {
         );
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_calculate_fee_payer_outflow_ata_not_double_counted_with_system_create() {
         let _m = ConfigMockBuilder::new().build_and_setup();
@@ -1636,6 +1653,7 @@ mod tests {
         );
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_calculate_fee_payer_outflow_duplicate_ata_idempotent_only_charged_once() {
         let _m = ConfigMockBuilder::new().build_and_setup();
@@ -1686,6 +1704,7 @@ mod tests {
         );
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_calculate_fee_payer_outflow_multiple_distinct_ata_idempotent_charged_per_ata() {
         let _m = ConfigMockBuilder::new().build_and_setup();
@@ -1737,6 +1756,7 @@ mod tests {
         );
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_analyze_payment_instructions_with_payment() {
         let _m = ConfigMockBuilder::new().build_and_setup();
@@ -1784,6 +1804,7 @@ mod tests {
         assert_eq!(transfer_fees, 0, "Should have no transfer fees for SPL token");
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_analyze_payment_instructions_without_payment() {
         let signer = setup_or_get_test_signer();
@@ -1815,6 +1836,7 @@ mod tests {
         assert_eq!(transfer_fees, 0, "Should have no transfer fees");
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_analyze_payment_instructions_with_wrong_destination() {
         let _m = ConfigMockBuilder::new().build_and_setup();
@@ -1863,6 +1885,7 @@ mod tests {
         assert_eq!(transfer_fees, 0, "Should have no transfer fees");
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_estimate_transaction_fee_basic() {
         let _m = ConfigMockBuilder::new().build_and_setup();
@@ -1897,6 +1920,7 @@ mod tests {
         assert_eq!(result.total_fee_lamports, 105_000, "Should return base fee + outflow");
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_estimate_transaction_fee_kora_signer_not_in_signers() {
         let _m = ConfigMockBuilder::new().build_and_setup();
@@ -1933,6 +1957,7 @@ mod tests {
         );
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_estimate_transaction_fee_with_payment_required() {
         let _m = ConfigMockBuilder::new().build_and_setup();
@@ -1972,6 +1997,7 @@ mod tests {
         );
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_analyze_payment_instructions_with_multiple_payments() {
         let _m = ConfigMockBuilder::new().build_and_setup();
@@ -2025,6 +2051,7 @@ mod tests {
         assert_eq!(transfer_fees, 0, "Should have no transfer fees for SPL tokens");
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_transaction_fee_util_get_estimate_fee_legacy() {
         let mocked_rpc_client = RpcMockBuilder::new().with_fee_estimate(7500).build();
@@ -2043,6 +2070,7 @@ mod tests {
         assert_eq!(result, 7500, "Should return mocked base fee for legacy message");
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_transaction_fee_util_get_estimate_fee_v0() {
         let mocked_rpc_client = RpcMockBuilder::new().with_fee_estimate(12500).build();

--- a/crates/lib/src/fee/price.rs
+++ b/crates/lib/src/fee/price.rs
@@ -113,6 +113,7 @@ mod tests {
         config_mock::{mock_state::get_config, ConfigMockBuilder},
     };
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_margin_model_get_required_lamports() {
         // Test margin of 0.1 (10%)
@@ -127,6 +128,7 @@ mod tests {
         assert_eq!(result, expected_lamports);
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_margin_model_get_required_lamports_zero_margin() {
         // Test margin of 0.0 (no margin)
@@ -140,6 +142,7 @@ mod tests {
         assert_eq!(result, min_transaction_fee);
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_fixed_model_get_required_lamports_with_oracle() {
         let _m = ConfigMockBuilder::new().build_and_setup();
@@ -167,6 +170,7 @@ mod tests {
         assert_eq!(result, 7500000);
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_fixed_model_get_required_lamports_with_custom_price() {
         let _m = ConfigMockBuilder::new().build_and_setup();
@@ -194,6 +198,7 @@ mod tests {
         assert_eq!(result, 500000000);
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_fixed_model_get_required_lamports_small_amount() {
         let _m = ConfigMockBuilder::new().build_and_setup();
@@ -219,6 +224,7 @@ mod tests {
         assert_eq!(result, 7500);
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_default_price_config() {
         // Test that default creates Margin with 0.0 margin

--- a/crates/lib/src/metrics/balance.rs
+++ b/crates/lib/src/metrics/balance.rs
@@ -184,6 +184,7 @@ mod tests {
         let _ = update_signer_pool(pool);
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_is_enabled_when_disabled() {
         let _m = ConfigMockBuilder::new()
@@ -201,6 +202,7 @@ mod tests {
         assert!(!BalanceTracker::is_enabled());
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_is_enabled_when_enabled() {
         let _m = ConfigMockBuilder::new()
@@ -218,6 +220,7 @@ mod tests {
         assert!(BalanceTracker::is_enabled());
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_is_enabled_requires_both_flags() {
         // Test case: metrics enabled but balance metrics disabled
@@ -236,6 +239,7 @@ mod tests {
         assert!(!BalanceTracker::is_enabled());
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_is_enabled_metrics_disabled_balance_enabled() {
         let _m = ConfigMockBuilder::new()
@@ -253,6 +257,7 @@ mod tests {
         assert!(!BalanceTracker::is_enabled());
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_init_when_disabled() {
         let _m = ConfigMockBuilder::new()
@@ -271,6 +276,7 @@ mod tests {
         assert!(result.is_ok());
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_init_when_enabled() {
         let _m = ConfigMockBuilder::new()
@@ -289,6 +295,7 @@ mod tests {
         assert!(result.is_ok());
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_track_all_signer_balances_when_disabled() {
         let _m = ConfigMockBuilder::new()
@@ -309,6 +316,7 @@ mod tests {
         assert!(result.is_ok());
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_track_all_signer_balances_successful() {
         let _m = ConfigMockBuilder::new()
@@ -334,6 +342,7 @@ mod tests {
         assert!(result.is_ok());
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_track_all_signer_balances_handles_rpc_errors() {
         let _m = ConfigMockBuilder::new()
@@ -358,6 +367,7 @@ mod tests {
         assert!(result.is_ok());
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_start_background_tracking_when_disabled() {
         let _m = ConfigMockBuilder::new()
@@ -378,6 +388,7 @@ mod tests {
         assert!(handle.is_none());
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_start_background_tracking_when_enabled() {
         let _m = ConfigMockBuilder::new()

--- a/crates/lib/src/oracle/jupiter.rs
+++ b/crates/lib/src/oracle/jupiter.rs
@@ -242,6 +242,7 @@ mod tests {
         assert!(matches!(result.err(), Some(KoraError::ConfigError(_))));
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_jupiter_price_fetch_with_api_key() {
@@ -286,6 +287,7 @@ mod tests {
         assert_eq!(price.source, PriceSource::Jupiter);
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_jupiter_missing_price_data_returns_error() {
@@ -328,6 +330,7 @@ mod tests {
         );
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_jupiter_rate_limit_429() {
@@ -355,6 +358,7 @@ mod tests {
         assert!(result.is_err());
         assert_eq!(result.err(), Some(KoraError::RateLimitExceeded));
     }
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_jupiter_price_exceeds_max_bounds() {
@@ -401,6 +405,7 @@ mod tests {
             matches!(result.err(), Some(KoraError::RpcError(msg)) if msg.contains("exceeds reasonable bounds"))
         );
     }
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_jupiter_price_below_min_bounds() {

--- a/crates/lib/src/oracle/oracle.rs
+++ b/crates/lib/src/oracle/oracle.rs
@@ -120,6 +120,7 @@ mod tests {
     use super::*;
     use std::time::Duration;
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_price_oracle_retries() {
         let mut mock_oracle = MockPriceOracle::new();
@@ -143,6 +144,7 @@ mod tests {
         let result = oracle.get_token_price("test").await;
         assert!(result.is_ok());
     }
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_price_oracle_empty_mints() {
         let mut mock_oracle = MockPriceOracle::new();
@@ -154,6 +156,7 @@ mod tests {
         assert!(result.is_ok());
         assert!(result.unwrap().is_empty());
     }
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_price_oracle_retries_all_fail() {
         let mut mock_oracle = MockPriceOracle::new();
@@ -167,6 +170,7 @@ mod tests {
         assert!(result.is_err());
         assert_eq!(result.err(), Some(KoraError::RpcError("mock error".to_string())));
     }
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_price_oracle_retry_then_succeed() {
         let mut mock_oracle = MockPriceOracle::new();
@@ -197,6 +201,7 @@ mod tests {
         let price = result.unwrap();
         assert_eq!(price.price, Decimal::from(42));
     }
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_get_token_price_not_found() {
         let mut mock_oracle = MockPriceOracle::new();

--- a/crates/lib/src/oracle/utils.rs
+++ b/crates/lib/src/oracle/utils.rs
@@ -58,6 +58,7 @@ mod tests {
     use super::*;
     use reqwest::Client;
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_mock_oracle_prices() {
         let oracle = OracleUtil::get_mock_oracle_price();

--- a/crates/lib/src/plugin/plugin_deploy_authority.rs
+++ b/crates/lib/src/plugin/plugin_deploy_authority.rs
@@ -312,6 +312,7 @@ mod tests {
             .await
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn accepts_write_when_kora_is_authority() {
         let (config, rpc_client) = build_runner();
@@ -322,6 +323,7 @@ mod tests {
         assert!(run_plugin(&config, &rpc_client, &fee_payer, ix).await.is_ok());
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn rejects_write_when_user_is_authority() {
         let (config, rpc_client) = build_runner();
@@ -337,6 +339,7 @@ mod tests {
         );
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn accepts_copy_when_kora_is_authority() {
         let (config, rpc_client) = build_runner();
@@ -348,6 +351,7 @@ mod tests {
         assert!(run_plugin(&config, &rpc_client, &fee_payer, ix).await.is_ok());
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn rejects_copy_when_user_is_authority() {
         let (config, rpc_client) = build_runner();
@@ -361,6 +365,7 @@ mod tests {
         assert!(matches!(err, KoraError::InvalidTransaction(_)));
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn accepts_set_program_length_when_kora_is_authority() {
         let (config, rpc_client) = build_runner();
@@ -371,6 +376,7 @@ mod tests {
         assert!(run_plugin(&config, &rpc_client, &fee_payer, ix).await.is_ok());
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn rejects_set_program_length_when_user_is_authority() {
         let (config, rpc_client) = build_runner();
@@ -383,6 +389,7 @@ mod tests {
         assert!(matches!(err, KoraError::InvalidTransaction(_)));
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn accepts_deploy_when_kora_is_authority() {
         let (config, rpc_client) = build_runner();
@@ -393,6 +400,7 @@ mod tests {
         assert!(run_plugin(&config, &rpc_client, &fee_payer, ix).await.is_ok());
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn rejects_deploy_when_user_is_authority() {
         let (config, rpc_client) = build_runner();
@@ -405,6 +413,7 @@ mod tests {
         assert!(matches!(err, KoraError::InvalidTransaction(_)));
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn accepts_retract_when_kora_is_authority() {
         let (config, rpc_client) = build_runner();
@@ -415,6 +424,7 @@ mod tests {
         assert!(run_plugin(&config, &rpc_client, &fee_payer, ix).await.is_ok());
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn rejects_retract_when_user_is_authority() {
         let (config, rpc_client) = build_runner();
@@ -427,6 +437,7 @@ mod tests {
         assert!(matches!(err, KoraError::InvalidTransaction(_)));
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn accepts_transfer_authority_when_new_is_kora() {
         // Attacker hands authority to Kora via TransferAuthority — plugin accepts because the
@@ -441,6 +452,7 @@ mod tests {
         assert!(run_plugin(&config, &rpc_client, &fee_payer, ix).await.is_ok());
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn rejects_transfer_authority_to_user() {
         let (config, rpc_client) = build_runner();
@@ -456,6 +468,7 @@ mod tests {
         );
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn rejects_finalize_even_when_kora_is_authority() {
         let (config, rpc_client) = build_runner();
@@ -471,6 +484,7 @@ mod tests {
         );
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn mixed_tx_rejects_when_loader_v4_authority_wrong() {
         let (config, rpc_client) = build_runner();
@@ -500,6 +514,7 @@ mod tests {
         assert!(matches!(err, KoraError::InvalidTransaction(_)));
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn no_loader_v4_instructions_is_noop() {
         // Plugin should not interfere with non-loader-v4 transactions.
@@ -567,6 +582,7 @@ mod tests {
         (config, rpc_client)
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn v3_accepts_write_when_kora_is_authority() {
         use solana_loader_v3_interface::instruction as loader_v3;
@@ -577,6 +593,7 @@ mod tests {
         assert!(run_plugin(&config, &rpc_client, &fee_payer, ix).await.is_ok());
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn v3_rejects_write_with_user_authority() {
         use solana_loader_v3_interface::instruction as loader_v3;
@@ -592,6 +609,7 @@ mod tests {
         );
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn v3_rejects_set_authority_handoff() {
         use solana_loader_v3_interface::instruction as loader_v3;
@@ -607,6 +625,7 @@ mod tests {
         );
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn v3_rejects_close_with_foreign_recipient() {
         use solana_loader_v3_interface::instruction as loader_v3;
@@ -622,6 +641,7 @@ mod tests {
         );
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn v3_accepts_close_back_to_kora() {
         use solana_loader_v3_interface::instruction as loader_v3;
@@ -632,6 +652,7 @@ mod tests {
         assert!(run_plugin(&config, &rpc_client, &fee_payer, ix).await.is_ok());
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn v3_rejects_extend_program_checked_with_attacker_authority_kora_payer() {
         // Regression: ExtendProgramChecked previously hit a `_ => {}` wildcard in the
@@ -651,6 +672,7 @@ mod tests {
         );
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn v3_rejects_migrate() {
         use solana_loader_v3_interface::instruction as loader_v3;

--- a/crates/lib/src/plugin/plugin_gas_swap.rs
+++ b/crates/lib/src/plugin/plugin_gas_swap.rs
@@ -182,6 +182,7 @@ mod tests {
         (config, rpc_client)
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn gas_swap_accepts_valid_top_level_swap_shape() {
         let (config, rpc_client) = build_runner();
@@ -222,6 +223,7 @@ mod tests {
         assert!(result.is_ok());
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn gas_swap_rejects_non_swap_programs() {
         let (config, rpc_client) = build_runner();
@@ -265,6 +267,7 @@ mod tests {
         assert!(matches!(result.unwrap_err(), KoraError::InvalidTransaction(_)));
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn gas_swap_rejects_non_transfer_system_instruction() {
         let (config, rpc_client) = build_runner();
@@ -304,6 +307,7 @@ mod tests {
         assert!(matches!(result.unwrap_err(), KoraError::InvalidTransaction(_)));
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn gas_swap_rejects_sol_transfer_not_from_fee_payer() {
         let (config, rpc_client) = build_runner();
@@ -346,6 +350,7 @@ mod tests {
         assert!(matches!(result.unwrap_err(), KoraError::InvalidTransaction(_)));
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn gas_swap_rejects_when_no_token_transfer() {
         let (config, rpc_client) = build_runner();
@@ -374,6 +379,7 @@ mod tests {
         assert!(matches!(result.unwrap_err(), KoraError::InvalidTransaction(_)));
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn gas_swap_accepts_compute_budget_instructions() {
         let (config, rpc_client) = build_runner();
@@ -416,6 +422,7 @@ mod tests {
         assert!(result.is_ok());
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn gas_swap_rejects_extra_non_budget_instruction() {
         let (config, rpc_client) = build_runner();

--- a/crates/lib/src/rpc_server/auth.rs
+++ b/crates/lib/src/rpc_server/auth.rs
@@ -258,6 +258,7 @@ mod tests {
         }
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_api_key_auth_valid_key() {
         let layer = ApiKeyAuthLayer::new("test-key".to_string());
@@ -273,6 +274,7 @@ mod tests {
         assert_eq!(response.status(), StatusCode::OK);
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_api_key_auth_invalid_key() {
         let layer = ApiKeyAuthLayer::new("test-key".to_string());
@@ -288,6 +290,7 @@ mod tests {
         assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_api_key_auth_missing_header() {
         let layer = ApiKeyAuthLayer::new("test-key".to_string());
@@ -299,6 +302,7 @@ mod tests {
         assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_api_key_auth_liveness_bypass() {
         let layer = ApiKeyAuthLayer::new("test-key".to_string());
@@ -314,6 +318,7 @@ mod tests {
         assert_eq!(response.status(), StatusCode::OK);
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_hmac_auth_valid_signature() {
         let secret = "test-secret";
@@ -345,6 +350,7 @@ mod tests {
         assert_eq!(response.status(), StatusCode::OK);
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_hmac_auth_invalid_signature() {
         let secret = "test-secret";
@@ -371,6 +377,7 @@ mod tests {
         assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_hmac_auth_missing_headers() {
         let secret = "test-secret";
@@ -385,6 +392,7 @@ mod tests {
         assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_hmac_auth_expired_timestamp() {
         let secret = "test-secret";
@@ -416,6 +424,7 @@ mod tests {
         assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_hmac_auth_malformed_timestamp() {
         let secret = "test-secret";
@@ -436,6 +445,7 @@ mod tests {
         assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_hmac_auth_liveness_bypass() {
         let secret = "test-secret";

--- a/crates/lib/src/rpc_server/method/estimate_bundle_fee.rs
+++ b/crates/lib/src/rpc_server/method/estimate_bundle_fee.rs
@@ -138,6 +138,7 @@ mod tests {
     use solana_sdk::pubkey::Pubkey;
     use solana_system_interface::instruction::transfer;
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_estimate_bundle_fee_empty_bundle() {
         let _m = ConfigMockBuilder::new().with_bundle_enabled(true).build_and_setup();
@@ -160,6 +161,7 @@ mod tests {
         assert!(matches!(err, KoraError::InvalidTransaction(_)));
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_estimate_bundle_fee_disabled() {
         let _m = ConfigMockBuilder::new().with_bundle_enabled(false).build_and_setup();
@@ -185,6 +187,7 @@ mod tests {
         }
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_estimate_bundle_fee_too_large() {
         let _m = ConfigMockBuilder::new().with_bundle_enabled(true).build_and_setup();
@@ -210,6 +213,7 @@ mod tests {
         }
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_estimate_bundle_fee_invalid_signer_key() {
         let _m = ConfigMockBuilder::new().with_bundle_enabled(true).build_and_setup();
@@ -232,6 +236,7 @@ mod tests {
         assert!(matches!(err, KoraError::ValidationError(_)));
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_estimate_bundle_fee_exactly_max_size() {
         let _m = ConfigMockBuilder::new()
@@ -264,6 +269,7 @@ mod tests {
         assert!(!response.payment_address.is_empty());
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_estimate_bundle_fee_single_transaction() {
         let _m = ConfigMockBuilder::new()
@@ -294,6 +300,7 @@ mod tests {
         assert!(!response.payment_address.is_empty());
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_estimate_bundle_fee_sig_verify_default() {
         // Test that sig_verify defaults correctly via serde (defaults to false)
@@ -304,6 +311,7 @@ mod tests {
         assert!(request.signer_key.is_none());
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_estimate_bundle_fee_request_deserialization() {
         let json = r#"{
@@ -323,6 +331,7 @@ mod tests {
         assert!(!request.sig_verify);
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_estimate_bundle_fee_skips_plugins() {
         let mut config = ConfigMockBuilder::new()
@@ -351,6 +360,7 @@ mod tests {
         assert!(result.is_ok(), "estimateBundleFee should skip transaction plugins");
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_estimate_bundle_fee_rejects_sequential_outflow_violation() {
         let mut server = Server::new_async().await;

--- a/crates/lib/src/rpc_server/method/estimate_transaction_fee.rs
+++ b/crates/lib/src/rpc_server/method/estimate_transaction_fee.rs
@@ -113,6 +113,7 @@ mod tests {
         transaction_mock::create_mock_encoded_transaction,
     };
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_estimate_transaction_fee_decode_error() {
         let _ = setup_or_get_test_config();
@@ -132,6 +133,7 @@ mod tests {
         assert!(result.is_err(), "Should fail with decode error");
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_estimate_transaction_fee_invalid_signer_key() {
         let _ = setup_or_get_test_config();
@@ -153,6 +155,7 @@ mod tests {
         assert!(matches!(error, KoraError::ValidationError(_)), "Should return ValidationError");
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_estimate_transaction_fee_invalid_token_mint() {
         let _ = setup_or_get_test_config();

--- a/crates/lib/src/rpc_server/method/get_blockhash.rs
+++ b/crates/lib/src/rpc_server/method/get_blockhash.rs
@@ -27,6 +27,7 @@ mod tests {
     use super::*;
     use crate::tests::{config_mock::ConfigMockBuilder, rpc_mock::RpcMockBuilder};
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_get_blockhash_success() {
         let _m = ConfigMockBuilder::new().build_and_setup();

--- a/crates/lib/src/rpc_server/method/get_config.rs
+++ b/crates/lib/src/rpc_server/method/get_config.rs
@@ -46,6 +46,7 @@ mod tests {
     };
     use serial_test::serial;
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_get_config_success() {

--- a/crates/lib/src/rpc_server/method/get_supported_tokens.rs
+++ b/crates/lib/src/rpc_server/method/get_supported_tokens.rs
@@ -26,6 +26,7 @@ mod tests {
     use crate::{state::update_config, tests::config_mock::ConfigMockBuilder};
     use serial_test::serial;
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_get_supported_tokens_empty_list() {
@@ -42,6 +43,7 @@ mod tests {
         );
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_get_supported_tokens_contains_expected_tokens() {

--- a/crates/lib/src/rpc_server/method/get_version.rs
+++ b/crates/lib/src/rpc_server/method/get_version.rs
@@ -15,6 +15,7 @@ pub async fn get_version() -> Result<GetVersionResponse, KoraError> {
 mod tests {
     use super::*;
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_get_version_success() {
         let result = get_version().await;

--- a/crates/lib/src/rpc_server/method/sign_and_send_bundle.rs
+++ b/crates/lib/src/rpc_server/method/sign_and_send_bundle.rs
@@ -165,6 +165,7 @@ mod tests {
     use solana_sdk::pubkey::Pubkey;
     use solana_system_interface::instruction::transfer;
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_sign_and_send_bundle_empty_bundle() {
         let _m = ConfigMockBuilder::new().with_bundle_enabled(true).build_and_setup();
@@ -187,6 +188,7 @@ mod tests {
         assert!(matches!(err, KoraError::InvalidTransaction(_)));
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_sign_and_send_bundle_disabled() {
         let _m = ConfigMockBuilder::new().with_bundle_enabled(false).build_and_setup();
@@ -212,6 +214,7 @@ mod tests {
         }
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_sign_and_send_bundle_too_large() {
         let _m = ConfigMockBuilder::new().with_bundle_enabled(true).build_and_setup();
@@ -237,6 +240,7 @@ mod tests {
         }
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_sign_and_send_bundle_invalid_signer_key() {
         let _m = ConfigMockBuilder::new().with_bundle_enabled(true).build_and_setup();
@@ -259,6 +263,7 @@ mod tests {
         assert!(matches!(err, KoraError::ValidationError(_)));
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_sign_and_send_bundle_sends_full_bundle_when_sign_only_indices_set() {
         let mut server = Server::new_async().await;
@@ -351,6 +356,7 @@ mod tests {
         assert_eq!(response.signed_transactions.len(), 3);
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_sign_and_send_bundle_rejects_sequential_outflow_violation() {
         let mut server = Server::new_async().await;
@@ -419,6 +425,7 @@ mod tests {
         assert!(err.contains("exceeds maximum allowed"), "Unexpected error: {err}");
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_sign_and_send_bundle_request_deserialization() {
         let json = r#"{
@@ -436,6 +443,7 @@ mod tests {
         assert!(request.sign_only_indices.is_none());
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_sign_and_send_bundle_request_deserialization_with_sign_only_indices() {
         let json = r#"{
@@ -452,6 +460,7 @@ mod tests {
         assert_eq!(request.sign_only_indices, Some(vec![1, 2]));
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_sign_and_send_bundle_sig_verify_default() {
         // sig_verify defaults to false
@@ -478,6 +487,7 @@ mod tests {
         assert!(json.contains("bundle-uuid-12345"));
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_sign_and_send_bundle_rejects_outflow_violation_before_signing_when_sig_verify_false(
     ) {

--- a/crates/lib/src/rpc_server/method/sign_and_send_transaction.rs
+++ b/crates/lib/src/rpc_server/method/sign_and_send_transaction.rs
@@ -90,6 +90,7 @@ mod tests {
         transaction_mock::create_mock_encoded_transaction,
     };
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_sign_and_send_transaction_decode_error() {
         let _m = ConfigMockBuilder::new().build_and_setup();
@@ -111,6 +112,7 @@ mod tests {
         assert!(result.is_err(), "Should fail with decode error");
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_sign_and_send_transaction_invalid_signer_key() {
         let _m = ConfigMockBuilder::new().build_and_setup();

--- a/crates/lib/src/rpc_server/method/sign_bundle.rs
+++ b/crates/lib/src/rpc_server/method/sign_bundle.rs
@@ -153,6 +153,7 @@ mod tests {
     use solana_sdk::pubkey::Pubkey;
     use solana_system_interface::instruction::transfer;
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_sign_bundle_empty_bundle() {
         let _m = ConfigMockBuilder::new().with_bundle_enabled(true).build_and_setup();
@@ -175,6 +176,7 @@ mod tests {
         assert!(matches!(err, KoraError::InvalidTransaction(_)));
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_sign_bundle_disabled() {
         let _m = ConfigMockBuilder::new().with_bundle_enabled(false).build_and_setup();
@@ -200,6 +202,7 @@ mod tests {
         }
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_sign_bundle_too_large() {
         let _m = ConfigMockBuilder::new().with_bundle_enabled(true).build_and_setup();
@@ -225,6 +228,7 @@ mod tests {
         }
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_sign_bundle_invalid_signer_key() {
         let _m = ConfigMockBuilder::new().with_bundle_enabled(true).build_and_setup();
@@ -247,6 +251,7 @@ mod tests {
         assert!(matches!(err, KoraError::ValidationError(_)));
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_sign_bundle_exactly_max_size() {
         let mut validation = ValidationConfigBuilder::new()
@@ -297,6 +302,7 @@ mod tests {
         assert!(!response.signer_pubkey.is_empty());
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_sign_bundle_single_transaction() {
         let mut validation = ValidationConfigBuilder::new()
@@ -342,6 +348,7 @@ mod tests {
         assert!(!response.signer_pubkey.is_empty());
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_sign_bundle_sig_verify_default() {
         // Test that sig_verify defaults correctly via serde (defaults to false)
@@ -352,6 +359,7 @@ mod tests {
         assert!(request.signer_key.is_none());
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_sign_bundle_request_deserialization() {
         let json = r#"{
@@ -369,6 +377,7 @@ mod tests {
         assert!(request.sign_only_indices.is_none());
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_sign_bundle_request_deserialization_with_sign_only_indices() {
         let json = r#"{
@@ -385,6 +394,7 @@ mod tests {
         assert_eq!(request.sign_only_indices, Some(vec![0, 2]));
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_sign_bundle_rejects_sequential_outflow_violation() {
         let mut server = Server::new_async().await;
@@ -453,6 +463,7 @@ mod tests {
         assert!(err.contains("exceeds maximum allowed"), "Unexpected error: {err}");
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_sign_bundle_rejects_outflow_violation_before_signing_when_sig_verify_false() {
         // When sig_verify = false (default), simulation runs BEFORE signing.

--- a/crates/lib/src/rpc_server/method/sign_transaction.rs
+++ b/crates/lib/src/rpc_server/method/sign_transaction.rs
@@ -120,6 +120,7 @@ mod tests {
         TransactionUtil::encode_versioned_transaction(&transaction).unwrap()
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_sign_transaction_decode_error() {
         let _m = ConfigMockBuilder::new().build_and_setup();
@@ -141,6 +142,7 @@ mod tests {
         assert!(result.is_err(), "Should fail with decode error");
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_sign_transaction_invalid_signer_key() {
         let _m = ConfigMockBuilder::new().build_and_setup();
@@ -164,6 +166,7 @@ mod tests {
         assert!(matches!(error, KoraError::ValidationError(_)), "Should return ValidationError");
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_sign_transaction_pre_sign_validation_error_does_not_pin_probe_lock() {

--- a/crates/lib/src/rpc_server/method/transfer_transaction.rs
+++ b/crates/lib/src/rpc_server/method/transfer_transaction.rs
@@ -179,6 +179,7 @@ mod tests {
     use serial_test::serial;
     use std::str::FromStr;
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[allow(deprecated)]
     async fn test_transfer_transaction_invalid_source() {
@@ -208,6 +209,7 @@ mod tests {
         }
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[allow(deprecated)]
     async fn test_transfer_transaction_invalid_destination() {
@@ -236,6 +238,7 @@ mod tests {
         }
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[allow(deprecated)]
     async fn test_transfer_transaction_invalid_token() {
@@ -264,6 +267,7 @@ mod tests {
         }
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[allow(deprecated)]
     async fn test_transfer_transaction_account_not_found_preserved() {
@@ -281,6 +285,7 @@ mod tests {
         assert!(matches!(mapped_error.unwrap_err(), KoraError::AccountNotFound(_)));
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[allow(deprecated)]
     async fn test_transfer_transaction_rpc_error_preserved() {
@@ -302,6 +307,7 @@ mod tests {
         }
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     #[allow(deprecated)]

--- a/crates/lib/src/rpc_server/middleware_utils.rs
+++ b/crates/lib/src/rpc_server/middleware_utils.rs
@@ -162,6 +162,7 @@ mod tests {
         }
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_method_validation_disallowed_method() {
         let allowed_methods = vec!["liveness".to_string(), "getConfig".to_string()];
@@ -176,6 +177,7 @@ mod tests {
         assert_eq!(response.status(), StatusCode::METHOD_NOT_ALLOWED);
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_method_validation_malformed_json() {
         let allowed_methods = vec!["liveness".to_string(), "getConfig".to_string()];
@@ -190,6 +192,7 @@ mod tests {
         assert_eq!(response.status(), StatusCode::METHOD_NOT_ALLOWED);
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_method_validation_missing_method_field() {
         let allowed_methods = vec!["liveness".to_string(), "getConfig".to_string()];
@@ -204,6 +207,7 @@ mod tests {
         assert_eq!(response.status(), StatusCode::METHOD_NOT_ALLOWED);
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_method_validation_multiple_allowed_methods() {
         let allowed_methods = vec![

--- a/crates/lib/src/rpc_server/recaptcha.rs
+++ b/crates/lib/src/rpc_server/recaptcha.rs
@@ -113,6 +113,7 @@ mod tests {
         )
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_recaptcha_layer_bypasses_unprotected_method() {
         let config = test_recaptcha_config();
@@ -127,6 +128,7 @@ mod tests {
         assert_eq!(response.status(), StatusCode::OK);
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_recaptcha_layer_rejects_protected_method_missing_token() {
         let config = test_recaptcha_config();
@@ -141,6 +143,7 @@ mod tests {
         assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_recaptcha_layer_rejects_sign_and_send_missing_token() {
         let config = test_recaptcha_config();
@@ -155,6 +158,7 @@ mod tests {
         assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_recaptcha_layer_rejects_empty_token() {
         let config = test_recaptcha_config();

--- a/crates/lib/src/rpc_server/rpc.rs
+++ b/crates/lib/src/rpc_server/rpc.rs
@@ -252,6 +252,7 @@ mod tests {
         KoraRpc::new(rpc_client)
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_liveness() {
         let kora_rpc = create_test_kora_rpc();
@@ -261,6 +262,7 @@ mod tests {
         assert!(result.is_ok());
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_get_version() {
         let kora_rpc = create_test_kora_rpc();
@@ -272,6 +274,7 @@ mod tests {
         assert_eq!(response.version, env!("CARGO_PKG_VERSION"));
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_method_delegation_with_mocks() {
         // Setup test environment with both config and signer

--- a/crates/lib/src/signer/bundle_signer.rs
+++ b/crates/lib/src/signer/bundle_signer.rs
@@ -137,6 +137,7 @@ mod tests {
         VersionedTransactionResolved::from_kora_built_transaction(&versioned).unwrap()
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_sign_transaction_for_bundle_success() {
@@ -162,6 +163,7 @@ mod tests {
         assert!(!resolved.transaction.signatures[0].to_string().is_empty());
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_sign_transaction_for_bundle_invalid_fee_payer() {
@@ -187,6 +189,7 @@ mod tests {
         assert!(matches!(result.unwrap_err(), KoraError::InvalidTransaction(_)));
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_sign_transaction_for_bundle_rejects_unsigned_fee_payer_occurrence() {
@@ -211,6 +214,7 @@ mod tests {
         assert!(matches!(result.unwrap_err(), KoraError::InvalidTransaction(_)));
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_sign_transaction_for_bundle_signature_position() {
@@ -240,6 +244,7 @@ mod tests {
         assert_ne!(resolved.transaction.signatures[0], original_sig);
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_sign_transaction_for_bundle_verifies_signature() {

--- a/crates/lib/src/signer/init.rs
+++ b/crates/lib/src/signer/init.rs
@@ -40,6 +40,7 @@ mod tests {
     };
     use std::path::PathBuf;
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_init_signers_skip_signer() {
         let _m = ConfigMockBuilder::new().build_and_setup();
@@ -56,6 +57,7 @@ mod tests {
         assert!(result.is_ok());
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_init_signers_no_config_no_skip() {
         let _m = ConfigMockBuilder::new().build_and_setup();
@@ -73,6 +75,7 @@ mod tests {
         assert!(matches!(result.unwrap_err(), KoraError::ValidationError(_)));
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_init_signers_with_invalid_config_path() {
         let _m = ConfigMockBuilder::new().build_and_setup();

--- a/crates/lib/src/signer/pool.rs
+++ b/crates/lib/src/signer/pool.rs
@@ -618,6 +618,7 @@ mod tests {
         assert!(selections.values().all(|&count| count == 50));
     }
 
+    #[cfg_attr(miri, ignore)]
     #[test]
     fn test_weighted_selection() {
         let mut pool = create_test_pool();

--- a/crates/lib/src/token/token.rs
+++ b/crates/lib/src/token/token.rs
@@ -1112,6 +1112,7 @@ mod tests_token {
         assert!(matches!(result.unwrap_err(), KoraError::ValidationError(_)));
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_get_mint_valid() {
         // Any valid mint account (valid owner and valid data) will count as valid here. (not related to allowed mint in Kora's config)
@@ -1126,6 +1127,7 @@ mod tests_token {
         assert_eq!(mint_data.decimals(), 9);
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_get_mint_account_not_found() {
         let _lock = ConfigMockBuilder::new().build_and_setup();
@@ -1137,6 +1139,7 @@ mod tests_token {
         assert!(result.is_err());
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_get_mint_decimals_valid() {
         let _lock = ConfigMockBuilder::new().build_and_setup();
@@ -1149,6 +1152,7 @@ mod tests_token {
         assert_eq!(result.unwrap(), 6);
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_get_token_price_and_decimals_spl() {
         let _lock = ConfigMockBuilder::new().build_and_setup();
@@ -1163,6 +1167,7 @@ mod tests_token {
         assert_eq!(token_price.price, Decimal::from(1));
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_get_token_price_and_decimals_token2022() {
         let _lock = ConfigMockBuilder::new().build_and_setup();
@@ -1177,6 +1182,7 @@ mod tests_token {
         assert_eq!(token_price.price, dec!(0.0075));
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_get_token_price_and_decimals_account_not_found() {
         let _lock = ConfigMockBuilder::new().build_and_setup();
@@ -1210,6 +1216,7 @@ mod tests_token {
         assert!(err.is_err());
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_calculate_token_value_in_lamports_sol() {
         let _lock = ConfigMockBuilder::new().build_and_setup();
@@ -1226,6 +1233,7 @@ mod tests_token {
         assert_eq!(result, 1_000_000_000); // Should equal input since SOL price is 1.0
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_calculate_token_value_in_lamports_usdc() {
         let _lock = ConfigMockBuilder::new().build_and_setup();
@@ -1243,6 +1251,7 @@ mod tests_token {
         assert_eq!(result, 7_500_000);
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_calculate_token_value_in_lamports_zero_amount() {
         let _lock = ConfigMockBuilder::new().build_and_setup();
@@ -1259,6 +1268,7 @@ mod tests_token {
         assert_eq!(result, 0);
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_calculate_token_value_in_lamports_small_amount() {
         let _lock = ConfigMockBuilder::new().build_and_setup();
@@ -1276,6 +1286,7 @@ mod tests_token {
         assert_eq!(result, 7);
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_calculate_lamports_value_in_token_sol() {
         let _lock = ConfigMockBuilder::new().build_and_setup();
@@ -1292,6 +1303,7 @@ mod tests_token {
         assert_eq!(result, 1_000_000_000); // Should equal input since SOL price is 1.0
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_calculate_lamports_value_in_token_usdc() {
         let _lock = ConfigMockBuilder::new().build_and_setup();
@@ -1309,6 +1321,7 @@ mod tests_token {
         assert_eq!(result, 1_000_000);
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_calculate_lamports_value_in_token_zero_lamports() {
         let _lock = ConfigMockBuilder::new().build_and_setup();
@@ -1325,6 +1338,7 @@ mod tests_token {
         assert_eq!(result, 0);
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_calculate_price_functions_consistency() {
         let _lock = ConfigMockBuilder::new().build_and_setup();
@@ -1361,6 +1375,7 @@ mod tests_token {
         }
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_calculate_spl_transfers_value_in_lamports_ignores_inflows() {
         let _lock = ConfigMockBuilder::new().with_cache_enabled(false).build_and_setup();
@@ -1415,6 +1430,7 @@ mod tests_token {
         assert_eq!(spl_outflow_value, 750_000_000);
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_calculate_spl_transfers_value_in_lamports_token2022_outflow_remains_gross() {
         let _lock = ConfigMockBuilder::new().with_cache_enabled(false).build_and_setup();
@@ -1450,6 +1466,7 @@ mod tests_token {
         assert_eq!(spl_outflow_value, 750_000_000);
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_price_calculation_with_account_error() {
         let _lock = ConfigMockBuilder::new().build_and_setup();
@@ -1464,6 +1481,7 @@ mod tests_token {
         assert!(result.is_err());
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_lamports_calculation_with_account_error() {
         let _lock = ConfigMockBuilder::new().build_and_setup();
@@ -1478,6 +1496,7 @@ mod tests_token {
         assert!(result.is_err());
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_calculate_lamports_value_in_token_decimal_precision() {
         let _lock = ConfigMockBuilder::new().build_and_setup();
@@ -1522,6 +1541,7 @@ mod tests_token {
         }
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_validate_token2022_extensions_for_payment_rpc_error() {
         let _lock = ConfigMockBuilder::new().build_and_setup();
@@ -1545,6 +1565,7 @@ mod tests_token {
         assert!(result.is_err());
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_validate_token2022_extensions_for_payment_allows_mutable_transfer_hook_authority()
     {
@@ -1584,6 +1605,7 @@ mod tests_token {
         assert!(result.is_ok());
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_validate_token2022_extensions_for_payment_allows_immutable_transfer_hook_authority(
     ) {
@@ -1623,6 +1645,7 @@ mod tests_token {
         assert!(result.is_ok());
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_validate_token2022_partial_for_ata_creation_allows_mutable_transfer_hook_authority(
     ) {
@@ -1655,6 +1678,7 @@ mod tests_token {
         assert!(result.is_ok());
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_validate_token2022_extensions_for_payment_no_mint_provided() {
         let _lock = ConfigMockBuilder::new().build_and_setup();
@@ -1685,6 +1709,7 @@ mod tests_token {
         assert!(!error_msg.contains("Blocked account extension found on source account"));
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_calculate_payment_lamport_totals_validates_token2022_when_both_sides_match_expected_owner(
     ) {

--- a/crates/lib/src/transaction/retry_util.rs
+++ b/crates/lib/src/transaction/retry_util.rs
@@ -119,6 +119,7 @@ mod tests {
         assert_eq!(signing_retry_window(Duration::from_secs(15), 5), Duration::from_millis(93_100));
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_sign_with_retry_succeeds_after_retries() {
         let calls = Arc::new(AtomicUsize::new(0));
@@ -140,6 +141,7 @@ mod tests {
         assert_eq!(calls.load(Ordering::Relaxed), 3);
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_sign_with_retry_returns_last_error_after_exhaustion() {
         let result = sign_with_retry(Duration::from_secs(1), 1, "signing", "Signing", || async {

--- a/crates/lib/src/transaction/versioned_transaction.rs
+++ b/crates/lib/src/transaction/versioned_transaction.rs
@@ -935,6 +935,7 @@ mod tests {
         assert_eq!(resolved.all_instructions[0].data, vec![1, 2, 3]);
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_from_transaction_legacy() {
         let config = setup_test_config();
@@ -995,6 +996,7 @@ mod tests {
         );
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_from_transaction_v0_with_lookup_tables() {
         let config = setup_test_config();
@@ -1093,6 +1095,7 @@ mod tests {
         assert_eq!(resolved.all_account_keys[2], resolved_address);
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_from_transaction_simulation_failure() {
         let config = setup_test_config();
@@ -1147,6 +1150,7 @@ mod tests {
         }
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_fetch_inner_instructions_with_inner_instructions() {
         let config = setup_test_config();
@@ -1200,6 +1204,7 @@ mod tests {
         assert_eq!(inner_instructions[0].data, vec![10, 20, 30]);
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_fetch_inner_instructions_with_sig_verify_false() {
         let config = setup_test_config();
@@ -1253,6 +1258,7 @@ mod tests {
         assert_eq!(inner_instructions[0].data, vec![10, 20, 30]);
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_get_or_parse_system_instructions() {
         let config = setup_test_config();
@@ -1288,6 +1294,7 @@ mod tests {
         );
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_resolve_lookup_table_addresses() {
         let config = setup_test_config();
@@ -1338,6 +1345,7 @@ mod tests {
         assert_eq!(resolved_addresses[2], address2);
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_resolve_lookup_table_addresses_empty() {
         let config = setup_test_config();
@@ -1354,6 +1362,7 @@ mod tests {
         assert_eq!(resolved_addresses.len(), 0);
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_resolve_lookup_table_addresses_account_not_found() {
         let config = setup_test_config();
@@ -1375,6 +1384,7 @@ mod tests {
         }
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_resolve_lookup_table_addresses_invalid_index() {
         let config = setup_test_config();
@@ -1422,6 +1432,7 @@ mod tests {
         }
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_resolve_lookup_table_addresses_invalid_readonly_index() {
         let config = setup_test_config();

--- a/crates/lib/src/usage_limit/usage_store.rs
+++ b/crates/lib/src/usage_limit/usage_store.rs
@@ -251,6 +251,7 @@ impl UsageStore for ErrorUsageStore {
 mod tests {
     use super::*;
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_in_memory_usage_store() {
         let store = InMemoryUsageStore::new();

--- a/crates/lib/src/usage_limit/usage_tracker.rs
+++ b/crates/lib/src/usage_limit/usage_tracker.rs
@@ -516,6 +516,7 @@ mod tests {
         UsageTracker::new(true, store, rules, HashSet::new(), false)
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_usage_limit_enforcement() {
         let tracker = create_test_tracker(2);
@@ -564,6 +565,7 @@ mod tests {
         ));
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_independent_user_limits() {
         let tracker = create_test_tracker(2);
@@ -642,6 +644,7 @@ mod tests {
         ));
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_unlimited_usage() {
         let store = Arc::new(InMemoryUsageStore::new());
@@ -672,6 +675,7 @@ mod tests {
         }
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_multiple_rules() {
         let store: Arc<dyn UsageStore> = Arc::new(InMemoryUsageStore::new());
@@ -733,6 +737,7 @@ mod tests {
         ));
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_usage_limiter_disabled_fallback() {
         // Test that when usage limiting is disabled, transactions are allowed
@@ -760,6 +765,7 @@ mod tests {
         assert!(result.is_ok());
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_usage_limiter_fallback_allowed() {
         let _m = ConfigMockBuilder::new()
@@ -786,6 +792,7 @@ mod tests {
         assert!(result.is_ok());
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_usage_limiter_fallback_denied() {
         let _m = ConfigMockBuilder::new()
@@ -877,6 +884,7 @@ mod tests {
         VersionedTransactionResolved::from_kora_built_transaction(&tx).unwrap()
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_extract_user_unsigned_owner_returns_none() {
         let store = Arc::new(InMemoryUsageStore::new());
@@ -911,6 +919,7 @@ mod tests {
         assert_eq!(result, None);
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_extract_user_signed_owner_returns_owner() {
         let store = Arc::new(InMemoryUsageStore::new());
@@ -945,6 +954,7 @@ mod tests {
         assert_eq!(result, Some(owner.pubkey()));
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_extract_user_multisig_owner_returns_owner_when_threshold_is_met() {
         let store = Arc::new(InMemoryUsageStore::new());
@@ -987,6 +997,7 @@ mod tests {
         assert_eq!(result, Some(multisig_owner));
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_extract_user_multisig_owner_returns_none_when_threshold_is_not_met() {
         let store = Arc::new(InMemoryUsageStore::new());

--- a/crates/lib/src/validator/account_validator.rs
+++ b/crates/lib/src/validator/account_validator.rs
@@ -358,6 +358,7 @@ mod tests {
             .contains("has invalid data for a TokenAccount account"));
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_validate_account_success_with_type() {
         let _m = ConfigMockBuilder::new().with_cache_enabled(false).build_and_setup();
@@ -372,6 +373,7 @@ mod tests {
         assert!(result.is_ok());
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_validate_account_success_without_type() {
         let _m = ConfigMockBuilder::new().with_cache_enabled(false).build_and_setup();
@@ -385,6 +387,7 @@ mod tests {
         assert!(result.is_ok());
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_validate_account_rpc_error() {
         let _m = ConfigMockBuilder::new().with_cache_enabled(false).build_and_setup();
@@ -401,6 +404,7 @@ mod tests {
         assert!(error_msg.contains("Account") && error_msg.contains("not found"));
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_validate_account_type_validation_failure() {
         let _m = ConfigMockBuilder::new().with_cache_enabled(false).build_and_setup();

--- a/crates/lib/src/validator/bundle_validator.rs
+++ b/crates/lib/src/validator/bundle_validator.rs
@@ -439,6 +439,7 @@ mod tests {
         assert!(programs.contains(&Pubkey::from_str(token_program).unwrap()));
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_validate_simulation_policy_rejects_disallowed_program() {
         let fee_payer = Pubkey::new_unique();
@@ -476,6 +477,7 @@ mod tests {
         assert!(err.contains("disallowed"));
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_validate_simulation_policy_wildcard_accepts_arbitrary_program() {
         let fee_payer = Pubkey::new_unique();
@@ -577,6 +579,7 @@ mod tests {
         assert!(err.contains("exceeds maximum allowed"));
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_validate_simulation_policy_accepts_outflow_within_limit() {
         let fee_payer = Pubkey::new_unique();
@@ -609,6 +612,7 @@ mod tests {
         assert!(result.is_ok());
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     async fn test_validate_simulation_policy_requires_per_tx_results() {
         let fee_payer = Pubkey::new_unique();

--- a/crates/lib/src/validator/cache_validator.rs
+++ b/crates/lib/src/validator/cache_validator.rs
@@ -123,6 +123,7 @@ mod tests {
     use crate::tests::config_mock::ConfigMockBuilder;
     use serial_test::serial;
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_validate_usage_limit_disabled() {
@@ -134,6 +135,7 @@ mod tests {
         assert!(warnings.is_empty());
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_validate_usage_limit_enabled_no_cache_url_fallback_enabled() {
@@ -151,6 +153,7 @@ mod tests {
         ));
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_validate_usage_limit_enabled_no_cache_url_fallback_disabled() {
@@ -173,6 +176,7 @@ mod tests {
         )));
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_validate_usage_limit_invalid_cache_url_format() {
@@ -193,6 +197,7 @@ mod tests {
         )));
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_validate_usage_limit_fallback_disabled_warning() {
@@ -215,6 +220,7 @@ mod tests {
         )));
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_validate_usage_limit_valid_redis_url() {
@@ -235,6 +241,7 @@ mod tests {
     }
 
     // Cache disabled — should skip all validation and return no errors
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_validate_rpc_cache_disabled() {
@@ -252,6 +259,7 @@ mod tests {
     }
 
     // Cache enabled but Redis URL missing — should return a config error
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_validate_rpc_cache_enabled_no_url() {
@@ -265,6 +273,7 @@ mod tests {
     }
 
     // Cache enabled but URL is not redis:// or rediss:// — should return format error
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_validate_rpc_cache_invalid_url_format() {
@@ -282,6 +291,7 @@ mod tests {
     }
 
     // Cache enabled, valid URL format but Redis unreachable — should return connection error
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_validate_rpc_cache_connection_failed() {

--- a/crates/lib/src/validator/config_validator.rs
+++ b/crates/lib/src/validator/config_validator.rs
@@ -1104,6 +1104,7 @@ mod tests {
 
     use super::*;
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_validate_config() {
@@ -1145,6 +1146,7 @@ mod tests {
         assert!(matches!(result.unwrap_err(), KoraError::InternalServerError(_)));
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_validate_with_result_successful_config() {
@@ -1192,6 +1194,7 @@ mod tests {
         assert!(warnings.iter().any(|w| w.contains("No authentication configured")));
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_validate_with_result_warns_for_unblocked_permanent_delegate_when_token2022_enabled(
@@ -1238,6 +1241,7 @@ mod tests {
         assert!(warnings.iter().any(|w| w.contains("No authentication configured")));
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_validate_with_result_no_permanent_delegate_warning_when_blocked() {
@@ -1287,6 +1291,7 @@ mod tests {
         assert!(warnings.iter().any(|w| w.contains("No authentication configured")));
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_validate_with_result_warnings() {
@@ -1360,6 +1365,7 @@ mod tests {
         assert!(warnings.iter().any(|w| w.contains("No allowed programs configured")));
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_validate_with_result_duplicate_plugins_warn() {
@@ -1378,6 +1384,7 @@ mod tests {
         assert!(warnings.iter().any(|w| w.contains("Duplicate transaction plugin configured")));
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_gas_swap_plugin_requires_system_program() {
@@ -1398,6 +1405,7 @@ mod tests {
             .any(|e| e.contains("GasSwap plugin requires System Program")));
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_gas_swap_plugin_requires_token_program() {
@@ -1418,6 +1426,7 @@ mod tests {
             .any(|e| e.contains("GasSwap plugin requires at least one token program")));
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_gas_swap_plugin_requires_allowed_tokens() {
@@ -1437,6 +1446,7 @@ mod tests {
             .any(|e| e.contains("GasSwap plugin requires at least one token in allowed_tokens")));
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_gas_swap_plugin_rejects_free_pricing() {
@@ -1456,6 +1466,7 @@ mod tests {
             .any(|e| e.contains("GasSwap plugin cannot be used with Free pricing")));
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_validate_with_result_empty_allowed_tokens_ok_when_free() {
@@ -1496,6 +1507,7 @@ mod tests {
         assert!(!warnings.iter().any(|w| w.contains("No allowed tokens configured")));
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_validate_with_result_empty_allowed_tokens_errors_when_fees_required() {
@@ -1537,6 +1549,7 @@ mod tests {
         assert!(errors.iter().any(|e| e.contains("No allowed tokens configured")));
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_validate_with_result_missing_system_program_warning() {
@@ -1580,6 +1593,7 @@ mod tests {
         assert!(warnings.iter().any(|w| w.contains("Missing Token Program in allowed programs")));
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_validate_with_result_invalid_must_call_program_pubkey() {
@@ -1599,6 +1613,7 @@ mod tests {
             .any(|e| e.contains("Invalid base58 pubkey format in require_one_of_programs")));
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_validate_with_result_must_call_program_not_in_allowed_programs() {
@@ -1620,6 +1635,7 @@ mod tests {
         }));
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_validate_with_result_require_one_of_programs_allows_compute_budget_program() {
@@ -1640,6 +1656,7 @@ mod tests {
         assert!(result.is_ok());
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_validate_with_result_valid_require_one_of_programs() {
@@ -1654,6 +1671,7 @@ mod tests {
         assert!(result.is_ok());
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_validate_with_result_errors() {
@@ -1699,6 +1717,7 @@ mod tests {
         assert!(errors.iter().any(|e| e.contains("Margin cannot be negative")));
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_validate_with_result_fixed_price_errors() {
@@ -1745,6 +1764,7 @@ mod tests {
         assert!(errors.iter().any(|e| e.contains("Invalid token address for fixed price")));
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_validate_with_result_fixed_price_not_in_allowed_tokens() {
@@ -1796,6 +1816,7 @@ mod tests {
         );
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_validate_with_result_fixed_price_zero_amount_warning() {
@@ -1848,6 +1869,7 @@ mod tests {
             .any(|w| w.contains("Fixed price amount is 0 - transactions will be free")));
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_validate_with_result_fee_validation_errors() {
@@ -1889,6 +1911,7 @@ mod tests {
             .any(|e| e.contains("When fees are enabled, allowed_spl_paid_tokens cannot be empty")));
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_validate_with_result_fee_and_any_spl_token_allowed() {
@@ -1931,6 +1954,7 @@ mod tests {
         assert!(warnings.iter().any(|w| w.contains("volatility risk")));
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_validate_with_result_paid_tokens_not_in_allowed_tokens() {
@@ -2023,6 +2047,7 @@ mod tests {
         }
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_validate_with_result_rpc_validation_valid_program() {
@@ -2045,6 +2070,7 @@ mod tests {
         assert!(!errors.iter().any(|e| e.contains("Program") && e.contains("validation failed")));
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_validate_with_result_rpc_validation_valid_token_mint() {
@@ -2065,6 +2091,7 @@ mod tests {
         assert!(warnings.iter().any(|w| w.contains("No allowed programs configured")));
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_validate_with_result_rpc_validation_non_executable_program_fails() {
@@ -2102,6 +2129,7 @@ mod tests {
         assert!(errors.iter().any(|e| e.contains("Program") && e.contains("validation failed")));
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_validate_with_result_rpc_validation_account_not_found_fails() {
@@ -2138,6 +2166,7 @@ mod tests {
         assert!(errors.len() >= 2, "Should have validation errors for programs and tokens");
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_validate_with_result_skip_rpc_validation() {
@@ -2174,6 +2203,7 @@ mod tests {
         assert!(result.is_ok()); // Should pass because RPC validation is skipped
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_validate_with_result_valid_token2022_extensions() {
@@ -2217,6 +2247,7 @@ mod tests {
         assert!(result.is_ok());
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_validate_with_result_invalid_token2022_mint_extension() {
@@ -2259,6 +2290,7 @@ mod tests {
             && e.contains("Invalid mint extension name: 'invalid_mint_extension'")));
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_validate_with_result_invalid_token2022_account_extension() {
@@ -2374,6 +2406,7 @@ mod tests {
             .any(|w| w.contains("transfer_hook_policy is 'deny_mutable_for_delayed_signing'")));
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_validate_with_result_fee_payer_policy_warnings() {
@@ -2665,6 +2698,7 @@ mod tests {
         }
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_check_token_mint_extensions_permanent_delegate() {
@@ -2691,6 +2725,7 @@ mod tests {
         assert!(warnings[0].contains("permanent delegate can transfer or burn tokens"));
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_check_token_mint_extensions_transfer_hook() {
@@ -2717,6 +2752,7 @@ mod tests {
         assert!(warnings[0].contains("custom program executes on every transfer"));
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_check_token_mint_extensions_both() {
@@ -2744,6 +2780,7 @@ mod tests {
         assert!(warnings.iter().any(|w| w.contains("TransferHook extension")));
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_check_token_mint_extensions_no_risky_extensions() {
@@ -2766,6 +2803,7 @@ mod tests {
         assert_eq!(warnings.len(), 0);
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_durable_transactions_warning_when_enabled() {
@@ -2808,6 +2846,7 @@ mod tests {
         assert!(warnings.iter().any(|w| w.contains("hold signed transactions indefinitely")));
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_durable_transactions_no_warning_when_disabled() {
@@ -2849,6 +2888,7 @@ mod tests {
         assert!(!warnings.iter().any(|w| w.contains("allow_durable_transactions")));
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_jupiter_price_source_requires_api_key() {
@@ -2894,6 +2934,7 @@ mod tests {
         assert!(errors.iter().any(|e| e.contains("price_source = Jupiter")));
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_lighthouse_enabled_not_in_allowed_programs_error() {
@@ -2943,6 +2984,7 @@ mod tests {
                 && e.contains("is not in allowed_programs")));
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_lighthouse_enabled_in_disallowed_accounts_error() {
@@ -2993,6 +3035,7 @@ mod tests {
                 && e.contains("is in disallowed_accounts")));
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_lighthouse_disabled_no_validation() {
@@ -3041,6 +3084,7 @@ mod tests {
         assert!(!warnings.iter().any(|w| w.contains("Lighthouse")));
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_validate_sign_timeout_zero() {

--- a/crates/lib/src/validator/transaction_validator.rs
+++ b/crates/lib/src/validator/transaction_validator.rs
@@ -1042,6 +1042,7 @@ mod tests {
         setup_both_configs(config);
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_validate_transaction() {
@@ -1065,6 +1066,7 @@ mod tests {
             .is_ok());
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_transfer_amount_limits() {
@@ -1100,6 +1102,7 @@ mod tests {
             .is_ok());
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_validate_programs() {
@@ -1139,6 +1142,7 @@ mod tests {
             .is_err());
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_validate_programs_wildcard_sentinel() {
@@ -1189,6 +1193,7 @@ mod tests {
             .is_ok());
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_validate_require_one_of_programs_only_cu_blocked() {
@@ -1217,6 +1222,7 @@ mod tests {
             .is_err());
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_validate_require_one_of_programs_required_program_called() {
@@ -1249,6 +1255,7 @@ mod tests {
             .is_ok());
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_validate_require_one_of_programs_no_required_program_fails() {
@@ -1278,6 +1285,7 @@ mod tests {
             .is_err());
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_validate_require_one_of_programs_or_semantics() {
@@ -1308,6 +1316,7 @@ mod tests {
             .is_ok());
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_validate_signatures() {
@@ -1343,6 +1352,7 @@ mod tests {
             .is_err());
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_sign_and_send_transaction_mode() {
@@ -1376,6 +1386,7 @@ mod tests {
             .is_ok());
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_empty_transaction() {
@@ -1396,6 +1407,7 @@ mod tests {
             .is_err());
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_reject_compute_budget_only_transaction() {
@@ -1424,6 +1436,7 @@ mod tests {
         assert!(error_message.contains("only ComputeBudget instructions"));
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_allow_transaction_with_compute_budget_and_non_compute_instruction() {
@@ -1460,6 +1473,7 @@ mod tests {
             .is_ok());
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_disallowed_accounts() {
@@ -1492,6 +1506,7 @@ mod tests {
             .is_err());
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_disallowed_instruction_data_spl_set_authority_new_authority() {
@@ -1528,6 +1543,7 @@ mod tests {
         assert!(result.is_err());
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_disallowed_instruction_data_token2022_set_authority_new_authority() {
@@ -1564,6 +1580,7 @@ mod tests {
         assert!(result.is_err());
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_disallowed_instruction_data_nonce_authorize_new_authority() {
@@ -1594,6 +1611,7 @@ mod tests {
         assert!(result.is_err());
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_disallowed_instruction_data_nonce_initialize_nonce_authority() {
@@ -1627,6 +1645,7 @@ mod tests {
         assert!(result.is_err());
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_disallowed_instruction_data_spl_initialize_account2_owner() {
@@ -1662,6 +1681,7 @@ mod tests {
         assert!(result.is_err());
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_disallowed_instruction_data_spl_initialize_mint2_freeze_authority() {
@@ -1697,6 +1717,7 @@ mod tests {
         assert!(result.is_err());
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_fee_payer_policy_sol_transfers() {
@@ -1741,6 +1762,7 @@ mod tests {
             .is_err());
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_fee_payer_policy_assign() {
@@ -1788,6 +1810,7 @@ mod tests {
             .is_err());
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_fee_payer_policy_spl_transfers() {
@@ -1881,6 +1904,7 @@ mod tests {
             .is_ok());
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_fee_payer_policy_token2022_transfers() {
@@ -1980,6 +2004,7 @@ mod tests {
             .is_ok());
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_fee_payer_policy_alt_freeze_lookup_table() {
@@ -2035,6 +2060,7 @@ mod tests {
             .is_ok());
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_fee_payer_policy_alt_create_lookup_table() {
@@ -2080,6 +2106,7 @@ mod tests {
             .is_ok());
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_fee_payer_policy_alt_extend_lookup_table() {
@@ -2173,6 +2200,7 @@ mod tests {
             .is_ok());
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_fee_payer_policy_alt_deactivate_lookup_table() {
@@ -2228,6 +2256,7 @@ mod tests {
             .is_ok());
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_fee_payer_policy_alt_close_lookup_table() {
@@ -2289,6 +2318,7 @@ mod tests {
             .is_ok());
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_validate_transfer_amounts_rejects_alt_close_outflow_above_max_allowed_lamports() {
@@ -2327,6 +2357,7 @@ mod tests {
         ));
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_validate_transfer_amounts_allows_alt_close_to_fee_payer() {
@@ -2362,6 +2393,7 @@ mod tests {
             .is_ok());
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_calculate_total_outflow() {
@@ -2532,6 +2564,7 @@ mod tests {
         );
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_fee_payer_policy_burn() {
@@ -2621,6 +2654,7 @@ mod tests {
             .is_err());
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_fee_payer_policy_close_account() {
@@ -2685,6 +2719,7 @@ mod tests {
             .is_err());
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_fee_payer_policy_approve() {
@@ -2776,6 +2811,7 @@ mod tests {
             .is_err());
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_fee_payer_policy_token2022_burn() {
@@ -2813,6 +2849,7 @@ mod tests {
             .is_err());
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_fee_payer_policy_token2022_close_account() {
@@ -2849,6 +2886,7 @@ mod tests {
             .is_err());
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_fee_payer_policy_token2022_approve() {
@@ -2941,6 +2979,7 @@ mod tests {
             .is_err());
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_fee_payer_policy_create_account() {
@@ -2986,6 +3025,7 @@ mod tests {
             .is_err());
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_fee_payer_policy_create_account_rejects_disallowed_owner() {
@@ -3012,6 +3052,7 @@ mod tests {
         assert!(result.unwrap_err().to_string().contains("not in the allowed programs list"));
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_fee_payer_policy_create_account_allows_valid_owner() {
@@ -3045,6 +3086,7 @@ mod tests {
             .is_ok());
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_fee_payer_policy_ata_create_idempotent() {
@@ -3092,6 +3134,7 @@ mod tests {
         }
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_ata_create_idempotent_charged_in_outflow_without_inner_create() {
@@ -3140,6 +3183,7 @@ mod tests {
         }
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_fee_payer_policy_allocate() {
@@ -3182,6 +3226,7 @@ mod tests {
             .is_err());
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_fee_payer_policy_nonce_initialize() {
@@ -3228,6 +3273,7 @@ mod tests {
             .is_err());
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_fee_payer_policy_nonce_advance() {
@@ -3285,6 +3331,7 @@ mod tests {
             .is_err());
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_fee_payer_policy_nonce_withdraw() {
@@ -3329,6 +3376,7 @@ mod tests {
             .is_err());
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_nonce_self_withdraw_does_not_hide_excess_fee_payer_outflow() {
@@ -3371,6 +3419,7 @@ mod tests {
         }
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_fee_payer_policy_nonce_authorize() {
@@ -3548,6 +3597,7 @@ mod tests {
         }
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_durable_transaction_rejected_by_default() {
@@ -3580,6 +3630,7 @@ mod tests {
         }
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_durable_transaction_allowed_when_enabled() {
@@ -3616,6 +3667,7 @@ mod tests {
             .is_ok());
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_non_durable_transaction_passes() {
@@ -3643,6 +3695,7 @@ mod tests {
             .is_ok());
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_fee_payer_policy_revoke() {
@@ -3702,6 +3755,7 @@ mod tests {
         }
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_fee_payer_policy_token2022_revoke() {
@@ -3761,6 +3815,7 @@ mod tests {
         }
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_fee_payer_policy_set_authority() {
@@ -3825,6 +3880,7 @@ mod tests {
         }
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_fee_payer_policy_token2022_set_authority() {
@@ -3889,6 +3945,7 @@ mod tests {
         }
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_fee_payer_policy_mint_to() {
@@ -3953,6 +4010,7 @@ mod tests {
         }
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_fee_payer_policy_token2022_mint_to() {
@@ -4017,6 +4075,7 @@ mod tests {
         }
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_fee_payer_policy_initialize_mint() {
@@ -4079,6 +4138,7 @@ mod tests {
         }
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_fee_payer_policy_token2022_initialize_mint() {
@@ -4140,6 +4200,7 @@ mod tests {
         }
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_fee_payer_policy_initialize_account() {
@@ -4201,6 +4262,7 @@ mod tests {
         }
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_fee_payer_policy_token2022_initialize_account() {
@@ -4261,6 +4323,7 @@ mod tests {
         }
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_fee_payer_policy_initialize_multisig() {
@@ -4322,6 +4385,7 @@ mod tests {
         }
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_fee_payer_policy_token2022_initialize_multisig() {
@@ -4382,6 +4446,7 @@ mod tests {
         }
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_fee_payer_policy_freeze_account() {
@@ -4445,6 +4510,7 @@ mod tests {
         }
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_fee_payer_policy_token2022_freeze_account() {
@@ -4507,6 +4573,7 @@ mod tests {
         }
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_fee_payer_policy_thaw_account() {
@@ -4570,6 +4637,7 @@ mod tests {
         }
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_fee_payer_policy_token2022_thaw_account() {
@@ -4632,6 +4700,7 @@ mod tests {
         }
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_fee_payer_policy_token2022_reallocate_rejected_for_fee_payer() {
@@ -4666,6 +4735,7 @@ mod tests {
         }
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_token2022_pause_with_fee_payer_rejected() {
@@ -4696,6 +4766,7 @@ mod tests {
         );
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_token2022_resume_allowed_when_policy_explicitly_enabled() {
@@ -4725,6 +4796,7 @@ mod tests {
         assert!(result.is_ok(), "Explicit thaw opt-in should allow Token2022 Resume: {result:?}");
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_token2022_pausable_initialize_rejects_fee_payer_authority_by_default() {
@@ -4754,6 +4826,7 @@ mod tests {
         );
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_token2022_transfer_hook_update_rejected_when_policy_denies() {
@@ -4794,6 +4867,7 @@ mod tests {
         );
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_token2022_transfer_hook_update_allowed_for_immediate_send_when_policy_is_delayed_only(
@@ -4836,6 +4910,7 @@ mod tests {
         );
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_token2022_transfer_hook_initialize_disallowed_program_id_rejected() {
@@ -4872,6 +4947,7 @@ mod tests {
         );
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_token2022_initialize_transfer_fee_config_rejects_fee_payer_authorities_by_default(
@@ -4905,6 +4981,7 @@ mod tests {
         );
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_token2022_initialize_transfer_fee_config_disallowed_withdraw_authority_rejected()
@@ -4943,6 +5020,7 @@ mod tests {
         );
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_token2022_update_metadata_pointer_rejects_fee_payer_authority_by_default() {
@@ -4975,6 +5053,7 @@ mod tests {
         );
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_token2022_update_metadata_pointer_allowed_when_extension_update_policy_enabled() {
@@ -5009,6 +5088,7 @@ mod tests {
         );
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_token2022_initialize_mint_close_authority_rejects_disallowed_new_authority() {
@@ -5043,6 +5123,7 @@ mod tests {
         );
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_token2022_initialize_metadata_pointer_rejects_blocked_extension() {
@@ -5078,6 +5159,7 @@ mod tests {
         );
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_token2022_confidential_extension_instructions_rejected() {
@@ -5107,6 +5189,7 @@ mod tests {
         }
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_fee_payer_policy_mixed_instructions() {
@@ -5218,6 +5301,7 @@ mod tests {
         setup_both_configs(config);
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_loader_v4_write_requires_policy() {
@@ -5259,6 +5343,7 @@ mod tests {
             .is_err());
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_loader_v4_deploy_requires_policy() {
@@ -5299,6 +5384,7 @@ mod tests {
             .is_err());
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_loader_v4_copy_requires_policy() {
@@ -5341,6 +5427,7 @@ mod tests {
             .is_err());
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_loader_v4_retract_requires_policy() {
@@ -5366,6 +5453,7 @@ mod tests {
             .is_ok());
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_loader_v4_set_program_length_accepts_self_recipient() {
@@ -5392,6 +5480,7 @@ mod tests {
             .is_ok());
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_loader_v4_set_program_length_rejects_foreign_recipient() {
@@ -5425,6 +5514,7 @@ mod tests {
         }
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_loader_v4_set_program_length_rejects_when_policy_disabled() {
@@ -5448,6 +5538,7 @@ mod tests {
             .is_err());
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_loader_v4_transfer_authority_denied_by_default() {
@@ -5472,6 +5563,7 @@ mod tests {
             .is_err());
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_loader_v4_transfer_authority_rejects_when_fee_payer_is_new_authority() {
@@ -5502,6 +5594,7 @@ mod tests {
             .is_err());
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_loader_v4_finalize_denied_by_default() {
@@ -5544,6 +5637,7 @@ mod tests {
         setup_both_configs(config);
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_bpf_v3_write_requires_policy() {
@@ -5582,6 +5676,7 @@ mod tests {
             .is_err());
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_bpf_v3_set_authority_denied_by_default() {
@@ -5606,6 +5701,7 @@ mod tests {
             .is_err());
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_bpf_v3_close_with_foreign_recipient_blocked_by_drainage_guard() {
@@ -5636,6 +5732,7 @@ mod tests {
         }
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_bpf_v3_close_with_self_recipient_accepted() {
@@ -5661,6 +5758,7 @@ mod tests {
             .is_ok());
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_bpf_v3_upgrade_with_kora_as_spill_does_not_require_allow_upgrade() {
@@ -5690,6 +5788,7 @@ mod tests {
             .is_ok());
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_bpf_v3_close_with_kora_as_recipient_does_not_require_allow_close() {
@@ -5715,6 +5814,7 @@ mod tests {
             .is_ok());
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_bpf_v3_extend_program_checked_with_kora_payer_denied_by_default() {
@@ -5747,6 +5847,7 @@ mod tests {
             .is_err());
     }
 
+    #[cfg_attr(miri, ignore)]
     #[tokio::test]
     #[serial]
     async fn test_bpf_v3_migrate_denied_by_default() {


### PR DESCRIPTION
## Summary
- Runs the Kora Miri job across the full library test target instead of selected modules
- Skips Tokio-based tests under Miri and one random weighted-selection test that hits unsupported CPU intrinsics
- Keeps Miri isolation/leak flags so non-async serial and filesystem-backed tests still run

## Test Plan
- cargo fmt --all -- --check
- cargo clippy -p kora-lib --tests -- -D warnings
- MIRIFLAGS='-Zmiri-disable-isolation -Zmiri-ignore-leaks' cargo +nightly miri test -p kora-lib --lib

## 📊 Unit Test Coverage
![Coverage](https://img.shields.io/badge/coverage-85.1%25-green)

**Unit Test Coverage: 85.1%**

[View Detailed Coverage Report](https://github.com/solana-foundation/kora/actions/runs/26237711976)