### PR TITLE
feat: expose HTTP timeout configuration for remote signer providers

### DIFF
--- a/crates/lib/src/signer/config.rs
+++ b/crates/lib/src/signer/config.rs
@@ -522,7 +522,7 @@ impl SignerConfig {
             poll_interval_ms: config.poll_interval_ms,
             max_poll_attempts: config.max_poll_attempts,
             use_program_call: config.use_program_call,
-            http_client_config: None,
+            http_client_config: config.http_config.as_ref().map(|c| c.to_keychain_http_config()),
         };
 
         Signer::from_fireblocks(keychain_config).await.map_err(|e| {
@@ -595,7 +595,7 @@ impl SignerConfig {
             private_key_pem,
             wallet_id,
             api_base_url: config.api_base_url.clone(),
-            http_client_config: None,
+            http_client_config: config.http_config.as_ref().map(|c| c.to_keychain_http_config()),
         };
         Signer::from_dfns(keychain_config).await.map_err(|e| {
             KoraError::SigningError(format!(
@@ -654,7 +654,10 @@ impl SignerConfig {
                 account_id,
                 wallet_secret,
                 api_base_url: config.api_base_url.clone(),
-                http_client_config: None,
+                http_client_config: config
+                    .http_config
+                    .as_ref()
+                    .map(|c| c.to_keychain_http_config()),
             })
             .map_err(map_err)?;
         signer.init().await.map_err(map_err)?;

--- a/crates/lib/src/signer/config.rs
+++ b/crates/lib/src/signer/config.rs
@@ -63,6 +63,22 @@ pub struct MemorySignerConfig {
     pub private_key_env: String,
 }
 
+/// Configuration for remote signer HTTP request and connection settings
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct RemoteSignerHttpConfig {
+    pub request_timeout_secs: Option<u64>,
+    pub connect_timeout_secs: Option<u64>,
+}
+
+impl RemoteSignerHttpConfig {
+    fn to_keychain_http_config(&self) -> solana_keychain::HttpClientConfig {
+        solana_keychain::HttpClientConfig {
+            request_timeout: self.request_timeout_secs.map(std::time::Duration::from_secs),
+            connect_timeout: self.connect_timeout_secs.map(std::time::Duration::from_secs),
+        }
+    }
+}
+
 /// Turnkey signer configuration
 #[derive(Clone, Serialize, Deserialize)]
 pub struct TurnkeySignerConfig {
@@ -71,6 +87,8 @@ pub struct TurnkeySignerConfig {
     pub organization_id_env: String,
     pub private_key_id_env: String,
     pub public_key_env: String,
+    #[serde(default)]
+    pub http_config: Option<RemoteSignerHttpConfig>,
 }
 
 /// Privy signer configuration
@@ -79,6 +97,8 @@ pub struct PrivySignerConfig {
     pub app_id_env: String,
     pub app_secret_env: String,
     pub wallet_id_env: String,
+    #[serde(default)]
+    pub http_config: Option<RemoteSignerHttpConfig>,
 }
 
 /// Openfort backend wallet signer configuration
@@ -96,6 +116,8 @@ pub struct OpenfortSignerConfig {
     /// Useful for pointing at staging or mock endpoints during testing. Must use HTTPS.
     #[serde(default)]
     pub api_base_url: Option<String>,
+    #[serde(default)]
+    pub http_config: Option<RemoteSignerHttpConfig>,
 }
 
 /// Vault signer configuration
@@ -105,6 +127,8 @@ pub struct VaultSignerConfig {
     pub vault_token_env: String,
     pub key_name_env: String,
     pub pubkey_env: String,
+    #[serde(default)]
+    pub http_config: Option<RemoteSignerHttpConfig>,
 }
 
 /// AWS KMS signer configuration
@@ -137,6 +161,8 @@ pub struct CdpSignerConfig {
     pub api_key_secret_env: String,
     pub wallet_secret_env: String,
     pub address_env: String,
+    #[serde(default)]
+    pub http_config: Option<RemoteSignerHttpConfig>,
 }
 
 /// Dfns signer configuration
@@ -148,6 +174,8 @@ pub struct DfnsSignerConfig {
     pub wallet_id_env: String,
     #[serde(default)]
     pub api_base_url: Option<String>,
+    #[serde(default)]
+    pub http_config: Option<RemoteSignerHttpConfig>,
 }
 
 /// Crossmint signer configuration
@@ -183,6 +211,8 @@ pub struct FireblocksSignerConfig {
     pub max_poll_attempts: Option<u32>,
     #[serde(default)]
     pub use_program_call: Option<bool>,
+    #[serde(default)]
+    pub http_config: Option<RemoteSignerHttpConfig>,
 }
 
 /// Signer type-specific configuration
@@ -1075,6 +1105,7 @@ private_key_env = "KORA_LOAD_CONFIG_KEY_99"
             organization_id_env: "TURNKEY_ORG_ID".to_string(),
             private_key_id_env: "TURNKEY_PRIVATE_KEY_ID".to_string(),
             public_key_env: "TURNKEY_PUBLIC_KEY".to_string(),
+            http_config: None,
         };
 
         let result = SignerConfig::build_turnkey_signer(&config, "test");
@@ -1099,6 +1130,7 @@ private_key_env = "KORA_LOAD_CONFIG_KEY_99"
             vault_token_env: "VAULT_TOKEN".to_string(),
             key_name_env: "VAULT_KEY_NAME".to_string(),
             pubkey_env: "VAULT_PUBKEY".to_string(),
+            http_config: None,
         };
 
         let result = SignerConfig::build_vault_signer(&config, "test");
@@ -1122,6 +1154,7 @@ private_key_env = "KORA_LOAD_CONFIG_KEY_99"
             api_key_secret_env: "CDP_API_KEY_SECRET".to_string(),
             wallet_secret_env: "CDP_WALLET_SECRET".to_string(),
             address_env: "CDP_ADDRESS".to_string(),
+            http_config: None,
         };
 
         let result = SignerConfig::build_cdp_signer(&config, "test");
@@ -1149,6 +1182,7 @@ private_key_env = "KORA_LOAD_CONFIG_KEY_99"
             poll_interval_ms: None,
             max_poll_attempts: None,
             use_program_call: None,
+            http_config: None,
         };
 
         let result = SignerConfig::build_fireblocks_signer(&config, "test").await;

--- a/crates/lib/src/signer/config.rs
+++ b/crates/lib/src/signer/config.rs
@@ -70,11 +70,11 @@ pub struct RemoteSignerHttpConfig {
     pub connect_timeout_secs: Option<u64>,
 }
 
-impl RemoteSignerHttpConfig {
-    fn to_keychain_http_config(&self) -> solana_keychain::HttpClientConfig {
+impl From<&RemoteSignerHttpConfig> for solana_keychain::HttpClientConfig {
+    fn from(c: &RemoteSignerHttpConfig) -> Self {
         solana_keychain::HttpClientConfig {
-            request_timeout: self.request_timeout_secs.map(std::time::Duration::from_secs),
-            connect_timeout: self.connect_timeout_secs.map(std::time::Duration::from_secs),
+            request_timeout: c.request_timeout_secs.map(std::time::Duration::from_secs),
+            connect_timeout: c.connect_timeout_secs.map(std::time::Duration::from_secs),
         }
     }
 }
@@ -428,7 +428,7 @@ impl SignerConfig {
             organization_id,
             private_key_id,
             public_key,
-            config.http_config.as_ref().map(|c| c.to_keychain_http_config()),
+            config.http_config.as_ref().map(solana_keychain::HttpClientConfig::from),
         )
         .map_err(|e| {
             KoraError::SigningError(format!(
@@ -450,7 +450,7 @@ impl SignerConfig {
             app_id,
             app_secret,
             wallet_id,
-            config.http_config.as_ref().map(|c| c.to_keychain_http_config()),
+            config.http_config.as_ref().map(solana_keychain::HttpClientConfig::from),
         )
         .await
         .map_err(|e| {
@@ -475,7 +475,7 @@ impl SignerConfig {
             vault_token,
             key_name,
             pubkey,
-            config.http_config.as_ref().map(|c| c.to_keychain_http_config()),
+            config.http_config.as_ref().map(solana_keychain::HttpClientConfig::from),
         )
         .map_err(|e| {
             KoraError::SigningError(format!(
@@ -522,7 +522,10 @@ impl SignerConfig {
             poll_interval_ms: config.poll_interval_ms,
             max_poll_attempts: config.max_poll_attempts,
             use_program_call: config.use_program_call,
-            http_client_config: config.http_config.as_ref().map(|c| c.to_keychain_http_config()),
+            http_client_config: config
+                .http_config
+                .as_ref()
+                .map(solana_keychain::HttpClientConfig::from),
         };
 
         Signer::from_fireblocks(keychain_config).await.map_err(|e| {
@@ -571,7 +574,7 @@ impl SignerConfig {
             api_key_secret,
             wallet_secret,
             address,
-            config.http_config.as_ref().map(|c| c.to_keychain_http_config()),
+            config.http_config.as_ref().map(solana_keychain::HttpClientConfig::from),
         )
         .map_err(|e| {
             KoraError::SigningError(format!(
@@ -595,7 +598,10 @@ impl SignerConfig {
             private_key_pem,
             wallet_id,
             api_base_url: config.api_base_url.clone(),
-            http_client_config: config.http_config.as_ref().map(|c| c.to_keychain_http_config()),
+            http_client_config: config
+                .http_config
+                .as_ref()
+                .map(solana_keychain::HttpClientConfig::from),
         };
         Signer::from_dfns(keychain_config).await.map_err(|e| {
             KoraError::SigningError(format!(
@@ -657,7 +663,7 @@ impl SignerConfig {
                 http_client_config: config
                     .http_config
                     .as_ref()
-                    .map(|c| c.to_keychain_http_config()),
+                    .map(solana_keychain::HttpClientConfig::from),
             })
             .map_err(map_err)?;
         signer.init().await.map_err(map_err)?;

--- a/crates/lib/src/signer/config.rs
+++ b/crates/lib/src/signer/config.rs
@@ -428,7 +428,7 @@ impl SignerConfig {
             organization_id,
             private_key_id,
             public_key,
-            None,
+            config.http_config.as_ref().map(|c| c.to_keychain_http_config()),
         )
         .map_err(|e| {
             KoraError::SigningError(format!(
@@ -446,7 +446,14 @@ impl SignerConfig {
         let app_secret = get_env_var_for_signer(&config.app_secret_env, signer_name)?;
         let wallet_id = get_env_var_for_signer(&config.wallet_id_env, signer_name)?;
 
-        Signer::from_privy(app_id, app_secret, wallet_id, None).await.map_err(|e| {
+        Signer::from_privy(
+            app_id,
+            app_secret,
+            wallet_id,
+            config.http_config.as_ref().map(|c| c.to_keychain_http_config()),
+        )
+        .await
+        .map_err(|e| {
             KoraError::SigningError(format!(
                 "Failed to create Privy signer '{signer_name}': {}",
                 sanitize_error!(e)
@@ -463,7 +470,14 @@ impl SignerConfig {
         let key_name = get_env_var_for_signer(&config.key_name_env, signer_name)?;
         let pubkey = get_env_var_for_signer(&config.pubkey_env, signer_name)?;
 
-        Signer::from_vault(vault_addr, vault_token, key_name, pubkey, None).map_err(|e| {
+        Signer::from_vault(
+            vault_addr,
+            vault_token,
+            key_name,
+            pubkey,
+            config.http_config.as_ref().map(|c| c.to_keychain_http_config()),
+        )
+        .map_err(|e| {
             KoraError::SigningError(format!(
                 "Failed to create Vault signer '{signer_name}': {}",
                 sanitize_error!(e)
@@ -552,7 +566,14 @@ impl SignerConfig {
         let api_key_secret = get_env_var_for_signer(&config.api_key_secret_env, signer_name)?;
         let wallet_secret = get_env_var_for_signer(&config.wallet_secret_env, signer_name)?;
         let address = get_env_var_for_signer(&config.address_env, signer_name)?;
-        Signer::from_cdp(api_key_id, api_key_secret, wallet_secret, address, None).map_err(|e| {
+        Signer::from_cdp(
+            api_key_id,
+            api_key_secret,
+            wallet_secret,
+            address,
+            config.http_config.as_ref().map(|c| c.to_keychain_http_config()),
+        )
+        .map_err(|e| {
             KoraError::SigningError(format!(
                 "Failed to create CDP signer '{signer_name}': {}",
                 sanitize_error!(e)

--- a/crates/lib/src/signer/config.rs
+++ b/crates/lib/src/signer/config.rs
@@ -1054,4 +1054,108 @@ private_key_env = "KORA_LOAD_CONFIG_KEY_99"
         assert!(result.is_ok());
         std::env::remove_var("KORA_TEST_PRESENT_KEY_12345");
     }
+
+    #[test]
+    fn test_turnkey_signer_builds_with_no_http_config() {
+        std::env::set_var(
+            "TURNKEY_API_PUBLIC_KEY",
+            "04746f04b2c1b181db8fb777e487504a500a501a500a501a500a501a500a501a501a501a501a501a501a501a501a501a501a501a501a501a501a501a501a50",
+        );
+        std::env::set_var(
+            "TURNKEY_API_PRIVATE_KEY",
+            "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+        );
+        std::env::set_var("TURNKEY_ORG_ID", "test-org");
+        std::env::set_var("TURNKEY_PRIVATE_KEY_ID", "test-key-id");
+        std::env::set_var("TURNKEY_PUBLIC_KEY", "7EcDhSYGxXyscszYEp35KHN8vvw3svAuLKTzXwCFLtV");
+
+        let config = TurnkeySignerConfig {
+            api_public_key_env: "TURNKEY_API_PUBLIC_KEY".to_string(),
+            api_private_key_env: "TURNKEY_API_PRIVATE_KEY".to_string(),
+            organization_id_env: "TURNKEY_ORG_ID".to_string(),
+            private_key_id_env: "TURNKEY_PRIVATE_KEY_ID".to_string(),
+            public_key_env: "TURNKEY_PUBLIC_KEY".to_string(),
+        };
+
+        let result = SignerConfig::build_turnkey_signer(&config, "test");
+        assert!(result.is_ok());
+
+        std::env::remove_var("TURNKEY_API_PUBLIC_KEY");
+        std::env::remove_var("TURNKEY_API_PRIVATE_KEY");
+        std::env::remove_var("TURNKEY_ORG_ID");
+        std::env::remove_var("TURNKEY_PRIVATE_KEY_ID");
+        std::env::remove_var("TURNKEY_PUBLIC_KEY");
+    }
+
+    #[test]
+    fn test_vault_signer_builds_with_no_http_config() {
+        std::env::set_var("VAULT_ADDR", "http://127.0.0.1:8200");
+        std::env::set_var("VAULT_TOKEN", "token");
+        std::env::set_var("VAULT_KEY_NAME", "key");
+        std::env::set_var("VAULT_PUBKEY", "7EcDhSYGxXyscszYEp35KHN8vvw3svAuLKTzXwCFLtV");
+
+        let config = VaultSignerConfig {
+            vault_addr_env: "VAULT_ADDR".to_string(),
+            vault_token_env: "VAULT_TOKEN".to_string(),
+            key_name_env: "VAULT_KEY_NAME".to_string(),
+            pubkey_env: "VAULT_PUBKEY".to_string(),
+        };
+
+        let result = SignerConfig::build_vault_signer(&config, "test");
+        assert!(result.is_ok());
+
+        std::env::remove_var("VAULT_ADDR");
+        std::env::remove_var("VAULT_TOKEN");
+        std::env::remove_var("VAULT_KEY_NAME");
+        std::env::remove_var("VAULT_PUBKEY");
+    }
+
+    #[test]
+    fn test_cdp_signer_builds_with_no_http_config() {
+        std::env::set_var("CDP_API_KEY_ID", "key-id");
+        std::env::set_var("CDP_API_KEY_SECRET", "secret");
+        std::env::set_var("CDP_WALLET_SECRET", "secret");
+        std::env::set_var("CDP_ADDRESS", "7EcDhSYGxXyscszYEp35KHN8vvw3svAuLKTzXwCFLtV");
+
+        let config = CdpSignerConfig {
+            api_key_id_env: "CDP_API_KEY_ID".to_string(),
+            api_key_secret_env: "CDP_API_KEY_SECRET".to_string(),
+            wallet_secret_env: "CDP_WALLET_SECRET".to_string(),
+            address_env: "CDP_ADDRESS".to_string(),
+        };
+
+        let result = SignerConfig::build_cdp_signer(&config, "test");
+        assert!(result.is_ok());
+
+        std::env::remove_var("CDP_API_KEY_ID");
+        std::env::remove_var("CDP_API_KEY_SECRET");
+        std::env::remove_var("CDP_WALLET_SECRET");
+        std::env::remove_var("CDP_ADDRESS");
+    }
+
+    #[tokio::test]
+    async fn test_fireblocks_signer_builds_with_no_http_config() {
+        const TEST_RSA_KEY: &str = "-----BEGIN PRIVATE KEY-----\nMIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQDKKw7fHhfK3/Ts\n-----END PRIVATE KEY-----";
+        std::env::set_var("FIREBLOCKS_API_KEY", "test");
+        std::env::set_var("FIREBLOCKS_PRIVATE_KEY_PEM", TEST_RSA_KEY);
+        std::env::set_var("FIREBLOCKS_VAULT_ACCOUNT_ID", "1");
+
+        let config = FireblocksSignerConfig {
+            api_key_env: "FIREBLOCKS_API_KEY".to_string(),
+            private_key_pem_env: "FIREBLOCKS_PRIVATE_KEY_PEM".to_string(),
+            vault_account_id_env: "FIREBLOCKS_VAULT_ACCOUNT_ID".to_string(),
+            asset_id: None,
+            api_base_url: None,
+            poll_interval_ms: None,
+            max_poll_attempts: None,
+            use_program_call: None,
+        };
+
+        let result = SignerConfig::build_fireblocks_signer(&config, "test").await;
+        assert!(result.is_err());
+
+        std::env::remove_var("FIREBLOCKS_API_KEY");
+        std::env::remove_var("FIREBLOCKS_PRIVATE_KEY_PEM");
+        std::env::remove_var("FIREBLOCKS_VAULT_ACCOUNT_ID");
+    }
 }

--- a/crates/lib/src/tests/config_mock.rs
+++ b/crates/lib/src/tests/config_mock.rs
@@ -858,6 +858,7 @@ impl SignerPoolConfigBuilder {
                     organization_id_env,
                     private_key_id_env,
                     public_key_env,
+                    http_config: None,
                 },
             },
         };
@@ -877,7 +878,12 @@ impl SignerPoolConfigBuilder {
             name,
             weight,
             config: SignerTypeConfig::Privy {
-                config: PrivySignerConfig { app_id_env, app_secret_env, wallet_id_env },
+                config: PrivySignerConfig {
+                    app_id_env,
+                    app_secret_env,
+                    wallet_id_env,
+                    http_config: None,
+                },
             },
         };
         self.config.signers.push(signer);
@@ -901,6 +907,7 @@ impl SignerPoolConfigBuilder {
                     account_id_env,
                     wallet_secret_env,
                     api_base_url: None,
+                    http_config: None,
                 },
             },
         };
@@ -926,6 +933,7 @@ impl SignerPoolConfigBuilder {
                     vault_token_env: token_env,
                     key_name_env,
                     pubkey_env,
+                    http_config: None,
                 },
             },
         };

--- a/crates/lib/src/validator/config_validator.rs
+++ b/crates/lib/src/validator/config_validator.rs
@@ -988,51 +988,6 @@ impl ConfigValidator {
                         SignerValidator::validate_with_result(&signer_config);
                     warnings.extend(signer_warnings);
                     errors.extend(signer_errors);
-
-                    for signer in &signer_config.signers {
-                        let name = &signer.name;
-                        let http_config = match &signer.config {
-                            crate::signer::SignerTypeConfig::Turnkey { config } => {
-                                &config.http_config
-                            }
-                            crate::signer::SignerTypeConfig::Privy { config } => {
-                                &config.http_config
-                            }
-                            crate::signer::SignerTypeConfig::Vault { config } => {
-                                &config.http_config
-                            }
-                            crate::signer::SignerTypeConfig::Cdp { config } => &config.http_config,
-                            crate::signer::SignerTypeConfig::Fireblocks { config } => {
-                                &config.http_config
-                            }
-                            crate::signer::SignerTypeConfig::Dfns { config } => &config.http_config,
-                            crate::signer::SignerTypeConfig::Openfort { config } => {
-                                &config.http_config
-                            }
-                            crate::signer::SignerTypeConfig::Memory { .. } => &None,
-                            crate::signer::SignerTypeConfig::AwsKms { .. } => &None,
-                            crate::signer::SignerTypeConfig::GcpKms { .. } => &None,
-                            crate::signer::SignerTypeConfig::Para { .. } => &None,
-                            crate::signer::SignerTypeConfig::Crossmint { .. } => &None,
-                        };
-
-                        if let Some(c) = http_config {
-                            if let Some(t) = c.request_timeout_secs {
-                                if t == 0 {
-                                    errors.push(format!(
-                                        "request_timeout_secs must be greater than 0 for signer '{name}'"
-                                    ));
-                                }
-                            }
-                            if let Some(t) = c.connect_timeout_secs {
-                                if t == 0 {
-                                    errors.push(format!(
-                                        "connect_timeout_secs must be greater than 0 for signer '{name}'"
-                                    ));
-                                }
-                            }
-                        }
-                    }
                 }
                 Err(e) => {
                     errors.push(format!("Failed to load signers config: {e}"));

--- a/crates/lib/src/validator/config_validator.rs
+++ b/crates/lib/src/validator/config_validator.rs
@@ -988,6 +988,51 @@ impl ConfigValidator {
                         SignerValidator::validate_with_result(&signer_config);
                     warnings.extend(signer_warnings);
                     errors.extend(signer_errors);
+
+                    for signer in &signer_config.signers {
+                        let name = &signer.name;
+                        let http_config = match &signer.config {
+                            crate::signer::SignerTypeConfig::Turnkey { config } => {
+                                &config.http_config
+                            }
+                            crate::signer::SignerTypeConfig::Privy { config } => {
+                                &config.http_config
+                            }
+                            crate::signer::SignerTypeConfig::Vault { config } => {
+                                &config.http_config
+                            }
+                            crate::signer::SignerTypeConfig::Cdp { config } => &config.http_config,
+                            crate::signer::SignerTypeConfig::Fireblocks { config } => {
+                                &config.http_config
+                            }
+                            crate::signer::SignerTypeConfig::Dfns { config } => &config.http_config,
+                            crate::signer::SignerTypeConfig::Openfort { config } => {
+                                &config.http_config
+                            }
+                            crate::signer::SignerTypeConfig::Memory { .. } => &None,
+                            crate::signer::SignerTypeConfig::AwsKms { .. } => &None,
+                            crate::signer::SignerTypeConfig::GcpKms { .. } => &None,
+                            crate::signer::SignerTypeConfig::Para { .. } => &None,
+                            crate::signer::SignerTypeConfig::Crossmint { .. } => &None,
+                        };
+
+                        if let Some(c) = http_config {
+                            if let Some(t) = c.request_timeout_secs {
+                                if t == 0 {
+                                    errors.push(format!(
+                                        "request_timeout_secs must be greater than 0 for signer '{name}'"
+                                    ));
+                                }
+                            }
+                            if let Some(t) = c.connect_timeout_secs {
+                                if t == 0 {
+                                    errors.push(format!(
+                                        "connect_timeout_secs must be greater than 0 for signer '{name}'"
+                                    ));
+                                }
+                            }
+                        }
+                    }
                 }
                 Err(e) => {
                     errors.push(format!("Failed to load signers config: {e}"));
@@ -3199,5 +3244,95 @@ mod tests {
         assert!(w.contains("found on:"), "expected 'found on:' in warning");
         assert!(w.contains("devnet"), "expected cluster name in warning");
         assert!(w.contains("possible cluster mismatch"), "expected mismatch note");
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_validate_signers_http_config() {
+        use std::io::Write;
+        use tempfile::NamedTempFile;
+
+        std::env::set_var("JUPITER_API_KEY", "test-api-key");
+        let config = Config {
+            validation: ValidationConfig {
+                max_allowed_lamports: 1_000_000,
+                max_signatures: 10,
+                allowed_programs: ProgramsConfig::Allowlist(vec![
+                    SYSTEM_PROGRAM_ID.to_string(),
+                    SPL_TOKEN_PROGRAM_ID.to_string(),
+                ]),
+                allowed_tokens: vec!["4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU".to_string()],
+                allowed_spl_paid_tokens: SplTokenConfig::Allowlist(vec![
+                    "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU".to_string(),
+                ]),
+                disallowed_accounts: vec![],
+                price_source: PriceSource::Jupiter,
+                fee_payer_policy: FeePayerPolicy::default(),
+                price: PriceConfig::default(),
+                token_2022: Token2022Config::default(),
+                allow_durable_transactions: false,
+                max_price_staleness_slots: 0,
+                require_one_of_programs: vec![],
+                cross_cluster_check: false,
+                cross_cluster_endpoints: vec![],
+            },
+            kora: KoraConfig::default(),
+            metrics: MetricsConfig::default(),
+        };
+
+        let _ = update_config(config);
+
+        let toml_content = r#"
+[signer_pool]
+strategy = "round_robin"
+
+[[signers]]
+name = "turnkey_signer_invalid"
+type = "turnkey"
+api_public_key_env = "TURNKEY_API_PUBLIC_KEY"
+api_private_key_env = "TURNKEY_API_PRIVATE_KEY"
+organization_id_env = "TURNKEY_ORG_ID"
+private_key_id_env = "TURNKEY_PRIVATE_KEY_ID"
+public_key_env = "TURNKEY_PUBLIC_KEY"
+http_config = { request_timeout_secs = 0, connect_timeout_secs = 0 }
+"#;
+
+        let mut temp_file = NamedTempFile::new().unwrap();
+        temp_file.write_all(toml_content.as_bytes()).unwrap();
+        temp_file.flush().unwrap();
+
+        std::env::set_var("TURNKEY_API_PUBLIC_KEY", "dummy");
+        std::env::set_var("TURNKEY_API_PRIVATE_KEY", "dummy");
+        std::env::set_var("TURNKEY_ORG_ID", "dummy");
+        std::env::set_var("TURNKEY_PRIVATE_KEY_ID", "dummy");
+        std::env::set_var("TURNKEY_PUBLIC_KEY", "7EcDhSYGxXyscszYEp35KHN8vvw3svAuLKTzXwCFLtV");
+
+        let rpc_client = RpcClient::new_with_commitment(
+            "http://localhost:8899".to_string(),
+            CommitmentConfig::confirmed(),
+        );
+
+        let result = ConfigValidator::validate_with_result_and_signers(
+            &rpc_client,
+            true,
+            Some(temp_file.path()),
+        )
+        .await;
+
+        std::env::remove_var("TURNKEY_API_PUBLIC_KEY");
+        std::env::remove_var("TURNKEY_API_PRIVATE_KEY");
+        std::env::remove_var("TURNKEY_ORG_ID");
+        std::env::remove_var("TURNKEY_PRIVATE_KEY_ID");
+        std::env::remove_var("TURNKEY_PUBLIC_KEY");
+        std::env::remove_var("JUPITER_API_KEY");
+
+        assert!(result.is_err());
+        let errors = result.unwrap_err();
+        assert!(errors.iter().any(|e| e.contains(
+            "request_timeout_secs must be greater than 0 for signer 'turnkey_signer_invalid'"
+        )));
+        assert!(errors.iter().any(|e| e.contains(
+            "connect_timeout_secs must be greater than 0 for signer 'turnkey_signer_invalid'"
+        )));
     }
 }

--- a/crates/lib/src/validator/signer_validator.rs
+++ b/crates/lib/src/validator/signer_validator.rs
@@ -1,6 +1,6 @@
 use crate::{
     error::KoraError,
-    signer::{SelectionStrategy, SignerPoolConfig},
+    signer::{SelectionStrategy, SignerPoolConfig, SignerTypeConfig},
 };
 
 pub struct SignerValidator {}
@@ -27,6 +27,41 @@ impl SignerValidator {
 
         // Generate strategy-specific warnings
         Self::validate_strategy_warnings(config, &mut warnings);
+
+        for signer in &config.signers {
+            let name = &signer.name;
+            let http_config = match &signer.config {
+                SignerTypeConfig::Turnkey { config } => &config.http_config,
+                SignerTypeConfig::Privy { config } => &config.http_config,
+                SignerTypeConfig::Vault { config } => &config.http_config,
+                SignerTypeConfig::Cdp { config } => &config.http_config,
+                SignerTypeConfig::Fireblocks { config } => &config.http_config,
+                SignerTypeConfig::Dfns { config } => &config.http_config,
+                SignerTypeConfig::Openfort { config } => &config.http_config,
+                SignerTypeConfig::Memory { .. } => &None,
+                SignerTypeConfig::AwsKms { .. } => &None,
+                SignerTypeConfig::GcpKms { .. } => &None,
+                SignerTypeConfig::Para { .. } => &None,
+                SignerTypeConfig::Crossmint { .. } => &None,
+            };
+
+            if let Some(c) = http_config {
+                if let Some(t) = c.request_timeout_secs {
+                    if t == 0 {
+                        errors.push(format!(
+                            "request_timeout_secs must be greater than 0 for signer '{name}'"
+                        ));
+                    }
+                }
+                if let Some(t) = c.connect_timeout_secs {
+                    if t == 0 {
+                        errors.push(format!(
+                            "connect_timeout_secs must be greater than 0 for signer '{name}'"
+                        ));
+                    }
+                }
+            }
+        }
 
         (warnings, errors)
     }

--- a/signers.example.toml
+++ b/signers.example.toml
@@ -28,6 +28,7 @@ api_private_key_env = "TURNKEY_API_PRIVATE_KEY_1"
 organization_id_env = "TURNKEY_ORG_ID_1"
 private_key_id_env = "TURNKEY_PRIVATE_KEY_ID_1"
 public_key_env = "TURNKEY_PUBLIC_KEY_1"
+# http_config = { request_timeout_secs = 30, connect_timeout_secs = 10 }
 weight = 2                                        # Higher weight = selected more often
 
 # Privy signer example
@@ -37,6 +38,7 @@ type = "privy"
 app_id_env = "PRIVY_APP_ID_1"
 app_secret_env = "PRIVY_APP_SECRET_1"
 wallet_id_env = "PRIVY_WALLET_ID_1"
+# http_config = { request_timeout_secs = 30, connect_timeout_secs = 10 }
 weight = 1
 
 # Vault signer example
@@ -47,6 +49,7 @@ addr_env = "VAULT_ADDR_1"
 token_env = "VAULT_TOKEN_1"
 key_name_env = "VAULT_KEY_NAME_1"
 pubkey_env = "VAULT_PUBKEY_1"
+# http_config = { request_timeout_secs = 30, connect_timeout_secs = 10 }
 weight = 1
 
 # Openfort backend wallet signer example
@@ -58,6 +61,7 @@ account_id_env = "OPENFORT_ACCOUNT_ID_1"
 wallet_secret_env = "OPENFORT_WALLET_SECRET_1"
 # Optional: override the Openfort API base URL (defaults to https://api.openfort.io). Must be HTTPS.
 # api_base_url = "https://staging.openfort.io"
+# http_config = { request_timeout_secs = 30, connect_timeout_secs = 10 }
 weight = 1
 
 # Environment Variables Required:


### PR DESCRIPTION
Remote signer providers (Turnkey, Privy, Vault, CDP, Fireblocks, Dfns, Openfort) were all constructed with `None` for HTTP client config, leaving Kora dependent on provider defaults for timeouts in one of its most sensitive subsystems.

Added an optional `http_config` block to each remote signer config struct:

```toml
http_config = { request_timeout_secs = 30, connect_timeout_secs = 10 }
```

- Optional field with `serde(default)` on each signer struct so existing configs require no changes
- Mapped to `solana_keychain::HttpClientConfig` via `From` impl
- Zero values rejected in `SignerValidator` with a descriptive error
- Documented in `signers.example.toml`