### PR TITLE
fix(devnet-deploy-paymaster): exec-form ENTRYPOINT + deploy_target input

### DIFF
--- a/.github/workflows/deploy-devnet-paymaster.yml
+++ b/.github/workflows/deploy-devnet-paymaster.yml
@@ -7,6 +7,15 @@ on:
         description: "Git ref to deploy"
         required: false
         default: main
+      deploy_target:
+        description: "What to deploy"
+        required: false
+        default: both
+        type: choice
+        options:
+          - both
+          - rpc
+          - reaper
 
 permissions:
   contents: read
@@ -38,6 +47,7 @@ jobs:
       - uses: google-github-actions/setup-gcloud@v3
 
       - id: build
+        if: inputs.deploy_target == 'both' || inputs.deploy_target == 'rpc'
         env:
           REGION: ${{ env.GCP_REGION }}
           PROJECT: ${{ env.GCP_PROJECT_ID }}
@@ -71,6 +81,7 @@ jobs:
           echo "image=$IMAGE" >> "$GITHUB_OUTPUT"
 
       - id: deploy
+        if: inputs.deploy_target == 'both' || inputs.deploy_target == 'rpc'
         uses: google-github-actions/deploy-cloudrun@v3
         with:
           service: ${{ env.CLOUD_RUN_SERVICE }}
@@ -91,9 +102,11 @@ jobs:
             --vpc-egress=private-ranges-only
 
       - name: Print service URL
+        if: inputs.deploy_target == 'both' || inputs.deploy_target == 'rpc'
         run: echo "Deployed ${{ env.CLOUD_RUN_SERVICE }} -> ${{ steps.deploy.outputs.url }}"
 
       - id: build-reaper
+        if: inputs.deploy_target == 'both' || inputs.deploy_target == 'reaper'
         env:
           REGION: ${{ env.GCP_REGION }}
           PROJECT: ${{ env.GCP_PROJECT_ID }}
@@ -127,6 +140,7 @@ jobs:
           echo "image=$IMAGE" >> "$GITHUB_OUTPUT"
 
       - id: deploy-reaper
+        if: inputs.deploy_target == 'both' || inputs.deploy_target == 'reaper'
         uses: google-github-actions/deploy-cloudrun@v3
         with:
           job: ${{ env.CLOUD_RUN_REAPER_JOB }}
@@ -140,4 +154,5 @@ jobs:
           env_vars_update_strategy: overwrite
 
       - name: Print reaper job
+        if: inputs.deploy_target == 'both' || inputs.deploy_target == 'reaper'
         run: echo "Updated Cloud Run Job ${{ env.CLOUD_RUN_REAPER_JOB }} (image ${{ steps.build-reaper.outputs.image }})"

--- a/examples/devnet-deploy-paymaster/Dockerfile.reaper
+++ b/examples/devnet-deploy-paymaster/Dockerfile.reaper
@@ -9,4 +9,4 @@ RUN cargo install \
 COPY kora.toml ./
 COPY signers.toml ./
 
-CMD devnet_deploy_reaper --config kora.toml --signers-config signers.toml --threshold-hours ${THRESHOLD_HOURS:-168}
+ENTRYPOINT ["devnet_deploy_reaper", "--config", "kora.toml", "--signers-config", "signers.toml"]


### PR DESCRIPTION
## Summary
- **fix:** rewrite `Dockerfile.reaper` `CMD` as exec-form `ENTRYPOINT`. Shell-form `CMD` doesn't survive Cloud Run Job `--args` overrides — the override replaces the whole `/bin/sh -c "..."` invocation, leaving `sh` confused. Previous job execution `kora-devnet-reaper-bg66l` failed with "Application failed to start" because of this.
- **feat:** add `deploy_target` workflow_dispatch input (`both` / `rpc` / `reaper`, default `both`) with `if:` guards on the per-side build/deploy steps. Lets manual triggers redeploy only the reaper without the ~15 min RPC rebuild.

## Test Plan
- [ ] Merge to main
- [ ] Trigger **Deploy devnet paymaster** with `deploy_target=reaper`; verify only reaper steps run, RPC steps skipped
- [ ] After deploy, manual dry-run: `gcloud run jobs execute kora-devnet-reaper --region=us-central1 --project=devnet-tools --args="--threshold-hours,168,--dry-run"`; verify container starts and `dry-run: 0 program(s) would be closed` logs (or whatever count) appears