### PR TITLE
fix: cache payment-side token prices and add oracle HTTP timeouts

### DIFF
--- a/crates/lib/src/cache.rs
+++ b/crates/lib/src/cache.rs
@@ -10,15 +10,19 @@ use tokio::sync::{Mutex, OnceCell};
 use crate::{
     config::Config,
     error::KoraError,
-    oracle::{get_price_oracle, PriceSource, RetryingPriceOracle, TokenPrice},
+    oracle::{PriceSource, RetryingPriceOracle, TokenPrice},
     sanitize_error,
 };
 
+#[cfg(not(test))]
+use crate::oracle::get_price_oracle;
 #[cfg(not(test))]
 use crate::state::get_config;
 
 #[cfg(test)]
 use crate::tests::config_mock::mock_state::get_config;
+#[cfg(test)]
+use crate::tests::oracle_mock::get_price_oracle;
 
 const ACCOUNT_CACHE_KEY: &str = "account";
 const BLOCKHASH_CACHE_KEY: &str = "kora:blockhash";

--- a/crates/lib/src/oracle/oracle.rs
+++ b/crates/lib/src/oracle/oracle.rs
@@ -56,20 +56,12 @@ pub struct RetryingPriceOracle {
     oracle: Arc<dyn PriceOracle + Send + Sync>,
 }
 
-#[cfg(test)]
-thread_local! {
-    pub static TEST_ORACLE: std::cell::RefCell<Option<Arc<dyn PriceOracle + Send + Sync>>> = std::cell::RefCell::new(None);
-}
+const ORACLE_CONNECT_TIMEOUT_SECS: u64 = 5;
+const ORACLE_REQUEST_TIMEOUT_SECS: u64 = 10;
 
 pub fn get_price_oracle(
     source: PriceSource,
 ) -> Result<Arc<dyn PriceOracle + Send + Sync>, KoraError> {
-    #[cfg(test)]
-    {
-        if let Some(oracle) = TEST_ORACLE.with(|o| o.borrow().clone()) {
-            return Ok(oracle);
-        }
-    }
     match source {
         PriceSource::Jupiter => Ok(Arc::new(JupiterPriceOracle::new()?)),
         PriceSource::Mock => Ok(OracleUtil::get_mock_oracle_price()),
@@ -83,8 +75,8 @@ impl RetryingPriceOracle {
         oracle: Arc<dyn PriceOracle + Send + Sync>,
     ) -> Self {
         let client = Client::builder()
-            .connect_timeout(Duration::from_secs(5))
-            .timeout(Duration::from_secs(10))
+            .connect_timeout(Duration::from_secs(ORACLE_CONNECT_TIMEOUT_SECS))
+            .timeout(Duration::from_secs(ORACLE_REQUEST_TIMEOUT_SECS))
             .build()
             .expect("Failed to build reqwest client");
         Self { client, max_retries, base_delay, oracle }

--- a/crates/lib/src/oracle/oracle.rs
+++ b/crates/lib/src/oracle/oracle.rs
@@ -56,8 +56,8 @@ pub struct RetryingPriceOracle {
     oracle: Arc<dyn PriceOracle + Send + Sync>,
 }
 
-const ORACLE_CONNECT_TIMEOUT_SECS: u64 = 5;
-const ORACLE_REQUEST_TIMEOUT_SECS: u64 = 10;
+const ORACLE_CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
+const ORACLE_REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
 
 pub fn get_price_oracle(
     source: PriceSource,
@@ -75,8 +75,8 @@ impl RetryingPriceOracle {
         oracle: Arc<dyn PriceOracle + Send + Sync>,
     ) -> Self {
         let client = Client::builder()
-            .connect_timeout(Duration::from_secs(ORACLE_CONNECT_TIMEOUT_SECS))
-            .timeout(Duration::from_secs(ORACLE_REQUEST_TIMEOUT_SECS))
+            .connect_timeout(ORACLE_CONNECT_TIMEOUT)
+            .timeout(ORACLE_REQUEST_TIMEOUT)
             .build()
             .expect("Failed to build reqwest client");
         Self { client, max_retries, base_delay, oracle }
@@ -126,6 +126,7 @@ impl RetryingPriceOracle {
 mod tests {
 
     use super::*;
+    use crate::tests::oracle_mock::{spawn_hanging_server, HangingOracle};
     use std::time::Duration;
 
     #[tokio::test]
@@ -220,44 +221,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_retrying_price_oracle_times_out_on_hanging_request() {
-        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
-        let port = listener.local_addr().unwrap().port();
-        let server_url = format!("http://127.0.0.1:{}", port);
-
-        let _server_handle = std::thread::spawn(move || {
-            if let Ok((stream, _)) = listener.accept() {
-                std::thread::sleep(Duration::from_secs(30));
-                let _ = stream;
-            }
-        });
-
-        struct HangingOracle {
-            url: String,
-        }
-
-        #[async_trait::async_trait]
-        impl PriceOracle for HangingOracle {
-            async fn get_price(
-                &self,
-                _client: &Client,
-                _mint_address: &str,
-            ) -> Result<TokenPrice, KoraError> {
-                unimplemented!()
-            }
-
-            async fn get_prices(
-                &self,
-                client: &Client,
-                _mint_addresses: &[String],
-            ) -> Result<HashMap<String, TokenPrice>, KoraError> {
-                client
-                    .get(&self.url)
-                    .send()
-                    .await
-                    .map_err(|e| KoraError::RpcError(format!("Request failed: {}", e)))?;
-                Ok(HashMap::new())
-            }
-        }
+        let server_url = spawn_hanging_server();
 
         let hanging_oracle = Arc::new(HangingOracle { url: server_url });
         let retrying_oracle =

--- a/crates/lib/src/oracle/oracle.rs
+++ b/crates/lib/src/oracle/oracle.rs
@@ -56,9 +56,20 @@ pub struct RetryingPriceOracle {
     oracle: Arc<dyn PriceOracle + Send + Sync>,
 }
 
+#[cfg(test)]
+thread_local! {
+    pub static TEST_ORACLE: std::cell::RefCell<Option<Arc<dyn PriceOracle + Send + Sync>>> = std::cell::RefCell::new(None);
+}
+
 pub fn get_price_oracle(
     source: PriceSource,
 ) -> Result<Arc<dyn PriceOracle + Send + Sync>, KoraError> {
+    #[cfg(test)]
+    {
+        if let Some(oracle) = TEST_ORACLE.with(|o| o.borrow().clone()) {
+            return Ok(oracle);
+        }
+    }
     match source {
         PriceSource::Jupiter => Ok(Arc::new(JupiterPriceOracle::new()?)),
         PriceSource::Mock => Ok(OracleUtil::get_mock_oracle_price()),
@@ -208,5 +219,59 @@ mod tests {
         let result = oracle.get_token_price("missing_mint").await;
         assert!(result.is_err());
         assert!(matches!(result.err(), Some(KoraError::InternalServerError(_))));
+    }
+
+    #[tokio::test]
+    async fn test_retrying_price_oracle_times_out_on_hanging_request() {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        let server_url = format!("http://127.0.0.1:{}", port);
+
+        let _server_handle = std::thread::spawn(move || {
+            if let Ok((stream, _)) = listener.accept() {
+                std::thread::sleep(Duration::from_secs(10));
+                let _ = stream;
+            }
+        });
+
+        struct HangingOracle {
+            url: String,
+        }
+
+        #[async_trait::async_trait]
+        impl PriceOracle for HangingOracle {
+            async fn get_price(
+                &self,
+                _client: &Client,
+                _mint_address: &str,
+            ) -> Result<TokenPrice, KoraError> {
+                unimplemented!()
+            }
+
+            async fn get_prices(
+                &self,
+                client: &Client,
+                _mint_addresses: &[String],
+            ) -> Result<HashMap<String, TokenPrice>, KoraError> {
+                client
+                    .get(&self.url)
+                    .send()
+                    .await
+                    .map_err(|e| KoraError::RpcError(format!("Request failed: {}", e)))?;
+                Ok(HashMap::new())
+            }
+        }
+
+        let hanging_oracle = Arc::new(HangingOracle { url: server_url });
+        let retrying_oracle =
+            RetryingPriceOracle::new(3, Duration::from_millis(10), hanging_oracle);
+
+        let result = tokio::time::timeout(
+            Duration::from_secs(2),
+            retrying_oracle.get_token_prices(&["dummy_mint".to_string()]),
+        )
+        .await;
+
+        assert!(result.is_err(), "Expected request to hang and timeout");
     }
 }

--- a/crates/lib/src/oracle/oracle.rs
+++ b/crates/lib/src/oracle/oracle.rs
@@ -82,7 +82,12 @@ impl RetryingPriceOracle {
         base_delay: Duration,
         oracle: Arc<dyn PriceOracle + Send + Sync>,
     ) -> Self {
-        Self { client: Client::new(), max_retries, base_delay, oracle }
+        let client = Client::builder()
+            .connect_timeout(Duration::from_secs(5))
+            .timeout(Duration::from_secs(10))
+            .build()
+            .expect("Failed to build reqwest client");
+        Self { client, max_retries, base_delay, oracle }
     }
 
     pub async fn get_token_price(&self, mint_address: &str) -> Result<TokenPrice, KoraError> {
@@ -229,7 +234,7 @@ mod tests {
 
         let _server_handle = std::thread::spawn(move || {
             if let Ok((stream, _)) = listener.accept() {
-                std::thread::sleep(Duration::from_secs(10));
+                std::thread::sleep(Duration::from_secs(30));
                 let _ = stream;
             }
         });
@@ -264,14 +269,16 @@ mod tests {
 
         let hanging_oracle = Arc::new(HangingOracle { url: server_url });
         let retrying_oracle =
-            RetryingPriceOracle::new(3, Duration::from_millis(10), hanging_oracle);
+            RetryingPriceOracle::new(1, Duration::from_millis(10), hanging_oracle);
 
         let result = tokio::time::timeout(
-            Duration::from_secs(2),
+            Duration::from_secs(15),
             retrying_oracle.get_token_prices(&["dummy_mint".to_string()]),
         )
         .await;
 
-        assert!(result.is_err(), "Expected request to hang and timeout");
+        assert!(result.is_ok(), "Expected request to actually timeout within the window");
+        let inner_result = result.unwrap();
+        assert!(inner_result.is_err());
     }
 }

--- a/crates/lib/src/tests/mod.rs
+++ b/crates/lib/src/tests/mod.rs
@@ -18,3 +18,6 @@ pub mod toml_mock;
 
 #[cfg(test)]
 pub mod transaction_mock;
+
+#[cfg(test)]
+pub mod oracle_mock;

--- a/crates/lib/src/tests/oracle_mock.rs
+++ b/crates/lib/src/tests/oracle_mock.rs
@@ -19,11 +19,8 @@ impl PriceOracle for TestOracleProxy {
         client: &Client,
         mint_address: &str,
     ) -> Result<TokenPrice, KoraError> {
-        let oracle = TEST_ORACLE.with(|o| {
-            o.borrow()
-                .clone()
-                .ok_or_else(|| KoraError::InternalServerError("No test oracle set".to_string()))
-        })?;
+        let oracle = TEST_ORACLE
+            .with(|o| o.borrow().clone().unwrap_or_else(|| OracleUtil::get_mock_oracle_price()));
         oracle.get_price(client, mint_address).await
     }
 

--- a/crates/lib/src/tests/oracle_mock.rs
+++ b/crates/lib/src/tests/oracle_mock.rs
@@ -1,15 +1,96 @@
-use std::sync::Arc;
+use crate::{
+    error::KoraError,
+    oracle::{utils::OracleUtil, PriceOracle, PriceSource, TokenPrice},
+};
+use reqwest::Client;
+use std::{collections::HashMap, sync::Arc, time::Duration};
 
 thread_local! {
-    pub static TEST_ORACLE: std::cell::RefCell<Option<Arc<dyn crate::oracle::PriceOracle + Send + Sync>>> = std::cell::RefCell::new(None);
+    /// Holds a per-test injectable oracle.
+    pub static TEST_ORACLE: std::cell::RefCell<Option<Arc<dyn PriceOracle + Send + Sync>>> = std::cell::RefCell::new(None);
 }
 
+struct TestOracleProxy;
+
+#[async_trait::async_trait]
+impl PriceOracle for TestOracleProxy {
+    async fn get_price(
+        &self,
+        client: &Client,
+        mint_address: &str,
+    ) -> Result<TokenPrice, KoraError> {
+        let oracle = TEST_ORACLE.with(|o| {
+            o.borrow()
+                .clone()
+                .ok_or_else(|| KoraError::InternalServerError("No test oracle set".to_string()))
+        })?;
+        oracle.get_price(client, mint_address).await
+    }
+
+    async fn get_prices(
+        &self,
+        client: &Client,
+        mint_addresses: &[String],
+    ) -> Result<HashMap<String, TokenPrice>, KoraError> {
+        let oracle = TEST_ORACLE.with(|o| {
+            if let Some(oracle) = o.borrow().clone() {
+                oracle
+            } else {
+                OracleUtil::get_mock_oracle_price()
+            }
+        });
+        oracle.get_prices(client, mint_addresses).await
+    }
+}
+
+/// Returns a TestOracleProxy which delegates to TEST_ORACLE.
 pub fn get_price_oracle(
-    _source: crate::oracle::PriceSource,
-) -> Result<Arc<dyn crate::oracle::PriceOracle + Send + Sync>, crate::error::KoraError> {
-    TEST_ORACLE.with(|o| {
-        o.borrow().clone().ok_or_else(|| {
-            crate::error::KoraError::InternalServerError("No test oracle set".to_string())
-        })
-    })
+    _source: PriceSource,
+) -> Result<Arc<dyn PriceOracle + Send + Sync>, KoraError> {
+    Ok(Arc::new(TestOracleProxy))
+}
+
+/// Simulates a server that never responds.
+pub struct HangingOracle {
+    pub url: String,
+}
+
+#[async_trait::async_trait]
+impl PriceOracle for HangingOracle {
+    async fn get_price(
+        &self,
+        _client: &Client,
+        _mint_address: &str,
+    ) -> Result<TokenPrice, KoraError> {
+        unimplemented!()
+    }
+
+    async fn get_prices(
+        &self,
+        client: &Client,
+        _mint_addresses: &[String],
+    ) -> Result<HashMap<String, TokenPrice>, KoraError> {
+        client
+            .get(&self.url)
+            .send()
+            .await
+            .map_err(|e| KoraError::RpcError(format!("Request failed: {}", e)))?;
+        Ok(HashMap::new())
+    }
+}
+
+/// Binds a TCP listener that accepts connections but never responds.
+pub fn spawn_hanging_server() -> String {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let port = listener.local_addr().unwrap().port();
+    let server_url = format!("http://127.0.0.1:{}", port);
+
+    let _server_handle = std::thread::spawn(move || {
+        if let Ok((stream, _)) = listener.accept() {
+            std::thread::sleep(Duration::from_secs(30));
+            let _ = stream;
+        }
+    });
+
+    server_url
 }

--- a/crates/lib/src/tests/oracle_mock.rs
+++ b/crates/lib/src/tests/oracle_mock.rs
@@ -1,0 +1,15 @@
+use std::sync::Arc;
+
+thread_local! {
+    pub static TEST_ORACLE: std::cell::RefCell<Option<Arc<dyn crate::oracle::PriceOracle + Send + Sync>>> = std::cell::RefCell::new(None);
+}
+
+pub fn get_price_oracle(
+    _source: crate::oracle::PriceSource,
+) -> Result<Arc<dyn crate::oracle::PriceOracle + Send + Sync>, crate::error::KoraError> {
+    TEST_ORACLE.with(|o| {
+        o.borrow().clone().ok_or_else(|| {
+            crate::error::KoraError::InternalServerError("No test oracle set".to_string())
+        })
+    })
+}

--- a/crates/lib/src/token/token.rs
+++ b/crates/lib/src/token/token.rs
@@ -1001,7 +1001,10 @@ impl TokenUtil {
 #[cfg(test)]
 mod tests_token {
     use crate::{
-        oracle::utils::{USDC_DEVNET_MINT, WSOL_DEVNET_MINT},
+        oracle::{
+            utils::{USDC_DEVNET_MINT, WSOL_DEVNET_MINT},
+            PriceSource,
+        },
         tests::{
             account_mock::create_transfer_fee_config,
             common::{MintAccountMockBuilder, RpcMockBuilder, TokenAccountMockBuilder},
@@ -1017,6 +1020,7 @@ mod tests_token {
         },
         pod::PodMint,
     };
+    use std::sync::Arc;
 
     use spl_associated_token_account_interface::address::get_associated_token_address_with_program_id;
 
@@ -2096,5 +2100,112 @@ mod tests_token {
 
         let err = decimal_scale(255).unwrap_err();
         assert!(err.to_string().contains("exceeds maximum supported value"));
+    }
+
+    #[tokio::test]
+    async fn test_calculate_payment_lamport_totals_batches_duplicate_mints() {
+        let _lock = ConfigMockBuilder::new().with_cache_enabled(false).build_and_setup();
+
+        let expected_destination_owner = Pubkey::new_unique();
+        let source_address = Pubkey::new_unique();
+        let destination_address = Pubkey::new_unique();
+        let mint = Pubkey::from_str(USDC_DEVNET_MINT).unwrap();
+
+        let source_account = TokenAccountMockBuilder::new()
+            .with_mint(&mint)
+            .with_owner(&Pubkey::new_unique())
+            .build();
+        let destination_account = TokenAccountMockBuilder::new()
+            .with_mint(&mint)
+            .with_owner(&expected_destination_owner)
+            .build();
+        let mint_account = MintAccountMockBuilder::new().with_decimals(6).build();
+
+        let instruction1 = spl_token_interface::instruction::transfer_checked(
+            &spl_token_interface::id(),
+            &source_address,
+            &mint,
+            &destination_address,
+            &expected_destination_owner,
+            &[],
+            1_000_000,
+            6,
+        )
+        .unwrap();
+
+        let instruction2 = spl_token_interface::instruction::transfer_checked(
+            &spl_token_interface::id(),
+            &source_address,
+            &mint,
+            &destination_address,
+            &expected_destination_owner,
+            &[],
+            2_000_000,
+            6,
+        )
+        .unwrap();
+
+        let message = VersionedMessage::Legacy(Message::new(
+            &[instruction1, instruction2],
+            Some(&expected_destination_owner),
+        ));
+        let mut transaction_resolved =
+            TransactionUtil::new_unsigned_versioned_transaction_resolved(message).unwrap();
+
+        let rpc_client = RpcMockBuilder::new().build_with_sequential_accounts(vec![
+            &source_account,
+            &destination_account,
+            &mint_account,
+            &source_account,
+            &destination_account,
+            &mint_account,
+        ]);
+
+        let mut mock_oracle = crate::oracle::MockPriceOracle::new();
+        mock_oracle.expect_get_prices().times(2).returning(|_, mint_addresses| {
+            let mut result = HashMap::new();
+            for mint in mint_addresses {
+                result.insert(
+                    mint.clone(),
+                    TokenPrice {
+                        price: Decimal::from(1),
+                        confidence: 1.0,
+                        source: PriceSource::Mock,
+                        block_id: None,
+                    },
+                );
+            }
+            Ok(result)
+        });
+
+        let shared_mock_oracle = Arc::new(mock_oracle);
+        crate::oracle::TEST_ORACLE.with(|o| {
+            *o.borrow_mut() = Some(shared_mock_oracle.clone());
+        });
+
+        struct OracleGuard;
+        impl Drop for OracleGuard {
+            fn drop(&mut self) {
+                crate::oracle::TEST_ORACLE.with(|o| {
+                    *o.borrow_mut() = None;
+                });
+            }
+        }
+        let _guard = OracleGuard;
+
+        let config = get_config().unwrap();
+        let result = TokenUtil::calculate_payment_lamport_totals(
+            &config,
+            &mut transaction_resolved,
+            &rpc_client,
+            &expected_destination_owner,
+            None,
+        )
+        .await;
+
+        assert!(result.is_ok());
+        let totals = result.unwrap();
+        assert_eq!(totals.inflow, 3_000_000_000);
+        assert_eq!(totals.outflow, 0);
     }
 }

--- a/crates/lib/src/token/token.rs
+++ b/crates/lib/src/token/token.rs
@@ -469,33 +469,7 @@ impl TokenUtil {
     ) -> Result<u64, KoraError> {
         let (token_price, decimals) =
             Self::get_token_price_and_decimals(mint, rpc_client, config).await?;
-
-        // Convert amount to Decimal with proper scaling
-        let amount_decimal = Decimal::from_u64(amount)
-            .ok_or_else(|| KoraError::ValidationError("Invalid token amount".to_string()))?;
-        let decimals_scale = decimal_scale(decimals)?;
-        let lamports_per_sol = Decimal::from_u64(LAMPORTS_PER_SOL)
-            .ok_or_else(|| KoraError::ValidationError("Invalid LAMPORTS_PER_SOL".to_string()))?;
-
-        // Calculate: (amount * price * LAMPORTS_PER_SOL) / 10^decimals
-        // Multiply before divide to preserve precision
-        let lamports_decimal = amount_decimal.checked_mul(token_price.price).and_then(|result| result.checked_mul(lamports_per_sol)).and_then(|result| result.checked_div(decimals_scale)).ok_or_else(|| {
-            log::error!("Token value calculation overflow: amount={}, price={}, decimals={}, lamports_per_sol={}",
-                amount,
-                token_price.price,
-                decimals,
-                lamports_per_sol
-            );
-            KoraError::ValidationError("Token value calculation overflow".to_string())
-        })?;
-
-        // Floor and convert to u64
-        let lamports = lamports_decimal
-            .floor()
-            .to_u64()
-            .ok_or_else(|| KoraError::ValidationError("Lamports value overflow".to_string()))?;
-
-        Ok(lamports)
+        Self::calculate_token_value_in_lamports_from_price(amount, token_price.price, decimals)
     }
 
     pub async fn calculate_lamports_value_in_token(
@@ -1091,11 +1065,15 @@ impl TokenUtil {
 #[cfg(test)]
 mod tests_token {
     use crate::{
-        oracle::utils::{USDC_DEVNET_MINT, WSOL_DEVNET_MINT},
+        oracle::{
+            utils::{USDC_DEVNET_MINT, WSOL_DEVNET_MINT},
+            PriceSource, TokenPrice,
+        },
         tests::{
             account_mock::create_transfer_fee_config,
             common::{MintAccountMockBuilder, RpcMockBuilder, TokenAccountMockBuilder},
             config_mock::ConfigMockBuilder,
+            oracle_mock::TEST_ORACLE,
         },
         transaction::TransactionUtil,
     };
@@ -1107,6 +1085,7 @@ mod tests_token {
         },
         pod::PodMint,
     };
+    use std::sync::Arc;
 
     use spl_associated_token_account_interface::address::get_associated_token_address_with_program_id;
 
@@ -1778,10 +1757,11 @@ mod tests_token {
     #[tokio::test]
     async fn test_calculate_payment_lamport_totals_validates_token2022_when_both_sides_match_expected_owner(
     ) {
-        let _lock = ConfigMockBuilder::new()
-            .with_cache_enabled(false)
-            .with_blocked_token2022_mint_extensions(vec!["transfer_fee_config".to_string()])
-            .build_and_setup();
+        let mut config = get_config().unwrap();
+        config.kora.cache.enabled = false;
+        config.validation.token_2022.blocked_mint_extensions =
+            vec!["transfer_fee_config".to_string()];
+        let _ = config.validation.token_2022.initialize();
 
         let expected_destination_owner = Pubkey::new_unique();
         let source_address = Pubkey::new_unique();
@@ -1826,7 +1806,6 @@ mod tests_token {
             &source_account,
         ]);
 
-        let config = get_config().unwrap();
         let result = TokenUtil::calculate_payment_lamport_totals(
             &config,
             &mut transaction_resolved,
@@ -2246,7 +2225,40 @@ mod tests_token {
             &mint_account,
         ]);
 
-        let config = get_config().unwrap();
+        let mut mock_oracle = crate::oracle::MockPriceOracle::new();
+        mock_oracle.expect_get_prices().times(1).returning(|_, mint_addresses| {
+            let mut result = HashMap::new();
+            for mint in mint_addresses {
+                result.insert(
+                    mint.clone(),
+                    TokenPrice {
+                        price: Decimal::from(1),
+                        confidence: 1.0,
+                        source: PriceSource::Mock,
+                        block_id: None,
+                    },
+                );
+            }
+            Ok(result)
+        });
+
+        let shared_mock_oracle = Arc::new(mock_oracle);
+        TEST_ORACLE.with(|o| {
+            *o.borrow_mut() = Some(shared_mock_oracle.clone());
+        });
+
+        struct OracleGuard;
+        impl Drop for OracleGuard {
+            fn drop(&mut self) {
+                TEST_ORACLE.with(|o| {
+                    *o.borrow_mut() = None;
+                });
+            }
+        }
+        let _guard = OracleGuard;
+
+        let mut config = get_config().unwrap();
+        config.kora.cache.enabled = false;
         let result = TokenUtil::calculate_payment_lamport_totals(
             &config,
             &mut transaction_resolved,
@@ -2258,7 +2270,7 @@ mod tests_token {
 
         assert!(result.is_ok());
         let totals = result.unwrap();
-        assert_eq!(totals.inflow, 22_500_000);
+        assert_eq!(totals.inflow, 3_000_000_000);
         assert_eq!(totals.outflow, 0);
     }
 }

--- a/crates/lib/src/token/token.rs
+++ b/crates/lib/src/token/token.rs
@@ -808,6 +808,7 @@ impl TokenUtil {
         let mut totals = PaymentLamportTotals::default();
         let mut cached_epoch: Option<u64> = None;
         let mut token2022_mints: HashMap<Pubkey, Box<dyn TokenMint>> = HashMap::new();
+        let mut payment_mints: HashSet<Pubkey> = HashSet::new();
 
         let all_instructions = bundle_instructions
             .map(|instructions| instructions.to_vec())
@@ -901,6 +902,8 @@ impl TokenUtil {
                         continue;
                     }
                 }
+
+                payment_mints.insert(token_mint);
 
                 let inflow_amount = if *is_2022 && is_inflow {
                     Self::calculate_token2022_net_amount(

--- a/crates/lib/src/token/token.rs
+++ b/crates/lib/src/token/token.rs
@@ -431,6 +431,36 @@ impl TokenUtil {
         Ok((token_price, decimals))
     }
 
+    fn calculate_token_value_in_lamports_from_price(
+        amount: u64,
+        price: Decimal,
+        decimals: u8,
+    ) -> Result<u64, KoraError> {
+        let amount_decimal = Decimal::from_u64(amount)
+            .ok_or_else(|| KoraError::ValidationError("Invalid token amount".to_string()))?;
+        let decimals_scale = decimal_scale(decimals)?;
+        let lamports_per_sol = Decimal::from_u64(LAMPORTS_PER_SOL)
+            .ok_or_else(|| KoraError::ValidationError("Invalid LAMPORTS_PER_SOL".to_string()))?;
+
+        let lamports_decimal = amount_decimal.checked_mul(price)
+            .and_then(|result| result.checked_mul(lamports_per_sol))
+            .and_then(|result| result.checked_div(decimals_scale))
+            .ok_or_else(|| {
+                log::error!("Token value calculation overflow: amount={}, price={}, decimals={}, lamports_per_sol={}",
+                    amount,
+                    price,
+                    decimals,
+                    lamports_per_sol
+                );
+                KoraError::ValidationError("Token value calculation overflow".to_string())
+            })?;
+
+        lamports_decimal
+            .floor()
+            .to_u64()
+            .ok_or_else(|| KoraError::ValidationError("Lamports value overflow".to_string()))
+    }
+
     pub async fn calculate_token_value_in_lamports(
         amount: u64,
         mint: &Pubkey,
@@ -809,6 +839,13 @@ impl TokenUtil {
         let mut cached_epoch: Option<u64> = None;
         let mut token2022_mints: HashMap<Pubkey, Box<dyn TokenMint>> = HashMap::new();
         let mut payment_mints: HashSet<Pubkey> = HashSet::new();
+        struct ValidTransfer {
+            is_inflow: bool,
+            is_outflow: bool,
+            token_mint: Pubkey,
+            inflow_amount: u64,
+            amount: u64,
+        }
         let mut valid_transfers = Vec::new();
 
         let all_instructions = bundle_instructions
@@ -920,7 +957,13 @@ impl TokenUtil {
                     *amount
                 };
 
-                valid_transfers.push((is_inflow, is_outflow, token_mint, inflow_amount, *amount));
+                valid_transfers.push(ValidTransfer {
+                    is_inflow,
+                    is_outflow,
+                    token_mint,
+                    inflow_amount,
+                    amount: *amount,
+                });
             }
         }
 
@@ -931,13 +974,8 @@ impl TokenUtil {
         let mint_addresses: Vec<String> =
             payment_mints.iter().map(|mint| mint.to_string()).collect();
 
-        let oracle = RetryingPriceOracle::new(
-            3,
-            Duration::from_secs(1),
-            get_price_oracle(config.validation.price_source.clone())?,
-        );
-
-        let prices = oracle.get_token_prices(&mint_addresses).await?;
+        let prices =
+            CacheUtil::get_or_fetch_token_prices(rpc_client, config, &mint_addresses).await?;
 
         let current_slot = if config.validation.max_price_staleness_slots > 0 {
             Some(
@@ -961,66 +999,34 @@ impl TokenUtil {
             .await?;
         }
 
-        for (is_inflow, is_outflow, token_mint, inflow_amount, amount) in valid_transfers {
-            let decimals = Self::get_mint_decimals(config, rpc_client, &token_mint).await?;
+        let mut mint_decimals = HashMap::new();
+        for mint in &payment_mints {
+            let decimals = Self::get_mint_decimals(config, rpc_client, mint).await?;
+            mint_decimals.insert(*mint, decimals);
+        }
+
+        for transfer in valid_transfers {
+            let ValidTransfer { is_inflow, is_outflow, token_mint, inflow_amount, amount } =
+                transfer;
+            let decimals = *mint_decimals.get(&token_mint).ok_or_else(|| {
+                KoraError::RpcError(format!("No decimals data for mint {token_mint}"))
+            })?;
             let price = prices.get(&token_mint.to_string()).ok_or_else(|| {
                 KoraError::RpcError(format!("No price data for mint {token_mint}"))
             })?;
 
             let inflow_lamports = if is_inflow {
-                let amount_decimal = Decimal::from_u64(inflow_amount).ok_or_else(|| {
-                    KoraError::ValidationError("Invalid token amount".to_string())
-                })?;
-                let decimals_scale = decimal_scale(decimals)?;
-                let lamports_per_sol = Decimal::from_u64(LAMPORTS_PER_SOL).ok_or_else(|| {
-                    KoraError::ValidationError("Invalid LAMPORTS_PER_SOL".to_string())
-                })?;
-
-                let lamports_decimal = amount_decimal.checked_mul(price.price)
-                    .and_then(|result| result.checked_mul(lamports_per_sol))
-                    .and_then(|result| result.checked_div(decimals_scale))
-                    .ok_or_else(|| {
-                        log::error!("Token value calculation overflow: amount={}, price={}, decimals={}, lamports_per_sol={}",
-                            inflow_amount,
-                            price.price,
-                            decimals,
-                            lamports_per_sol
-                        );
-                        KoraError::ValidationError("Token value calculation overflow".to_string())
-                    })?;
-
-                lamports_decimal.floor().to_u64().ok_or_else(|| {
-                    KoraError::ValidationError("Lamports value overflow".to_string())
-                })?
+                Self::calculate_token_value_in_lamports_from_price(
+                    inflow_amount,
+                    price.price,
+                    decimals,
+                )?
             } else {
                 0
             };
 
             let outflow_lamports = if is_outflow {
-                let amount_decimal = Decimal::from_u64(amount).ok_or_else(|| {
-                    KoraError::ValidationError("Invalid token amount".to_string())
-                })?;
-                let decimals_scale = decimal_scale(decimals)?;
-                let lamports_per_sol = Decimal::from_u64(LAMPORTS_PER_SOL).ok_or_else(|| {
-                    KoraError::ValidationError("Invalid LAMPORTS_PER_SOL".to_string())
-                })?;
-
-                let lamports_decimal = amount_decimal.checked_mul(price.price)
-                    .and_then(|result| result.checked_mul(lamports_per_sol))
-                    .and_then(|result| result.checked_div(decimals_scale))
-                    .ok_or_else(|| {
-                        log::error!("Token value calculation overflow: amount={}, price={}, decimals={}, lamports_per_sol={}",
-                            amount,
-                            price.price,
-                            decimals,
-                            lamports_per_sol
-                        );
-                        KoraError::ValidationError("Token value calculation overflow".to_string())
-                    })?;
-
-                lamports_decimal.floor().to_u64().ok_or_else(|| {
-                    KoraError::ValidationError("Lamports value overflow".to_string())
-                })?
+                Self::calculate_token_value_in_lamports_from_price(amount, price.price, decimals)?
             } else {
                 0
             };
@@ -1085,10 +1091,7 @@ impl TokenUtil {
 #[cfg(test)]
 mod tests_token {
     use crate::{
-        oracle::{
-            utils::{USDC_DEVNET_MINT, WSOL_DEVNET_MINT},
-            PriceSource,
-        },
+        oracle::utils::{USDC_DEVNET_MINT, WSOL_DEVNET_MINT},
         tests::{
             account_mock::create_transfer_fee_config,
             common::{MintAccountMockBuilder, RpcMockBuilder, TokenAccountMockBuilder},
@@ -1104,7 +1107,6 @@ mod tests_token {
         },
         pod::PodMint,
     };
-    use std::sync::Arc;
 
     use spl_associated_token_account_interface::address::get_associated_token_address_with_program_id;
 
@@ -2242,40 +2244,7 @@ mod tests_token {
             &source_account,
             &destination_account,
             &mint_account,
-            &mint_account,
         ]);
-
-        let mut mock_oracle = crate::oracle::MockPriceOracle::new();
-        mock_oracle.expect_get_prices().times(1).returning(|_, mint_addresses| {
-            let mut result = HashMap::new();
-            for mint in mint_addresses {
-                result.insert(
-                    mint.clone(),
-                    TokenPrice {
-                        price: Decimal::from(1),
-                        confidence: 1.0,
-                        source: PriceSource::Mock,
-                        block_id: None,
-                    },
-                );
-            }
-            Ok(result)
-        });
-
-        let shared_mock_oracle = Arc::new(mock_oracle);
-        crate::oracle::TEST_ORACLE.with(|o| {
-            *o.borrow_mut() = Some(shared_mock_oracle.clone());
-        });
-
-        struct OracleGuard;
-        impl Drop for OracleGuard {
-            fn drop(&mut self) {
-                crate::oracle::TEST_ORACLE.with(|o| {
-                    *o.borrow_mut() = None;
-                });
-            }
-        }
-        let _guard = OracleGuard;
 
         let config = get_config().unwrap();
         let result = TokenUtil::calculate_payment_lamport_totals(
@@ -2289,7 +2258,7 @@ mod tests_token {
 
         assert!(result.is_ok());
         let totals = result.unwrap();
-        assert_eq!(totals.inflow, 3_000_000_000);
+        assert_eq!(totals.inflow, 22_500_000);
         assert_eq!(totals.outflow, 0);
     }
 }

--- a/crates/lib/src/token/token.rs
+++ b/crates/lib/src/token/token.rs
@@ -809,6 +809,7 @@ impl TokenUtil {
         let mut cached_epoch: Option<u64> = None;
         let mut token2022_mints: HashMap<Pubkey, Box<dyn TokenMint>> = HashMap::new();
         let mut payment_mints: HashSet<Pubkey> = HashSet::new();
+        let mut valid_transfers = Vec::new();
 
         let all_instructions = bundle_instructions
             .map(|instructions| instructions.to_vec())
@@ -919,35 +920,115 @@ impl TokenUtil {
                     *amount
                 };
 
-                let inflow_lamports = if is_inflow {
-                    Self::calculate_token_value_in_lamports(
-                        inflow_amount,
-                        &token_mint,
-                        rpc_client,
-                        config,
-                    )
-                    .await?
-                } else {
-                    0
-                };
-
-                let outflow_lamports = if is_outflow {
-                    Self::calculate_token_value_in_lamports(
-                        *amount,
-                        &token_mint,
-                        rpc_client,
-                        config,
-                    )
-                    .await?
-                } else {
-                    0
-                };
-
-                totals.checked_add_assign(PaymentLamportTotals {
-                    inflow: inflow_lamports,
-                    outflow: outflow_lamports,
-                })?;
+                valid_transfers.push((is_inflow, is_outflow, token_mint, inflow_amount, *amount));
             }
+        }
+
+        if payment_mints.is_empty() {
+            return Ok(totals);
+        }
+
+        let mint_addresses: Vec<String> =
+            payment_mints.iter().map(|mint| mint.to_string()).collect();
+
+        let oracle = RetryingPriceOracle::new(
+            3,
+            Duration::from_secs(1),
+            get_price_oracle(config.validation.price_source.clone())?,
+        );
+
+        let prices = oracle.get_token_prices(&mint_addresses).await?;
+
+        let current_slot = if config.validation.max_price_staleness_slots > 0 {
+            Some(
+                rpc_client
+                    .get_slot()
+                    .await
+                    .map_err(|e| KoraError::RpcError(format!("Failed to get current slot: {e}")))?,
+            )
+        } else {
+            None
+        };
+
+        for (mint_addr, price) in &prices {
+            Self::check_price_staleness(
+                rpc_client,
+                config,
+                price,
+                &format!(" for {mint_addr}"),
+                current_slot,
+            )
+            .await?;
+        }
+
+        for (is_inflow, is_outflow, token_mint, inflow_amount, amount) in valid_transfers {
+            let decimals = Self::get_mint_decimals(config, rpc_client, &token_mint).await?;
+            let price = prices.get(&token_mint.to_string()).ok_or_else(|| {
+                KoraError::RpcError(format!("No price data for mint {token_mint}"))
+            })?;
+
+            let inflow_lamports = if is_inflow {
+                let amount_decimal = Decimal::from_u64(inflow_amount).ok_or_else(|| {
+                    KoraError::ValidationError("Invalid token amount".to_string())
+                })?;
+                let decimals_scale = decimal_scale(decimals)?;
+                let lamports_per_sol = Decimal::from_u64(LAMPORTS_PER_SOL).ok_or_else(|| {
+                    KoraError::ValidationError("Invalid LAMPORTS_PER_SOL".to_string())
+                })?;
+
+                let lamports_decimal = amount_decimal.checked_mul(price.price)
+                    .and_then(|result| result.checked_mul(lamports_per_sol))
+                    .and_then(|result| result.checked_div(decimals_scale))
+                    .ok_or_else(|| {
+                        log::error!("Token value calculation overflow: amount={}, price={}, decimals={}, lamports_per_sol={}",
+                            inflow_amount,
+                            price.price,
+                            decimals,
+                            lamports_per_sol
+                        );
+                        KoraError::ValidationError("Token value calculation overflow".to_string())
+                    })?;
+
+                lamports_decimal.floor().to_u64().ok_or_else(|| {
+                    KoraError::ValidationError("Lamports value overflow".to_string())
+                })?
+            } else {
+                0
+            };
+
+            let outflow_lamports = if is_outflow {
+                let amount_decimal = Decimal::from_u64(amount).ok_or_else(|| {
+                    KoraError::ValidationError("Invalid token amount".to_string())
+                })?;
+                let decimals_scale = decimal_scale(decimals)?;
+                let lamports_per_sol = Decimal::from_u64(LAMPORTS_PER_SOL).ok_or_else(|| {
+                    KoraError::ValidationError("Invalid LAMPORTS_PER_SOL".to_string())
+                })?;
+
+                let lamports_decimal = amount_decimal.checked_mul(price.price)
+                    .and_then(|result| result.checked_mul(lamports_per_sol))
+                    .and_then(|result| result.checked_div(decimals_scale))
+                    .ok_or_else(|| {
+                        log::error!("Token value calculation overflow: amount={}, price={}, decimals={}, lamports_per_sol={}",
+                            amount,
+                            price.price,
+                            decimals,
+                            lamports_per_sol
+                        );
+                        KoraError::ValidationError("Token value calculation overflow".to_string())
+                    })?;
+
+                lamports_decimal.floor().to_u64().ok_or_else(|| {
+                    KoraError::ValidationError("Lamports value overflow".to_string())
+                })?
+            } else {
+                0
+            };
+
+            totals.checked_add_assign(PaymentLamportTotals {
+                inflow: inflow_lamports,
+                outflow: outflow_lamports,
+            })?;
         }
 
         Ok(totals)
@@ -2158,14 +2239,14 @@ mod tests_token {
         let rpc_client = RpcMockBuilder::new().build_with_sequential_accounts(vec![
             &source_account,
             &destination_account,
-            &mint_account,
             &source_account,
             &destination_account,
+            &mint_account,
             &mint_account,
         ]);
 
         let mut mock_oracle = crate::oracle::MockPriceOracle::new();
-        mock_oracle.expect_get_prices().times(2).returning(|_, mint_addresses| {
+        mock_oracle.expect_get_prices().times(1).returning(|_, mint_addresses| {
             let mut result = HashMap::new();
             for mint in mint_addresses {
                 result.insert(


### PR DESCRIPTION
Added 5s connect and 10s read timeouts to the Jupiter oracle reqwest client via named Duration constants so retry logic can actually fire on hanging requests. Hanging server helper and HangingOracle extracted to oracle_mock.rs.

Refactored `calculate_payment_lamport_totals` to batch fetch prices via `CacheUtil::get_or_fetch_token_prices` and decimals once per unique mint instead of per transfer matching `calculate_spl_transfers_value_in_lamports`. Extracted repeated lamport math into `calculate_token_value_in_lamports_from_price` and updated `calculate_token_value_in_lamports` to use it.

Closes #519