### PR TITLE
fix(plugin): count programdata in loader CreateAccount pairing check

### DIFF
--- a/crates/lib/src/plugin/plugin_deploy_authority.rs
+++ b/crates/lib/src/plugin/plugin_deploy_authority.rs
@@ -225,8 +225,13 @@ impl TransactionPlugin for DeployAuthorityPlugin {
                     v3_consumed.push(*buffer)
                 }
                 ParsedBpfLoaderUpgradeableInstructionData::DeployWithMaxDataLen {
-                    program, ..
-                } => v3_consumed.push(*program),
+                    program,
+                    program_data,
+                    ..
+                } => {
+                    v3_consumed.push(*program);
+                    v3_consumed.push(*program_data);
+                }
                 _ => {}
             }
         }
@@ -792,16 +797,25 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn accepts_create_account_paired_with_deploy() {
+    async fn accepts_deploy_with_inner_programdata_create() {
         use solana_loader_v3_interface::instruction as loader_v3;
         let (config, rpc_client) = build_runner_v3();
         let fee_payer = Pubkey::new_unique();
         let program = Pubkey::new_unique();
         let buffer = Pubkey::new_unique();
-        let ixs = loader_v3::deploy_with_max_program_len(
+        let program_data =
+            Pubkey::find_program_address(&[program.as_ref()], &BPF_LOADER_UPGRADEABLE_PROGRAM_ID).0;
+        let mut ixs = loader_v3::deploy_with_max_program_len(
             &fee_payer, &program, &buffer, &fee_payer, 1_000_000, 0,
         )
         .unwrap();
+        ixs.push(system_create_account(
+            &fee_payer,
+            &program_data,
+            1_000_000,
+            0,
+            &BPF_LOADER_UPGRADEABLE_PROGRAM_ID,
+        ));
         assert!(run_plugin_ixs(&config, &rpc_client, &fee_payer, &ixs).await.is_ok());
     }
 


### PR DESCRIPTION
## Summary
**Hotfix** — the orphan-pairing guard added in #542 rejects legitimate deploys.

`DeployWithMaxDataLen` creates the programdata account **internally**, which Kora surfaces as an inner `CreateAccount` (loader-owned, fee-payer-funded). The guard's "consumed in the same tx" set only included `DeployWithMaxDataLen.program`, not `.program_data`, so the inner programdata create failed the check and the whole deploy was rejected. Adds `program_data` to the consumed set.

The unit tests missed this because `from_kora_built_transaction` does not simulate, so the inner instruction never appeared — caught by the live suite, whose provisioning does a real deploy.

## Test Plan
- `accepts_deploy_with_inner_programdata_create` now appends the programdata `CreateAccount` that simulation surfaces, and passes with the fix.
- `cargo test -p kora-lib --lib plugin_deploy_authority` → 36 passed
- Will re-run the live adversarial suite after deploy to confirm deploys work again and U1/A1/#4 still reject.

## 📊 Unit Test Coverage
![Coverage](https://img.shields.io/badge/coverage-84.7%25-green)

**Unit Test Coverage: 84.7%**

[View Detailed Coverage Report](https://github.com/solana-foundation/kora/actions/runs/26907215764)