### PR TITLE
fix(devnet-deploy-paymaster): build reaper image via cargo install

### DIFF
--- a/.github/workflows/deploy-devnet-paymaster.yml
+++ b/.github/workflows/deploy-devnet-paymaster.yml
@@ -102,7 +102,7 @@ jobs:
           set -euo pipefail
           IMAGE="${REGION}-docker.pkg.dev/${PROJECT}/cloud-run-source-deploy/${JOB}:${GITHUB_SHA::12}"
 
-          BUILD_ID=$(gcloud builds submit . \
+          BUILD_ID=$(gcloud builds submit examples/devnet-deploy-paymaster/ \
             --config=examples/devnet-deploy-paymaster/cloudbuild.reaper.yaml \
             --substitutions="_IMAGE=$IMAGE" \
             --project="$PROJECT" \

--- a/examples/devnet-deploy-paymaster/Dockerfile.reaper
+++ b/examples/devnet-deploy-paymaster/Dockerfile.reaper
@@ -1,17 +1,12 @@
-FROM rustlang/rust:nightly AS builder
-WORKDIR /workspace
-COPY . .
-RUN cargo build --release --package devnet-deploy-paymaster --bin devnet_deploy_reaper
+FROM rustlang/rust:nightly
 
-FROM debian:bookworm-slim
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends ca-certificates \
-    && rm -rf /var/lib/apt/lists/*
+RUN cargo install \
+    --git https://github.com/solana-foundation/kora \
+    --branch main \
+    --bin devnet_deploy_reaper \
+    devnet-deploy-paymaster
 
-WORKDIR /app
-COPY --from=builder /workspace/target/release/devnet_deploy_reaper /usr/local/bin/devnet_deploy_reaper
-COPY examples/devnet-deploy-paymaster/kora.toml ./kora.toml
-COPY examples/devnet-deploy-paymaster/signers.toml ./signers.toml
+COPY kora.toml ./
+COPY signers.toml ./
 
-ENTRYPOINT ["devnet_deploy_reaper"]
-CMD ["--config", "kora.toml", "--signers-config", "signers.toml", "--threshold-hours", "168"]
+CMD devnet_deploy_reaper --config kora.toml --signers-config signers.toml --threshold-hours ${THRESHOLD_HOURS:-168}

--- a/examples/devnet-deploy-paymaster/cloudbuild.reaper.yaml
+++ b/examples/devnet-deploy-paymaster/cloudbuild.reaper.yaml
@@ -1,10 +1,9 @@
-# Build context = repo root (path deps on kora-lib).
 steps:
   - name: gcr.io/cloud-builders/docker
     args:
       - build
       - -f
-      - examples/devnet-deploy-paymaster/Dockerfile.reaper
+      - Dockerfile.reaper
       - -t
       - ${_IMAGE}
       - .


### PR DESCRIPTION
## Summary
- Rewrite `Dockerfile.reaper` to mirror the existing RPC `Dockerfile`: single stage, `cargo install --git https://github.com/solana-foundation/kora --branch main --bin devnet_deploy_reaper devnet-deploy-paymaster`.
- Build context shrinks from repo root to `examples/devnet-deploy-paymaster/` (cargo install fetches source from git, no path deps).
- `cloudbuild.reaper.yaml` `-f` path is now relative to the new context.

## Why
The first deploy run (#26589547659) failed in Cloud Build with rustup's cross-device-link bug — `cargo build` triggered `rust-toolchain.toml` to sync components inside the docker overlay fs, which can't rename across layer mounts. The RPC image doesn't hit this because `cargo install --git` builds in a fresh tmp dir with no toolchain.toml in cwd. Match that pattern.

## Test Plan
- [ ] After merge: trigger **Deploy devnet paymaster** workflow on `main`; verify both Cloud Build steps succeed and `gcloud run jobs update kora-devnet-reaper` lands the new image.
- [ ] Then manual dry-run: `gcloud run jobs execute kora-devnet-reaper --region=us-central1 --project=devnet-tools --args="--config,kora.toml,--signers-config,signers.toml,--dry-run"`.