### PR TITLE
fix(plugin): harden deploy_authority against further fee-payer drains

### DIFF
--- a/crates/lib/src/plugin/plugin_deploy_authority.rs
+++ b/crates/lib/src/plugin/plugin_deploy_authority.rs
@@ -113,12 +113,21 @@ impl TransactionPlugin for DeployAuthorityPlugin {
                     }
                 }
                 ParsedBpfLoaderUpgradeableInstructionData::Upgrade {
-                    upgrade_authority, ..
+                    upgrade_authority,
+                    spill,
+                    ..
                 } => {
                     if upgrade_authority != fee_payer {
                         return Err(KoraError::InvalidTransaction(format!(
                             "DeployAuthority plugin: Upgrade upgrade_authority must be the \
                              fee payer ({fee_payer}), got {upgrade_authority} in {}",
+                            context.method_name()
+                        )));
+                    }
+                    if spill != fee_payer {
+                        return Err(KoraError::InvalidTransaction(format!(
+                            "DeployAuthority plugin: Upgrade spill must be the fee payer \
+                             ({fee_payer}), got {spill} in {}",
                             context.method_name()
                         )));
                     }
@@ -207,8 +216,20 @@ impl TransactionPlugin for DeployAuthorityPlugin {
             }
         }
 
-        // Fee-payer-funded CreateAccount must land in a loader-owned account, else the caller
-        // siphons the deploy budget into a wallet they control.
+        // A fee-payer-funded account must be loader-owned and, for loader-v3, consumed in the same
+        // tx (buffer init or program deploy) — otherwise its rent is siphoned or stranded.
+        let mut v3_consumed: Vec<Pubkey> = Vec::new();
+        for data in bpf_v3.values().flatten() {
+            match data {
+                ParsedBpfLoaderUpgradeableInstructionData::InitializeBuffer { buffer, .. } => {
+                    v3_consumed.push(*buffer)
+                }
+                ParsedBpfLoaderUpgradeableInstructionData::DeployWithMaxDataLen {
+                    program, ..
+                } => v3_consumed.push(*program),
+                _ => {}
+            }
+        }
         let system = transaction.get_or_parse_system_instructions()?.clone();
         for data in
             system.get(&ParsedSystemInstructionType::SystemCreateAccount).into_iter().flatten()
@@ -220,14 +241,23 @@ impl TransactionPlugin for DeployAuthorityPlugin {
                 ..
             } = data
             {
-                if payer == fee_payer
-                    && *owner != BPF_LOADER_UPGRADEABLE_PROGRAM_ID
-                    && *owner != LOADER_V4_PROGRAM_ID
-                {
+                if payer != fee_payer {
+                    continue;
+                }
+                if *owner != BPF_LOADER_UPGRADEABLE_PROGRAM_ID && *owner != LOADER_V4_PROGRAM_ID {
                     return Err(KoraError::InvalidTransaction(format!(
                         "DeployAuthority plugin: fee payer ({fee_payer}) may only fund \
                          loader-owned accounts; CreateAccount for {new_account} assigns owner \
                          {owner} in {}",
+                        context.method_name()
+                    )));
+                }
+                if *owner == BPF_LOADER_UPGRADEABLE_PROGRAM_ID && !v3_consumed.contains(new_account)
+                {
+                    return Err(KoraError::InvalidTransaction(format!(
+                        "DeployAuthority plugin: fee payer ({fee_payer}) funded CreateAccount for \
+                         {new_account} that is not initialized as a buffer or deployed as a \
+                         program in the same transaction in {}",
                         context.method_name()
                     )));
                 }
@@ -326,8 +356,17 @@ mod tests {
         fee_payer: &Pubkey,
         ix: solana_sdk::instruction::Instruction,
     ) -> Result<(), KoraError> {
+        run_plugin_ixs(config, rpc_client, fee_payer, &[ix]).await
+    }
+
+    async fn run_plugin_ixs(
+        config: &Config,
+        rpc_client: &Arc<RpcClient>,
+        fee_payer: &Pubkey,
+        ixs: &[solana_sdk::instruction::Instruction],
+    ) -> Result<(), KoraError> {
         let tx = TransactionUtil::new_unsigned_versioned_transaction(VersionedMessage::Legacy(
-            Message::new(&[ix], Some(fee_payer)),
+            Message::new(ixs, Some(fee_payer)),
         ));
         let mut resolved = VersionedTransactionResolved::from_kora_built_transaction(&tx).unwrap();
         let runner = TransactionPluginRunner::from_config(config);
@@ -697,6 +736,33 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn v3_rejects_upgrade_with_foreign_spill() {
+        use solana_loader_v3_interface::instruction as loader_v3;
+        let (config, rpc_client) = build_runner_v3();
+        let fee_payer = Pubkey::new_unique();
+        let program = Pubkey::new_unique();
+        let buffer = Pubkey::new_unique();
+        let attacker = Pubkey::new_unique();
+        let ix = loader_v3::upgrade(&program, &buffer, &fee_payer, &attacker);
+        let err = run_plugin(&config, &rpc_client, &fee_payer, ix).await.expect_err("must reject");
+        assert!(
+            matches!(&err, KoraError::InvalidTransaction(msg) if msg.contains("Upgrade spill")),
+            "{err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn v3_accepts_upgrade_spill_to_kora() {
+        use solana_loader_v3_interface::instruction as loader_v3;
+        let (config, rpc_client) = build_runner_v3();
+        let fee_payer = Pubkey::new_unique();
+        let program = Pubkey::new_unique();
+        let buffer = Pubkey::new_unique();
+        let ix = loader_v3::upgrade(&program, &buffer, &fee_payer, &fee_payer);
+        assert!(run_plugin(&config, &rpc_client, &fee_payer, ix).await.is_ok());
+    }
+
+    #[tokio::test]
     async fn rejects_create_account_funding_caller_wallet() {
         let (config, rpc_client) = build_runner_v3();
         let fee_payer = Pubkey::new_unique();
@@ -716,7 +782,31 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn accepts_create_account_funding_loader_owned_account() {
+    async fn accepts_create_account_paired_with_initialize_buffer() {
+        use solana_loader_v3_interface::instruction as loader_v3;
+        let (config, rpc_client) = build_runner_v3();
+        let fee_payer = Pubkey::new_unique();
+        let buffer = Pubkey::new_unique();
+        let ixs = loader_v3::create_buffer(&fee_payer, &buffer, &fee_payer, 1_000_000, 0).unwrap();
+        assert!(run_plugin_ixs(&config, &rpc_client, &fee_payer, &ixs).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn accepts_create_account_paired_with_deploy() {
+        use solana_loader_v3_interface::instruction as loader_v3;
+        let (config, rpc_client) = build_runner_v3();
+        let fee_payer = Pubkey::new_unique();
+        let program = Pubkey::new_unique();
+        let buffer = Pubkey::new_unique();
+        let ixs = loader_v3::deploy_with_max_program_len(
+            &fee_payer, &program, &buffer, &fee_payer, 1_000_000, 0,
+        )
+        .unwrap();
+        assert!(run_plugin_ixs(&config, &rpc_client, &fee_payer, &ixs).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn rejects_orphan_loader_owned_create_account() {
         let (config, rpc_client) = build_runner_v3();
         let fee_payer = Pubkey::new_unique();
         let buffer = Pubkey::new_unique();
@@ -727,7 +817,12 @@ mod tests {
             36,
             &BPF_LOADER_UPGRADEABLE_PROGRAM_ID,
         );
-        assert!(run_plugin(&config, &rpc_client, &fee_payer, ix).await.is_ok());
+        let err = run_plugin(&config, &rpc_client, &fee_payer, ix).await.expect_err("must reject");
+        assert!(
+            matches!(&err, KoraError::InvalidTransaction(msg)
+                if msg.contains("not initialized as a buffer or deployed as a program")),
+            "{err:?}"
+        );
     }
 
     #[tokio::test]

--- a/examples/devnet-deploy-paymaster/kora.toml
+++ b/examples/devnet-deploy-paymaster/kora.toml
@@ -56,9 +56,8 @@ blocked_account_extensions = []
 [validation.fee_payer_policy.system]
 allow_transfer = false
 allow_assign = false
-# Needed so Kora can fund the loader-v4 program account (CreateAccount + SetProgramLength).
 allow_create_account = true
-allow_allocate = true
+allow_allocate = false
 
 [validation.fee_payer_policy.system.nonce]
 allow_initialize = false


### PR DESCRIPTION
## Summary
Hardens the devnet deploy paymaster against three further fee-payer vectors found against the live deployer.

**Plugin (`DeployAuthorityPlugin`):**
- **Upgrade `spill` redirect.** `Upgrade` only checked `upgrade_authority`, not `spill`. Since this paymaster owns its programs and is the upgrade authority, a caller could upgrade a Kora-owned program from a Kora-funded buffer with `spill = attacker`, redirecting the buffer's lamports to themselves. Now requires `spill == fee_payer`, mirroring the `Close` recipient guard.
- **Orphan loader-owned CreateAccount.** A fee-payer-funded loader-v3 `CreateAccount` wasn't required to be consumed in the same tx, allowing a loader-owned account that strands the rent. Now the new account must be initialized as a buffer (`InitializeBuffer`) or deployed as a program (`DeployWithMaxDataLen`) in the same transaction — matching how the CLI and standard tooling bundle these. (loader-v4 pairing is left for when v4 is enabled; its parser doesn't expose the target account.)

**Config (`kora.toml`):**
- **Disable `allow_allocate`.** The deploy flow never emits System `Allocate` (programdata is sized via CreateAccount/SetProgramLength), and the only Allocate the fee payer can sign targets its own account — which a large allocation could push below rent-exemption. Disabled at the config layer; the core fee-payer policy then rejects it (no plugin guard needed, since `allow_allocate` already expresses this).

## Test Plan
- Unit tests in `plugin_deploy_authority.rs`:
  - reject Upgrade with foreign spill; accept spill == fee payer
  - accept CreateAccount paired with InitializeBuffer and with DeployWithMaxDataLen; reject an orphan loader-owned CreateAccount
- `cargo test -p kora-lib --lib plugin_deploy_authority` → 36 passed


## 📊 Unit Test Coverage
![Coverage](https://img.shields.io/badge/coverage-84.7%25-green)

**Unit Test Coverage: 84.7%**

[View Detailed Coverage Report](https://github.com/solana-foundation/kora/actions/runs/26905026163)