### PR TITLE
Replace vec pubkey with hashset

### DIFF
--- a/crates/lib/src/validator/transaction_validator.rs
+++ b/crates/lib/src/validator/transaction_validator.rs
@@ -17,19 +17,19 @@ use crate::{
 };
 use solana_client::nonblocking::rpc_client::RpcClient;
 use solana_sdk::{pubkey::Pubkey, transaction::VersionedTransaction};
-use std::str::FromStr;
+use std::{collections::HashSet, str::FromStr};
 
 use crate::fee::price::PriceModel;
 
 pub struct TransactionValidator {
     fee_payer_pubkey: Pubkey,
     max_allowed_lamports: u64,
-    allowed_programs: Vec<Pubkey>,
+    allowed_programs: HashSet<Pubkey>,
     allow_all_programs: bool,
-    require_one_of_programs: Vec<Pubkey>,
+    require_one_of_programs: HashSet<Pubkey>,
     max_signatures: u64,
-    allowed_tokens: Vec<Pubkey>,
-    disallowed_accounts: Vec<Pubkey>,
+    allowed_tokens: HashSet<Pubkey>,
+    disallowed_accounts: HashSet<Pubkey>,
     _price_source: PriceSource,
     fee_payer_policy: FeePayerPolicy,
     allow_durable_transactions: bool,
@@ -40,7 +40,7 @@ impl TransactionValidator {
         let config = &config.validation;
 
         let (allow_all_programs, allowed_programs) = match &config.allowed_programs {
-            ProgramsConfig::All => (true, Vec::new()),
+            ProgramsConfig::All => (true, HashSet::new()),
             ProgramsConfig::Allowlist(programs) => (
                 false,
                 programs
@@ -52,7 +52,7 @@ impl TransactionValidator {
                             ))
                         })
                     })
-                    .collect::<Result<Vec<Pubkey>, KoraError>>()?,
+                    .collect::<Result<HashSet<Pubkey>, KoraError>>()?,
             ),
         };
 
@@ -66,7 +66,7 @@ impl TransactionValidator {
                     ))
                 })
             })
-            .collect::<Result<Vec<Pubkey>, KoraError>>()?;
+            .collect::<Result<HashSet<Pubkey>, KoraError>>()?;
 
         Ok(Self {
             fee_payer_pubkey,
@@ -80,7 +80,7 @@ impl TransactionValidator {
                 .allowed_tokens
                 .iter()
                 .map(|addr| Pubkey::from_str(addr))
-                .collect::<Result<Vec<Pubkey>, _>>()
+                .collect::<Result<HashSet<Pubkey>, _>>()
                 .map_err(|e| {
                     KoraError::InternalServerError(format!("Invalid allowed token address: {e}"))
                 })?,
@@ -88,7 +88,7 @@ impl TransactionValidator {
                 .disallowed_accounts
                 .iter()
                 .map(|addr| Pubkey::from_str(addr))
-                .collect::<Result<Vec<Pubkey>, _>>()
+                .collect::<Result<HashSet<Pubkey>, _>>()
                 .map_err(|e| {
                     KoraError::InternalServerError(format!(
                         "Invalid disallowed account address: {e}"


### PR DESCRIPTION
This pull request refactors the `TransactionValidator` struct and its initialization logic to use `HashSet<Pubkey>` instead of `Vec<Pubkey>` for storing collections of public keys. This change improves lookup performance and ensures uniqueness for allowed/disallowed programs, tokens, and accounts.

**Data structure improvements:**

* Changed the types of `allowed_programs`, `require_one_of_programs`, `allowed_tokens`, and `disallowed_accounts` in `TransactionValidator` from `Vec<Pubkey>` to `HashSet<Pubkey>` for more efficient lookups and to prevent duplicates.
* Updated all relevant initialization code to collect public keys into `HashSet` instead of `Vec`. This includes parsing configuration values and constructing the validator. [[1]](diffhunk://#diff-14924e7a2617beffc4a219ef1736f9a4f6ce524651369e99dc5f237f2e8c5ff2L43-R43) [[2]](diffhunk://#diff-14924e7a2617beffc4a219ef1736f9a4f6ce524651369e99dc5f237f2e8c5ff2L55-R55) [[3]](diffhunk://#diff-14924e7a2617beffc4a219ef1736f9a4f6ce524651369e99dc5f237f2e8c5ff2L69-R69) [[4]](diffhunk://#diff-14924e7a2617beffc4a219ef1736f9a4f6ce524651369e99dc5f237f2e8c5ff2L83-R91)