### PR TITLE
feat(devnet-deploy-paymaster): reap orphan loader-v3 buffers

### DIFF
--- a/examples/devnet-deploy-paymaster/src/reaper/closer.rs
+++ b/examples/devnet-deploy-paymaster/src/reaper/closer.rs
@@ -13,7 +13,7 @@ use solana_sdk::{
     pubkey::Pubkey,
 };
 
-use super::{ClosedProgram, Loader, OwnedProgram};
+use super::{AccountKind, ClosedProgram, Loader, OwnedProgram};
 
 pub async fn close_program(
     rpc: &Arc<RpcClient>,
@@ -59,6 +59,9 @@ pub async fn close_program(
 }
 
 fn build_v3_close(fee_payer: &Pubkey, program: &OwnedProgram) -> Result<Vec<Instruction>> {
+    if program.kind == AccountKind::Buffer {
+        return Ok(vec![loader_v3::close_any(&program.program, fee_payer, Some(fee_payer), None)]);
+    }
     let program_data = program
         .program_data
         .ok_or_else(|| anyhow!("v3 program {} missing program_data", program.program))?;
@@ -97,6 +100,7 @@ mod tests {
         let fee_payer = Pubkey::new_unique();
         let p = OwnedProgram {
             loader: Loader::V3,
+            kind: AccountKind::Program,
             program: Pubkey::new_unique(),
             program_data: Some(Pubkey::new_unique()),
             last_state_slot: 100,
@@ -114,9 +118,33 @@ mod tests {
     }
 
     #[test]
+    fn build_v3_close_buffer_targets_buffer_with_no_program_account() {
+        let fee_payer = Pubkey::new_unique();
+        let buffer = Pubkey::new_unique();
+        let b = OwnedProgram {
+            loader: Loader::V3,
+            kind: AccountKind::Buffer,
+            program: buffer,
+            program_data: None,
+            last_state_slot: 0,
+        };
+        let ixs = build_v3_close(&fee_payer, &b).unwrap();
+
+        assert_eq!(ixs.len(), 1);
+        let ix = &ixs[0];
+        // close_any: [buffer, recipient, authority]
+        assert_eq!(ix.accounts.len(), 3);
+        assert_eq!(ix.accounts[0].pubkey, buffer);
+        assert_eq!(ix.accounts[1].pubkey, fee_payer);
+        assert_eq!(ix.accounts[2].pubkey, fee_payer);
+        assert!(ix.accounts[2].is_signer);
+    }
+
+    #[test]
     fn build_v3_close_errors_without_program_data() {
         let bad = OwnedProgram {
             loader: Loader::V3,
+            kind: AccountKind::Program,
             program: Pubkey::new_unique(),
             program_data: None,
             last_state_slot: 0,
@@ -129,6 +157,7 @@ mod tests {
         let fee_payer = Pubkey::new_unique();
         let p = OwnedProgram {
             loader: Loader::V4,
+            kind: AccountKind::Program,
             program: Pubkey::new_unique(),
             program_data: None,
             last_state_slot: 0,

--- a/examples/devnet-deploy-paymaster/src/reaper/discovery.rs
+++ b/examples/devnet-deploy-paymaster/src/reaper/discovery.rs
@@ -13,7 +13,7 @@ use solana_loader_v3_interface::state::UpgradeableLoaderState;
 use solana_loader_v4_interface::state::LoaderV4State;
 use solana_sdk::pubkey::Pubkey;
 
-use super::{Loader, OwnedProgram};
+use super::{AccountKind, Loader, OwnedProgram};
 
 // UpgradeableLoaderState::ProgramData bincode layout: [discriminator 4][slot 8][Option tag 1][authority 32]
 const V3_PROGRAMDATA_DISCRIMINATOR: [u8; 4] = [3, 0, 0, 0];
@@ -25,6 +25,10 @@ const V3_PROGRAM_DISCRIMINATOR: [u8; 4] = [2, 0, 0, 0];
 const V3_PROGRAM_PDATA_OFFSET: usize = 4;
 const V3_PROGRAM_ACCOUNT_SIZE: u64 = UpgradeableLoaderState::size_of_program() as u64;
 
+// UpgradeableLoaderState::Buffer bincode layout: [discriminator 4][Option tag 1][authority 32]
+const V3_BUFFER_DISCRIMINATOR: [u8; 4] = [1, 0, 0, 0];
+const V3_BUFFER_AUTH_OFFSET: usize = 5;
+
 const V4_SLOT_OFFSET: usize = std::mem::offset_of!(LoaderV4State, slot);
 const V4_AUTH_OFFSET: usize =
     std::mem::offset_of!(LoaderV4State, authority_address_or_next_version);
@@ -35,8 +39,46 @@ pub async fn discover_owned_programs(
 ) -> Result<Vec<OwnedProgram>> {
     let mut out = Vec::new();
     out.extend(discover_v3(rpc, fee_payer).await.context("discover v3")?);
+    out.extend(discover_v3_buffers(rpc, fee_payer).await.context("discover v3 buffers")?);
     out.extend(discover_v4(rpc, fee_payer).await.context("discover v4")?);
     Ok(out)
+}
+
+async fn discover_v3_buffers(
+    rpc: &Arc<RpcClient>,
+    fee_payer: &Pubkey,
+) -> Result<Vec<OwnedProgram>> {
+    let filters = vec![
+        RpcFilterType::Memcmp(Memcmp::new_raw_bytes(0, V3_BUFFER_DISCRIMINATOR.to_vec())),
+        RpcFilterType::Memcmp(Memcmp::new_raw_bytes(
+            V3_BUFFER_AUTH_OFFSET,
+            fee_payer.as_ref().to_vec(),
+        )),
+    ];
+
+    let accounts = rpc
+        .get_program_accounts_with_config(
+            &BPF_LOADER_UPGRADEABLE_PROGRAM_ID,
+            RpcProgramAccountsConfig {
+                filters: Some(filters),
+                account_config: account_config_slice(0, 0),
+                with_context: None,
+                sort_results: None,
+            },
+        )
+        .await
+        .map_err(|e| anyhow!("getProgramAccounts(loader-v3 Buffer): {e}"))?;
+
+    Ok(accounts
+        .into_iter()
+        .map(|(buffer, _)| OwnedProgram {
+            loader: Loader::V3,
+            kind: AccountKind::Buffer,
+            program: buffer,
+            program_data: None,
+            last_state_slot: 0,
+        })
+        .collect())
 }
 
 async fn discover_v3(rpc: &Arc<RpcClient>, fee_payer: &Pubkey) -> Result<Vec<OwnedProgram>> {
@@ -70,6 +112,7 @@ async fn discover_v3(rpc: &Arc<RpcClient>, fee_payer: &Pubkey) -> Result<Vec<Own
         };
         out.push(OwnedProgram {
             loader: Loader::V3,
+            kind: AccountKind::Program,
             program,
             program_data: Some(pdata_pubkey),
             last_state_slot,
@@ -127,6 +170,7 @@ async fn discover_v4(rpc: &Arc<RpcClient>, fee_payer: &Pubkey) -> Result<Vec<Own
         .into_iter()
         .map(|(program_pubkey, account)| OwnedProgram {
             loader: Loader::V4,
+            kind: AccountKind::Program,
             program: program_pubkey,
             program_data: None,
             last_state_slot: parse_u64_le(&account.data).unwrap_or(0),

--- a/examples/devnet-deploy-paymaster/src/reaper/runner.rs
+++ b/examples/devnet-deploy-paymaster/src/reaper/runner.rs
@@ -21,7 +21,8 @@ pub async fn run(rpc: Arc<RpcClient>, cfg: ReaperConfig) -> Result<ReaperReport>
             Ok(ActivityVerdict::Recent { .. }) => report.skipped_recent += 1,
             Ok(ActivityVerdict::Idle { last_seen_unix }) => {
                 log::info!(
-                    "idle program={} loader={:?} last_seen={:?}",
+                    "idle {:?} {} loader={:?} last_seen={:?}",
+                    program.kind,
                     program.program,
                     program.loader,
                     last_seen_unix

--- a/examples/devnet-deploy-paymaster/src/reaper/types.rs
+++ b/examples/devnet-deploy-paymaster/src/reaper/types.rs
@@ -8,11 +8,18 @@ pub enum Loader {
     V4,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AccountKind {
+    Program,
+    Buffer,
+}
+
 #[derive(Debug, Clone)]
 pub struct OwnedProgram {
     pub loader: Loader,
+    pub kind: AccountKind,
     pub program: Pubkey,
-    /// `None` for v4 — state and code share one account.
+    /// `None` for v4 and for buffers — state and code share one account.
     pub program_data: Option<Pubkey>,
     pub last_state_slot: u64,
 }


### PR DESCRIPTION
## Summary
The reaper only discovered deployed programs (`ProgramData`/`Program` accounts), so a **buffer** left behind by an aborted deploy — created + written but never deployed — locked its rent forever. (We hit this: ~11 such buffers, 6.7 SOL, had accumulated on the live deployer from failed runs.)

This adds buffer reaping:
- **Discovery:** query `BPFLoaderUpgradeable` for `Buffer` accounts (`[1,0,0,0]` discriminator) whose authority is the fee payer.
- **Idle check:** reuses `activity::classify` unchanged — a buffer's age comes from its last-signature `block_time`, so a buffer still being written mid-deploy is treated as `Recent` and not yanked. Buffers have no `slot` field, so they rely purely on signature history.
- **Close:** `close_any(buffer, recipient = fee_payer, authority = fee_payer)` (no program account), back to the fee payer.

Adds an `AccountKind { Program, Buffer }` discriminator to `OwnedProgram`; buffers flow through the same `classify` → idle → close pipeline, honoring `--dry-run` and `--max-closes`.

## Test Plan
- New unit test `build_v3_close_buffer_targets_buffer_with_no_program_account`; existing close tests updated for the new field.
- `cargo test -p devnet-deploy-paymaster --lib reaper` → 6 passed (+1 ignored devnet test).
- Verified the same discovery+close logic against the live deployer (throwaway run) closed 11 orphan buffers, reclaiming 6.7387 SOL.