### PR TITLE
Add async transaction sending

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3623,6 +3623,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-util",
  "toml",
  "tower 0.4.13",
  "tower-http 0.3.5",
@@ -8305,6 +8306,7 @@ dependencies = [
  "futures-core",
  "futures-io",
  "futures-sink",
+ "futures-util",
  "pin-project-lite",
  "tokio",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,7 @@ tower = { version = "0.4.13", features = ["full"] }
 tower-http = { version = "0.3.5", features = ["full", "cors"] }
 clap = { version = "4.6", features = ["derive", "env"] }
 tokio = { version = "1.50.0", features = ["full"] }
+tokio-util = { version = "0.7.16", features = ["rt"] }
 prettyplease = "0.2.25"
 syn = "2.0.89"
 parking_lot = "0.12"

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -2,16 +2,15 @@ mod args;
 
 use args::GlobalArgs;
 use clap::{Parser, Subcommand};
-use std::time::Duration;
 
 use kora_lib::{
     admin::token_util::initialize_atas,
     error::KoraError,
     log::LoggingFormat,
     rpc::get_rpc_client,
-    rpc_server::{run_rpc_server, server::ServerHandles, KoraRpc, RpcArgs},
+    rpc_server::{run_rpc_server, KoraRpc, RpcArgs},
     signer::init::init_signers,
-    state::{drain_background_tasks, init_config},
+    state::init_config,
     validator::config_validator::ConfigValidator,
     CacheUtil, Config,
 };
@@ -189,45 +188,14 @@ async fn main() -> Result<(), KoraError> {
 
                     let kora_rpc = KoraRpc::new(rpc_client);
 
-                    let ServerHandles { rpc_handle, metrics_handle, balance_tracker_handle } =
-                        run_rpc_server(kora_rpc, rpc_args.port).await?;
+                    let handles = run_rpc_server(kora_rpc, rpc_args.port).await?;
 
                     if let Err(e) = tokio::signal::ctrl_c().await {
                         panic!("Error waiting for Ctrl+C signal: {e:?}");
                     }
                     println!("Shutting down server...");
 
-                    // Stop the balance tracker task
-                    if let Some(handle) = balance_tracker_handle {
-                        log::info!("Stopping balance tracker background task...");
-                        handle.abort();
-                    }
-
-                    // Stop the RPC server and wait until it finishes handling
-                    // in-flight requests, so no new background broadcasts are
-                    // spawned while we drain the existing ones.
-                    if let Err(e) = rpc_handle.stop() {
-                        panic!("Error stopping RPC server: {e:?}");
-                    }
-                    rpc_handle.stopped().await;
-
-                    // Drain fire-and-forget broadcasts (RespondAfter::Signed) so they
-                    // reach an RPC node before the runtime exits and cancels them.
-                    let drain_timeout = Duration::from_secs(30);
-                    if !drain_background_tasks(drain_timeout).await {
-                        log::warn!(
-                            "Timed out after {}s waiting for background broadcasts to finish; \
-                             some transactions may not have been forwarded",
-                            drain_timeout.as_secs()
-                        );
-                    }
-
-                    // Stop the metrics server if running
-                    if let Some(handle) = metrics_handle {
-                        if let Err(e) = handle.stop() {
-                            panic!("Error stopping metrics server: {e:?}");
-                        }
-                    }
+                    handles.shutdown(rpc_args.port).await;
                 }
                 RpcCommands::InitializeAtas {
                     rpc_args,

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -211,7 +211,7 @@ async fn main() -> Result<(), KoraError> {
                     }
                     rpc_handle.stopped().await;
 
-                    // Drain fire-and-forget broadcasts (ConfirmationMode::None) so they
+                    // Drain fire-and-forget broadcasts (RespondAfter::Signed) so they
                     // reach an RPC node before the runtime exits and cancels them.
                     let drain_timeout = Duration::from_secs(30);
                     if !drain_background_tasks(drain_timeout).await {

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -2,6 +2,8 @@ mod args;
 
 use args::GlobalArgs;
 use clap::{Parser, Subcommand};
+use std::time::Duration;
+
 use kora_lib::{
     admin::token_util::initialize_atas,
     error::KoraError,
@@ -9,7 +11,7 @@ use kora_lib::{
     rpc::get_rpc_client,
     rpc_server::{run_rpc_server, server::ServerHandles, KoraRpc, RpcArgs},
     signer::init::init_signers,
-    state::init_config,
+    state::{drain_background_tasks, init_config},
     validator::config_validator::ConfigValidator,
     CacheUtil, Config,
 };
@@ -201,9 +203,23 @@ async fn main() -> Result<(), KoraError> {
                         handle.abort();
                     }
 
-                    // Stop the RPC server
+                    // Stop the RPC server and wait until it finishes handling
+                    // in-flight requests, so no new background broadcasts are
+                    // spawned while we drain the existing ones.
                     if let Err(e) = rpc_handle.stop() {
                         panic!("Error stopping RPC server: {e:?}");
+                    }
+                    rpc_handle.stopped().await;
+
+                    // Drain fire-and-forget broadcasts (ConfirmationMode::None) so they
+                    // reach an RPC node before the runtime exits and cancels them.
+                    let drain_timeout = Duration::from_secs(30);
+                    if !drain_background_tasks(drain_timeout).await {
+                        log::warn!(
+                            "Timed out after {}s waiting for background broadcasts to finish; \
+                             some transactions may not have been forwarded",
+                            drain_timeout.as_secs()
+                        );
                     }
 
                     // Stop the metrics server if running

--- a/crates/lib/Cargo.toml
+++ b/crates/lib/Cargo.toml
@@ -40,6 +40,7 @@ bincode = { workspace = true }
 borsh = { workspace = true }
 base64 = { workspace = true }
 tokio = { workspace = true }
+tokio-util = { workspace = true }
 async-trait = { workspace = true }
 reqwest = { workspace = true }
 spl-token-interface = { workspace = true }

--- a/crates/lib/src/rpc_server/method/sign_and_send_transaction.rs
+++ b/crates/lib/src/rpc_server/method/sign_and_send_transaction.rs
@@ -1,6 +1,8 @@
 use crate::{
     rpc_server::middleware_utils::default_sig_verify,
-    transaction::{TransactionUtil, VersionedTransactionOps, VersionedTransactionResolved},
+    transaction::{
+        ConfirmationMode, TransactionUtil, VersionedTransactionOps, VersionedTransactionResolved,
+    },
     usage_limit::UsageTracker,
     KoraError,
 };
@@ -30,6 +32,12 @@ pub struct SignAndSendTransactionRequest {
     /// Optional user ID for usage tracking (required when pricing is free and usage tracking is enabled)
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub user_id: Option<String>,
+    /// How long to wait on the broadcast before responding (defaults to "confirmed"):
+    /// "confirmed" waits for on-chain confirmation, "sent" returns once the RPC node
+    /// accepts the transaction, "none" broadcasts in the background and returns as soon
+    /// as signing completes.
+    #[serde(default)]
+    pub confirmation: ConfirmationMode,
 }
 
 #[derive(Debug, Serialize, ToSchema)]
@@ -71,8 +79,9 @@ pub async fn sign_and_send_transaction(
     )
     .await?;
 
-    let (signature, signed_transaction) =
-        resolved_transaction.sign_and_send_transaction(config, &signer, rpc_client).await?;
+    let (signature, signed_transaction) = resolved_transaction
+        .sign_and_send_transaction(config, &signer, rpc_client, request.confirmation)
+        .await?;
 
     Ok(SignAndSendTransactionResponse {
         signed_transaction,
@@ -104,6 +113,7 @@ mod tests {
             signer_key: None,
             sig_verify: true,
             user_id: None,
+            confirmation: ConfirmationMode::Confirmed,
         };
 
         let result = sign_and_send_transaction(&rpc_client, request).await;
@@ -125,6 +135,7 @@ mod tests {
             signer_key: Some("invalid_pubkey".to_string()),
             sig_verify: true,
             user_id: None,
+            confirmation: ConfirmationMode::Confirmed,
         };
 
         let result = sign_and_send_transaction(&rpc_client, request).await;
@@ -132,5 +143,71 @@ mod tests {
         assert!(result.is_err(), "Should fail with invalid signer key");
         let error = result.unwrap_err();
         assert!(matches!(error, KoraError::ValidationError(_)), "Should return ValidationError");
+    }
+
+    #[tokio::test]
+    async fn test_sign_and_send_transaction_no_confirmation_decode_error() {
+        let _m = ConfigMockBuilder::new().build_and_setup();
+        let _ = setup_or_get_test_signer();
+
+        let _ = setup_or_get_test_usage_limiter().await;
+
+        let rpc_client = Arc::new(RpcMockBuilder::new().build());
+
+        let request = SignAndSendTransactionRequest {
+            transaction: "invalid_base64!@#$".to_string(),
+            signer_key: None,
+            sig_verify: true,
+            user_id: None,
+            confirmation: ConfirmationMode::None,
+        };
+
+        let result = sign_and_send_transaction(&rpc_client, request).await;
+
+        assert!(result.is_err(), "Should fail with decode error");
+    }
+
+    #[tokio::test]
+    async fn test_sign_and_send_transaction_no_confirmation_invalid_signer_key() {
+        let _m = ConfigMockBuilder::new().build_and_setup();
+        let _ = setup_or_get_test_signer();
+
+        let _ = setup_or_get_test_usage_limiter().await;
+
+        let rpc_client = Arc::new(RpcMockBuilder::new().build());
+
+        let request = SignAndSendTransactionRequest {
+            transaction: create_mock_encoded_transaction(),
+            signer_key: Some("invalid_pubkey".to_string()),
+            sig_verify: true,
+            user_id: None,
+            confirmation: ConfirmationMode::None,
+        };
+
+        let result = sign_and_send_transaction(&rpc_client, request).await;
+
+        assert!(result.is_err(), "Should fail with invalid signer key");
+        let error = result.unwrap_err();
+        assert!(matches!(error, KoraError::ValidationError(_)), "Should return ValidationError");
+    }
+
+    #[test]
+    fn test_confirmation_mode_deserialization() {
+        let request: SignAndSendTransactionRequest =
+            serde_json::from_str(r#"{"transaction": "abc"}"#).unwrap();
+        assert_eq!(request.confirmation, ConfirmationMode::Confirmed);
+
+        let request: SignAndSendTransactionRequest =
+            serde_json::from_str(r#"{"transaction": "abc", "confirmation": "sent"}"#).unwrap();
+        assert_eq!(request.confirmation, ConfirmationMode::Sent);
+
+        let request: SignAndSendTransactionRequest =
+            serde_json::from_str(r#"{"transaction": "abc", "confirmation": "none"}"#).unwrap();
+        assert_eq!(request.confirmation, ConfirmationMode::None);
+
+        let result = serde_json::from_str::<SignAndSendTransactionRequest>(
+            r#"{"transaction": "abc", "confirmation": "finalized"}"#,
+        );
+        assert!(result.is_err(), "Unknown confirmation mode should be rejected");
     }
 }

--- a/crates/lib/src/rpc_server/method/sign_and_send_transaction.rs
+++ b/crates/lib/src/rpc_server/method/sign_and_send_transaction.rs
@@ -1,7 +1,7 @@
 use crate::{
     rpc_server::middleware_utils::default_sig_verify,
     transaction::{
-        ConfirmationMode, TransactionUtil, VersionedTransactionOps, VersionedTransactionResolved,
+        RespondAfter, TransactionUtil, VersionedTransactionOps, VersionedTransactionResolved,
     },
     usage_limit::UsageTracker,
     KoraError,
@@ -32,12 +32,12 @@ pub struct SignAndSendTransactionRequest {
     /// Optional user ID for usage tracking (required when pricing is free and usage tracking is enabled)
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub user_id: Option<String>,
-    /// How long to wait on the broadcast before responding (defaults to "confirmed"):
+    /// The lifecycle milestone to wait for before responding (defaults to "confirmed"):
     /// "confirmed" waits for on-chain confirmation, "sent" returns once the RPC node
-    /// accepts the transaction, "none" broadcasts in the background and returns as soon
-    /// as signing completes.
+    /// accepts the transaction, "signed" returns as soon as signing completes and
+    /// broadcasts in the background.
     #[serde(default)]
-    pub confirmation: ConfirmationMode,
+    pub respond_after: RespondAfter,
 }
 
 #[derive(Debug, Serialize, ToSchema)]
@@ -80,7 +80,7 @@ pub async fn sign_and_send_transaction(
     .await?;
 
     let (signature, signed_transaction) = resolved_transaction
-        .sign_and_send_transaction(config, &signer, rpc_client, request.confirmation)
+        .sign_and_send_transaction(config, &signer, rpc_client, request.respond_after)
         .await?;
 
     Ok(SignAndSendTransactionResponse {
@@ -113,7 +113,7 @@ mod tests {
             signer_key: None,
             sig_verify: true,
             user_id: None,
-            confirmation: ConfirmationMode::Confirmed,
+            respond_after: RespondAfter::Confirmed,
         };
 
         let result = sign_and_send_transaction(&rpc_client, request).await;
@@ -135,7 +135,7 @@ mod tests {
             signer_key: Some("invalid_pubkey".to_string()),
             sig_verify: true,
             user_id: None,
-            confirmation: ConfirmationMode::Confirmed,
+            respond_after: RespondAfter::Confirmed,
         };
 
         let result = sign_and_send_transaction(&rpc_client, request).await;
@@ -146,7 +146,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_sign_and_send_transaction_no_confirmation_decode_error() {
+    async fn test_sign_and_send_transaction_respond_after_signed_decode_error() {
         let _m = ConfigMockBuilder::new().build_and_setup();
         let _ = setup_or_get_test_signer();
 
@@ -159,7 +159,7 @@ mod tests {
             signer_key: None,
             sig_verify: true,
             user_id: None,
-            confirmation: ConfirmationMode::None,
+            respond_after: RespondAfter::Signed,
         };
 
         let result = sign_and_send_transaction(&rpc_client, request).await;
@@ -168,7 +168,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_sign_and_send_transaction_no_confirmation_invalid_signer_key() {
+    async fn test_sign_and_send_transaction_respond_after_signed_invalid_signer_key() {
         let _m = ConfigMockBuilder::new().build_and_setup();
         let _ = setup_or_get_test_signer();
 
@@ -181,7 +181,7 @@ mod tests {
             signer_key: Some("invalid_pubkey".to_string()),
             sig_verify: true,
             user_id: None,
-            confirmation: ConfirmationMode::None,
+            respond_after: RespondAfter::Signed,
         };
 
         let result = sign_and_send_transaction(&rpc_client, request).await;
@@ -192,22 +192,22 @@ mod tests {
     }
 
     #[test]
-    fn test_confirmation_mode_deserialization() {
+    fn test_respond_after_deserialization() {
         let request: SignAndSendTransactionRequest =
             serde_json::from_str(r#"{"transaction": "abc"}"#).unwrap();
-        assert_eq!(request.confirmation, ConfirmationMode::Confirmed);
+        assert_eq!(request.respond_after, RespondAfter::Confirmed);
 
         let request: SignAndSendTransactionRequest =
-            serde_json::from_str(r#"{"transaction": "abc", "confirmation": "sent"}"#).unwrap();
-        assert_eq!(request.confirmation, ConfirmationMode::Sent);
+            serde_json::from_str(r#"{"transaction": "abc", "respond_after": "sent"}"#).unwrap();
+        assert_eq!(request.respond_after, RespondAfter::Sent);
 
         let request: SignAndSendTransactionRequest =
-            serde_json::from_str(r#"{"transaction": "abc", "confirmation": "none"}"#).unwrap();
-        assert_eq!(request.confirmation, ConfirmationMode::None);
+            serde_json::from_str(r#"{"transaction": "abc", "respond_after": "signed"}"#).unwrap();
+        assert_eq!(request.respond_after, RespondAfter::Signed);
 
         let result = serde_json::from_str::<SignAndSendTransactionRequest>(
-            r#"{"transaction": "abc", "confirmation": "finalized"}"#,
+            r#"{"transaction": "abc", "respond_after": "finalized"}"#,
         );
-        assert!(result.is_err(), "Unknown confirmation mode should be rejected");
+        assert!(result.is_err(), "Unknown respond_after milestone should be rejected");
     }
 }

--- a/crates/lib/src/rpc_server/openapi/docs.rs
+++ b/crates/lib/src/rpc_server/openapi/docs.rs
@@ -7,7 +7,7 @@ use crate::{
     },
     fee::price::{PriceConfig, PriceModel},
     oracle::oracle::{PriceSource, TokenPrice},
-    transaction::ConfirmationMode,
+    transaction::RespondAfter,
 };
 use std::path::PathBuf;
 use utoipa::{
@@ -69,7 +69,7 @@ const JSON_CONTENT_TYPE: &str = "application/json";
         GetPayerSignerResponse,
         GetSupportedTokensResponse,
         GetVersionResponse,
-        ConfirmationMode,
+        RespondAfter,
         SignAndSendTransactionRequest,
         SignAndSendTransactionResponse,
         SignTransactionRequest,

--- a/crates/lib/src/rpc_server/openapi/docs.rs
+++ b/crates/lib/src/rpc_server/openapi/docs.rs
@@ -7,6 +7,7 @@ use crate::{
     },
     fee::price::{PriceConfig, PriceModel},
     oracle::oracle::{PriceSource, TokenPrice},
+    transaction::ConfirmationMode,
 };
 use std::path::PathBuf;
 use utoipa::{
@@ -68,6 +69,7 @@ const JSON_CONTENT_TYPE: &str = "application/json";
         GetPayerSignerResponse,
         GetSupportedTokensResponse,
         GetVersionResponse,
+        ConfirmationMode,
         SignAndSendTransactionRequest,
         SignAndSendTransactionResponse,
         SignTransactionRequest,

--- a/crates/lib/src/rpc_server/recaptcha.rs
+++ b/crates/lib/src/rpc_server/recaptcha.rs
@@ -70,7 +70,7 @@ where
                 new_request.headers().get(X_RECAPTCHA_TOKEN).and_then(|v| v.to_str().ok());
 
             if let Err(resp) = config.validate(recaptcha_token).await {
-                return Ok(resp);
+                return Ok(*resp);
             }
 
             inner.call(new_request).await

--- a/crates/lib/src/rpc_server/recaptcha_util.rs
+++ b/crates/lib/src/rpc_server/recaptcha_util.rs
@@ -34,17 +34,25 @@ impl RecaptchaConfig {
         self.protected_methods.iter().any(|m| m == method)
     }
 
-    pub async fn validate(&self, token: Option<&str>) -> Result<(), Response<Body>> {
+    pub async fn validate(&self, token: Option<&str>) -> Result<(), Box<Response<Body>>> {
         let token = match token {
             Some(t) if !t.is_empty() => t,
             _ => {
-                return Err(build_response_with_graceful_error(None, StatusCode::UNAUTHORIZED, ""))
+                return Err(Box::new(build_response_with_graceful_error(
+                    None,
+                    StatusCode::UNAUTHORIZED,
+                    "",
+                )))
             }
         };
 
         if let Err(e) = self.verify_token(token).await {
             log::error!("reCAPTCHA verification error: {}", sanitize_error!(e));
-            return Err(build_response_with_graceful_error(None, StatusCode::UNAUTHORIZED, ""));
+            return Err(Box::new(build_response_with_graceful_error(
+                None,
+                StatusCode::UNAUTHORIZED,
+                "",
+            )));
         }
 
         Ok(())

--- a/crates/lib/src/rpc_server/server.rs
+++ b/crates/lib/src/rpc_server/server.rs
@@ -12,6 +12,8 @@ use crate::{
     usage_limit::UsageTracker,
 };
 
+use crate::state::drain_background_tasks;
+
 #[cfg(not(test))]
 use crate::state::get_config;
 
@@ -31,6 +33,70 @@ pub struct ServerHandles {
     pub rpc_handle: ServerHandle,
     pub metrics_handle: Option<ServerHandle>,
     pub balance_tracker_handle: Option<JoinHandle<()>>,
+}
+
+/// How long to wait for the RPC server to finish in-flight requests before
+/// giving up and continuing shutdown.
+const RPC_STOP_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// How long to wait for fire-and-forget broadcasts to reach an RPC node before
+/// giving up and letting the runtime exit.
+const BROADCAST_DRAIN_TIMEOUT: Duration = Duration::from_secs(30);
+
+impl ServerHandles {
+    /// Gracefully shut down the RPC server and its background work.
+    ///
+    /// Order matters: stop the balance tracker, wait for the RPC server to
+    /// finish in-flight requests (so no new background broadcasts are spawned),
+    /// drain the broadcasts that were spawned, then stop the metrics server.
+    ///
+    /// `port` is the RPC port, needed to wake an idle accept loop (see
+    /// [`wait_for_rpc_stop`]).
+    pub async fn shutdown(self, port: u16) {
+        if let Some(handle) = self.balance_tracker_handle {
+            log::info!("Stopping balance tracker background task...");
+            handle.abort();
+        }
+
+        wait_for_rpc_stop(self.rpc_handle, port).await;
+
+        if !drain_background_tasks(BROADCAST_DRAIN_TIMEOUT).await {
+            log::warn!(
+                "Timed out after {}s waiting for background broadcasts to finish; \
+                 some transactions may not have been forwarded",
+                BROADCAST_DRAIN_TIMEOUT.as_secs()
+            );
+        }
+
+        if let Some(handle) = self.metrics_handle {
+            if let Err(e) = handle.stop() {
+                log::warn!("Error stopping metrics server: {e:?}");
+            }
+        }
+    }
+}
+
+/// Stop the RPC server and wait until it finishes handling in-flight requests.
+///
+/// jsonrpsee 0.16 only re-checks its stop signal when the accept loop is woken
+/// by a new connection, so on a server that has been idle since startup
+/// `stopped()` would block until the next request arrives. Open a throwaway
+/// connection to wake the loop immediately, and cap the wait so shutdown can
+/// never hang.
+async fn wait_for_rpc_stop(rpc_handle: ServerHandle, port: u16) {
+    if let Err(e) = rpc_handle.stop() {
+        log::warn!("RPC server was already stopping: {e:?}");
+        return;
+    }
+
+    let _ = tokio::net::TcpStream::connect(("127.0.0.1", port)).await;
+
+    if tokio::time::timeout(RPC_STOP_TIMEOUT, rpc_handle.stopped()).await.is_err() {
+        log::warn!(
+            "RPC server did not finish stopping within {}s; continuing shutdown",
+            RPC_STOP_TIMEOUT.as_secs()
+        );
+    }
 }
 
 // We'll always prioritize the environment variable over the config value

--- a/crates/lib/src/rpc_server/server.rs
+++ b/crates/lib/src/rpc_server/server.rs
@@ -78,11 +78,16 @@ impl ServerHandles {
 
 /// Stop the RPC server and wait until it finishes handling in-flight requests.
 ///
-/// jsonrpsee 0.16 only re-checks its stop signal when the accept loop is woken
+/// This whole helper only exists to work around the jsonrpsee version we are
+/// pinned to (0.16): its accept loop re-checks the stop signal only when woken
 /// by a new connection, so on a server that has been idle since startup
-/// `stopped()` would block until the next request arrives. Open a throwaway
+/// `stopped()` would block until the next request arrives. We open a throwaway
 /// connection to wake the loop immediately, and cap the wait so shutdown can
 /// never hang.
+///
+/// Newer jsonrpsee releases reworked graceful shutdown and `stopped()` returns
+/// on its own, so this function (the TcpStream wake and the timeout) can be
+/// dropped once we upgrade.
 async fn wait_for_rpc_stop(rpc_handle: ServerHandle, port: u16) {
     if let Err(e) = rpc_handle.stop() {
         log::warn!("RPC server was already stopping: {e:?}");

--- a/crates/lib/src/state.rs
+++ b/crates/lib/src/state.rs
@@ -4,6 +4,7 @@ use std::sync::{
     atomic::{AtomicPtr, Ordering},
     Arc,
 };
+use tokio_util::task::TaskTracker;
 
 use crate::{
     config::Config, error::KoraError, signer::SignerPool, transaction::signing_retry_window,
@@ -15,6 +16,37 @@ static GLOBAL_SIGNER_POOL: Lazy<RwLock<Option<Arc<SignerPool>>>> = Lazy::new(|| 
 
 // Global config with zero-cost reads and hot-reload capability
 static GLOBAL_CONFIG: AtomicPtr<Config> = AtomicPtr::new(std::ptr::null_mut());
+
+// Tracks detached background tasks (currently the fire-and-forget broadcasts of
+// `ConfirmationMode::None`) so a graceful shutdown can wait for in-flight sends
+// to reach an RPC node instead of cancelling them when the runtime exits.
+static BACKGROUND_TASKS: Lazy<TaskTracker> = Lazy::new(TaskTracker::new);
+
+/// Returns the global tracker for detached background tasks.
+///
+/// Spawn fire-and-forget work through this tracker (`get_background_tasks().spawn(..)`)
+/// so shutdown can drain it via [`drain_background_tasks`].
+pub fn get_background_tasks() -> &'static TaskTracker {
+    &BACKGROUND_TASKS
+}
+
+/// Waits for all tracked background tasks to finish, up to `timeout`.
+///
+/// Closes the tracker so no new spawns keep the wait alive, then awaits
+/// completion. Returns `false` if the timeout elapsed with tasks still running.
+pub async fn drain_background_tasks(timeout: Duration) -> bool {
+    drain_tracker(get_background_tasks(), timeout).await
+}
+
+async fn drain_tracker(tracker: &TaskTracker, timeout: Duration) -> bool {
+    tracker.close();
+
+    if tracker.is_empty() {
+        return true;
+    }
+
+    tokio::time::timeout(timeout, tracker.wait()).await.is_ok()
+}
 
 fn sync_probe_lease_from_config(pool: &SignerPool, config: &Config) {
     let sign_timeout = Duration::from_secs(config.kora.sign_timeout_seconds);
@@ -173,5 +205,39 @@ mod tests {
 
         let pool = get_signer_pool().unwrap();
         assert_eq!(pool.probe_lease(), signing_retry_window(Duration::from_secs(15), 5));
+    }
+
+    #[tokio::test]
+    async fn test_drain_tracker_waits_for_in_flight_task() {
+        let tracker = TaskTracker::new();
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        tracker.spawn(async move {
+            let _ = rx.await;
+        });
+
+        // Release the task shortly after the drain starts so it completes within
+        // the timeout window.
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(50)).await;
+            let _ = tx.send(());
+        });
+
+        assert!(drain_tracker(&tracker, Duration::from_secs(5)).await);
+    }
+
+    #[tokio::test]
+    async fn test_drain_tracker_times_out_when_task_outlives_timeout() {
+        let tracker = TaskTracker::new();
+        tracker.spawn(async {
+            tokio::time::sleep(Duration::from_secs(60)).await;
+        });
+
+        assert!(!drain_tracker(&tracker, Duration::from_millis(50)).await);
+    }
+
+    #[tokio::test]
+    async fn test_drain_tracker_returns_immediately_when_empty() {
+        let tracker = TaskTracker::new();
+        assert!(drain_tracker(&tracker, Duration::from_secs(5)).await);
     }
 }

--- a/crates/lib/src/state.rs
+++ b/crates/lib/src/state.rs
@@ -18,7 +18,7 @@ static GLOBAL_SIGNER_POOL: Lazy<RwLock<Option<Arc<SignerPool>>>> = Lazy::new(|| 
 static GLOBAL_CONFIG: AtomicPtr<Config> = AtomicPtr::new(std::ptr::null_mut());
 
 // Tracks detached background tasks (currently the fire-and-forget broadcasts of
-// `ConfirmationMode::None`) so a graceful shutdown can wait for in-flight sends
+// `RespondAfter::Signed`) so a graceful shutdown can wait for in-flight sends
 // to reach an RPC node instead of cancelling them when the runtime exits.
 static BACKGROUND_TASKS: Lazy<TaskTracker> = Lazy::new(TaskTracker::new);
 

--- a/crates/lib/src/transaction/versioned_transaction.rs
+++ b/crates/lib/src/transaction/versioned_transaction.rs
@@ -560,6 +560,17 @@ impl VersionedTransactionOps for VersionedTransactionResolved {
         // transiently even though the transaction is valid.
         let send_config = RpcSendTransactionConfig { skip_preflight: true, ..Default::default() };
 
+        // Skipping preflight also skips the RPC node's signature verification, so a
+        // transaction with an unfilled co-signer slot (possible when validation ran
+        // with sig_verify off) would be accepted by the RPC but dropped silently by
+        // validators. Reject it here so the caller gets an error instead of a
+        // signature for a transaction that can never land.
+        if transaction.signatures.iter().any(|s| *s == Signature::default()) {
+            return Err(KoraError::InvalidTransaction(
+                "Transaction is missing required signatures".to_string(),
+            ));
+        }
+
         match confirmation {
             ConfirmationMode::Confirmed => {
                 let signature = rpc_client
@@ -578,16 +589,6 @@ impl VersionedTransactionOps for VersionedTransactionResolved {
                 Ok((signature.to_string(), encoded))
             }
             ConfirmationMode::None => {
-                // The response is built before the broadcast runs, so a transaction
-                // that can never land (missing co-signer signature when sig_verify is
-                // off) must be rejected here instead of failing silently in the
-                // background.
-                if transaction.signatures.iter().any(|s| *s == Signature::default()) {
-                    return Err(KoraError::InvalidTransaction(
-                        "Transaction is missing required signatures".to_string(),
-                    ));
-                }
-
                 // A Solana transaction is identified by its first signature, which is
                 // already present once signing completes — so the caller gets it
                 // without waiting for the broadcast.

--- a/crates/lib/src/transaction/versioned_transaction.rs
+++ b/crates/lib/src/transaction/versioned_transaction.rs
@@ -91,20 +91,21 @@ impl Deref for VersionedTransactionResolved {
     }
 }
 
-/// How long `signAndSendTransaction` waits on the broadcast before responding.
+/// The transaction lifecycle milestone `signAndSendTransaction` waits for before
+/// responding, ordered by increasing assurance: `Signed` < `Sent` < `Confirmed`.
 ///
 /// All modes share the immediate sign-and-send validation flow (`will_send = true`)
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Deserialize, ToSchema)]
 #[serde(rename_all = "snake_case")]
-pub enum ConfirmationMode {
+pub enum RespondAfter {
     /// Wait for on-chain confirmation at `confirmed` commitment (default).
     #[default]
     Confirmed,
     /// Wait only until the RPC node accepts the transaction; no confirmation wait.
     Sent,
-    /// Broadcast in the background and return as soon as signing completes. Broadcast
+    /// Return as soon as signing completes and broadcast in the background. Broadcast
     /// failures are logged server-side, not returned to the caller.
-    None,
+    Signed,
 }
 
 #[async_trait]
@@ -126,7 +127,7 @@ pub trait VersionedTransactionOps {
         config: &Config,
         signer: &std::sync::Arc<Signer>,
         rpc_client: &std::sync::Arc<RpcClient>,
-        confirmation: ConfirmationMode,
+        respond_after: RespondAfter,
     ) -> Result<(String, String), KoraError>;
 }
 
@@ -549,7 +550,7 @@ impl VersionedTransactionOps for VersionedTransactionResolved {
         config: &Config,
         signer: &std::sync::Arc<Signer>,
         rpc_client: &std::sync::Arc<RpcClient>,
-        confirmation: ConfirmationMode,
+        respond_after: RespondAfter,
     ) -> Result<(String, String), KoraError> {
         // Payment validation is handled in sign_transaction
         let (transaction, encoded) =
@@ -571,8 +572,8 @@ impl VersionedTransactionOps for VersionedTransactionResolved {
             ));
         }
 
-        match confirmation {
-            ConfirmationMode::Confirmed => {
+        match respond_after {
+            RespondAfter::Confirmed => {
                 let signature = rpc_client
                     .send_and_confirm_transaction(&transaction)
                     .await
@@ -580,7 +581,7 @@ impl VersionedTransactionOps for VersionedTransactionResolved {
 
                 Ok((signature.to_string(), encoded))
             }
-            ConfirmationMode::Sent => {
+            RespondAfter::Sent => {
                 let signature = rpc_client
                     .send_transaction_with_config(&transaction, send_config)
                     .await
@@ -588,7 +589,7 @@ impl VersionedTransactionOps for VersionedTransactionResolved {
 
                 Ok((signature.to_string(), encoded))
             }
-            ConfirmationMode::None => {
+            RespondAfter::Signed => {
                 // A Solana transaction is identified by its first signature, which is
                 // already present once signing completes — so the caller gets it
                 // without waiting for the broadcast.

--- a/crates/lib/src/transaction/versioned_transaction.rs
+++ b/crates/lib/src/transaction/versioned_transaction.rs
@@ -559,7 +559,12 @@ impl VersionedTransactionOps for VersionedTransactionResolved {
         // Validation already simulated the transaction, so the fast modes skip
         // preflight: a second simulation only delays landing and can fail
         // transiently even though the transaction is valid.
-        let send_config = RpcSendTransactionConfig { skip_preflight: true, ..Default::default() };
+        //
+        // That simulation ran before Kora signed and used the caller's sig_verify
+        // (default false), so it does not cover signature validity — only the
+        // explicit guard below does.
+        let skip_preflight_config =
+            RpcSendTransactionConfig { skip_preflight: true, ..Default::default() };
 
         // Skipping preflight also skips the RPC node's signature verification, so a
         // transaction with an unfilled co-signer slot (possible when validation ran
@@ -583,7 +588,7 @@ impl VersionedTransactionOps for VersionedTransactionResolved {
             }
             RespondAfter::Sent => {
                 let signature = rpc_client
-                    .send_transaction_with_config(&transaction, send_config)
+                    .send_transaction_with_config(&transaction, skip_preflight_config)
                     .await
                     .map_err(|e| KoraError::RpcError(sanitize_error!(e)))?;
 
@@ -603,9 +608,15 @@ impl VersionedTransactionOps for VersionedTransactionResolved {
                     })?
                     .to_string();
 
-                // Broadcast in the background so the response returns instantly. The
-                // send is fire-and-forget: failures are logged rather than returned to
-                // the caller, who can rebroadcast the returned signed transaction.
+                // Broadcast in the background so the response returns instantly. This
+                // mode carries ZERO delivery guarantee: the response (signature +
+                // signed transaction) is returned before the send is even attempted,
+                // so any failure — a transient RPC error, the node dropping the
+                // transaction, or the broadcast never landing on-chain — happens after
+                // the caller already has a "successful" response. Failures are only
+                // logged server-side, never returned. Callers who need delivery
+                // assurance must use Sent or Confirmed, or rebroadcast the returned
+                // signed transaction themselves and verify it landed.
                 //
                 // The task is registered with the global tracker so a graceful
                 // shutdown drains in-flight broadcasts instead of cancelling them
@@ -614,7 +625,9 @@ impl VersionedTransactionOps for VersionedTransactionResolved {
                 let log_signature = signature.clone();
                 get_background_tasks().spawn(async move {
                     if let Err(e) =
-                        rpc_client.send_transaction_with_config(&transaction, send_config).await
+                        rpc_client
+                            .send_transaction_with_config(&transaction, skip_preflight_config)
+                            .await
                     {
                         log::error!(
                             "Background broadcast failed for transaction {log_signature}: {}",

--- a/crates/lib/src/transaction/versioned_transaction.rs
+++ b/crates/lib/src/transaction/versioned_transaction.rs
@@ -1,17 +1,25 @@
 use async_trait::async_trait;
 use base64::{engine::general_purpose::STANDARD, Engine as _};
-use solana_client::{nonblocking::rpc_client::RpcClient, rpc_config::RpcSimulateTransactionConfig};
+use serde::Deserialize;
+use solana_client::{
+    nonblocking::rpc_client::RpcClient,
+    rpc_config::{RpcSendTransactionConfig, RpcSimulateTransactionConfig},
+};
 use solana_commitment_config::CommitmentConfig;
 use solana_keychain::{Signer, SolanaSigner};
 use solana_message::{
     compiled_instruction::CompiledInstruction, v0::MessageAddressTableLookup, VersionedMessage,
 };
-use solana_sdk::{instruction::Instruction, pubkey::Pubkey, transaction::VersionedTransaction};
+use solana_sdk::{
+    instruction::Instruction, pubkey::Pubkey, signature::Signature,
+    transaction::VersionedTransaction,
+};
 use std::{
     collections::{HashMap, HashSet},
     ops::Deref,
     time::Duration,
 };
+use utoipa::ToSchema;
 
 use solana_transaction_status_client_types::UiTransactionEncoding;
 
@@ -83,6 +91,22 @@ impl Deref for VersionedTransactionResolved {
     }
 }
 
+/// How long `signAndSendTransaction` waits on the broadcast before responding.
+///
+/// All modes share the immediate sign-and-send validation flow (`will_send = true`)
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Deserialize, ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum ConfirmationMode {
+    /// Wait for on-chain confirmation at `confirmed` commitment (default).
+    #[default]
+    Confirmed,
+    /// Wait only until the RPC node accepts the transaction; no confirmation wait.
+    Sent,
+    /// Broadcast in the background and return as soon as signing completes. Broadcast
+    /// failures are logged server-side, not returned to the caller.
+    None,
+}
+
 #[async_trait]
 pub trait VersionedTransactionOps {
     fn encode_b64_transaction(&self) -> Result<String, KoraError>;
@@ -101,7 +125,8 @@ pub trait VersionedTransactionOps {
         &mut self,
         config: &Config,
         signer: &std::sync::Arc<Signer>,
-        rpc_client: &RpcClient,
+        rpc_client: &std::sync::Arc<RpcClient>,
+        confirmation: ConfirmationMode,
     ) -> Result<(String, String), KoraError>;
 }
 
@@ -523,19 +548,78 @@ impl VersionedTransactionOps for VersionedTransactionResolved {
         &mut self,
         config: &Config,
         signer: &std::sync::Arc<Signer>,
-        rpc_client: &RpcClient,
+        rpc_client: &std::sync::Arc<RpcClient>,
+        confirmation: ConfirmationMode,
     ) -> Result<(String, String), KoraError> {
         // Payment validation is handled in sign_transaction
         let (transaction, encoded) =
             self.sign_transaction(config, signer, rpc_client, true).await?;
 
-        // Send and confirm transaction
-        let signature = rpc_client
-            .send_and_confirm_transaction(&transaction)
-            .await
-            .map_err(|e| KoraError::RpcError(sanitize_error!(e)))?;
+        // Validation already simulated the transaction, so the fast modes skip
+        // preflight: a second simulation only delays landing and can fail
+        // transiently even though the transaction is valid.
+        let send_config = RpcSendTransactionConfig { skip_preflight: true, ..Default::default() };
 
-        Ok((signature.to_string(), encoded))
+        match confirmation {
+            ConfirmationMode::Confirmed => {
+                let signature = rpc_client
+                    .send_and_confirm_transaction(&transaction)
+                    .await
+                    .map_err(|e| KoraError::RpcError(sanitize_error!(e)))?;
+
+                Ok((signature.to_string(), encoded))
+            }
+            ConfirmationMode::Sent => {
+                let signature = rpc_client
+                    .send_transaction_with_config(&transaction, send_config)
+                    .await
+                    .map_err(|e| KoraError::RpcError(sanitize_error!(e)))?;
+
+                Ok((signature.to_string(), encoded))
+            }
+            ConfirmationMode::None => {
+                // The response is built before the broadcast runs, so a transaction
+                // that can never land (missing co-signer signature when sig_verify is
+                // off) must be rejected here instead of failing silently in the
+                // background.
+                if transaction.signatures.iter().any(|s| *s == Signature::default()) {
+                    return Err(KoraError::InvalidTransaction(
+                        "Transaction is missing required signatures".to_string(),
+                    ));
+                }
+
+                // A Solana transaction is identified by its first signature, which is
+                // already present once signing completes — so the caller gets it
+                // without waiting for the broadcast.
+                let signature = transaction
+                    .signatures
+                    .first()
+                    .ok_or_else(|| {
+                        KoraError::InvalidTransaction(
+                            "Signed transaction has no signatures".to_string(),
+                        )
+                    })?
+                    .to_string();
+
+                // Broadcast in the background so the response returns instantly. The
+                // send is fire-and-forget: failures are logged rather than returned to
+                // the caller, who can rebroadcast the returned signed transaction.
+                let rpc_client = std::sync::Arc::clone(rpc_client);
+                let log_signature = signature.clone();
+                tokio::spawn(async move {
+                    if let Err(e) =
+                        rpc_client.send_transaction_with_config(&transaction, send_config).await
+                    {
+                        log::error!(
+                            "Background broadcast failed for transaction {log_signature}: {}",
+                            sanitize_error!(e)
+                        );
+                    }
+                });
+
+                Ok((signature, encoded))
+            }
+        }
     }
 }
 

--- a/crates/lib/src/transaction/versioned_transaction.rs
+++ b/crates/lib/src/transaction/versioned_transaction.rs
@@ -624,10 +624,9 @@ impl VersionedTransactionOps for VersionedTransactionResolved {
                 let rpc_client = std::sync::Arc::clone(rpc_client);
                 let log_signature = signature.clone();
                 get_background_tasks().spawn(async move {
-                    if let Err(e) =
-                        rpc_client
-                            .send_transaction_with_config(&transaction, skip_preflight_config)
-                            .await
+                    if let Err(e) = rpc_client
+                        .send_transaction_with_config(&transaction, skip_preflight_config)
+                        .await
                     {
                         log::error!(
                             "Background broadcast failed for transaction {log_signature}: {}",

--- a/crates/lib/src/transaction/versioned_transaction.rs
+++ b/crates/lib/src/transaction/versioned_transaction.rs
@@ -30,7 +30,7 @@ use crate::{
     lighthouse::LighthouseUtil,
     plugin::{PluginExecutionContext, TransactionPluginRunner},
     sanitize_error,
-    state::{get_signer_pool, reserve_request_signer_by_pubkey},
+    state::{get_background_tasks, get_signer_pool, reserve_request_signer_by_pubkey},
     token::token::TransferHookValidationFlow,
     transaction::{
         instruction_util::IxUtils, ParsedALTInstructionData, ParsedALTInstructionType,
@@ -605,9 +605,13 @@ impl VersionedTransactionOps for VersionedTransactionResolved {
                 // Broadcast in the background so the response returns instantly. The
                 // send is fire-and-forget: failures are logged rather than returned to
                 // the caller, who can rebroadcast the returned signed transaction.
+                //
+                // The task is registered with the global tracker so a graceful
+                // shutdown drains in-flight broadcasts instead of cancelling them
+                // when the runtime exits.
                 let rpc_client = std::sync::Arc::clone(rpc_client);
                 let log_signature = signature.clone();
-                tokio::spawn(async move {
+                get_background_tasks().spawn(async move {
                     if let Err(e) =
                         rpc_client.send_transaction_with_config(&transaction, send_config).await
                     {

--- a/sdks/ts/src/client.ts
+++ b/sdks/ts/src/client.ts
@@ -263,10 +263,10 @@ export class KoraClient {
      * Signs a transaction and immediately broadcasts it to the Solana network.
      * @param request - Sign and send request parameters
      * @param request.transaction - Base64-encoded transaction to sign and send
-     * @param request.confirmation - How long the server waits on the broadcast before
+     * @param request.respond_after - The lifecycle milestone to wait for before
      * responding (defaults to `'confirmed'`): `'confirmed'` waits for on-chain confirmation,
-     * `'sent'` returns once the RPC node accepts the transaction, `'none'` broadcasts in the
-     * background and returns as soon as signing completes (broadcast failures are logged
+     * `'sent'` returns once the RPC node accepts the transaction, `'signed'` returns as soon
+     * as signing completes and broadcasts in the background (broadcast failures are logged
      * server-side; rebroadcast the returned signed transaction if it never lands)
      * @returns Signature and the signed transaction
      * @throws {Error} When the RPC call fails, validation fails, or broadcast fails
@@ -278,10 +278,10 @@ export class KoraClient {
      * });
      * console.log('Transaction signature:', result.signature);
      *
-     * // Lowest latency: return without waiting for the broadcast
+     * // Lowest latency: return as soon as signing completes
      * const fast = await client.signAndSendTransaction({
      *   transaction: 'base64EncodedTransaction',
-     *   confirmation: 'none'
+     *   respond_after: 'signed'
      * });
      * ```
      */

--- a/sdks/ts/src/client.ts
+++ b/sdks/ts/src/client.ts
@@ -263,6 +263,11 @@ export class KoraClient {
      * Signs a transaction and immediately broadcasts it to the Solana network.
      * @param request - Sign and send request parameters
      * @param request.transaction - Base64-encoded transaction to sign and send
+     * @param request.confirmation - How long the server waits on the broadcast before
+     * responding (defaults to `'confirmed'`): `'confirmed'` waits for on-chain confirmation,
+     * `'sent'` returns once the RPC node accepts the transaction, `'none'` broadcasts in the
+     * background and returns as soon as signing completes (broadcast failures are logged
+     * server-side; rebroadcast the returned signed transaction if it never lands)
      * @returns Signature and the signed transaction
      * @throws {Error} When the RPC call fails, validation fails, or broadcast fails
      *
@@ -272,6 +277,12 @@ export class KoraClient {
      *   transaction: 'base64EncodedTransaction'
      * });
      * console.log('Transaction signature:', result.signature);
+     *
+     * // Lowest latency: return without waiting for the broadcast
+     * const fast = await client.signAndSendTransaction({
+     *   transaction: 'base64EncodedTransaction',
+     *   confirmation: 'none'
+     * });
      * ```
      */
     async signAndSendTransaction(request: SignAndSendTransactionRequest): Promise<SignAndSendTransactionResponse> {

--- a/sdks/ts/src/types/index.ts
+++ b/sdks/ts/src/types/index.ts
@@ -19,9 +19,19 @@ export interface SignTransactionRequest {
 }
 
 /**
+ * How long the server waits on the broadcast before responding:
+ * - `confirmed`: wait for on-chain confirmation (default)
+ * - `sent`: return once the RPC node accepts the transaction
+ * - `none`: broadcast in the background and return as soon as signing completes
+ */
+export type ConfirmationMode = 'confirmed' | 'none' | 'sent';
+
+/**
  * Parameters for signing and sending a transaction.
  */
 export interface SignAndSendTransactionRequest {
+    /** Optional broadcast wait mode (defaults to "confirmed") */
+    confirmation?: ConfirmationMode;
     /** Optional signer verification during transaction simulation (defaults to false) */
     sig_verify?: boolean;
     /** Optional signer address for the transaction */

--- a/sdks/ts/src/types/index.ts
+++ b/sdks/ts/src/types/index.ts
@@ -19,19 +19,20 @@ export interface SignTransactionRequest {
 }
 
 /**
- * How long the server waits on the broadcast before responding:
+ * The transaction lifecycle milestone the server waits for before responding,
+ * ordered by increasing assurance: `signed` < `sent` < `confirmed`:
  * - `confirmed`: wait for on-chain confirmation (default)
  * - `sent`: return once the RPC node accepts the transaction
- * - `none`: broadcast in the background and return as soon as signing completes
+ * - `signed`: return as soon as signing completes and broadcast in the background
  */
-export type ConfirmationMode = 'confirmed' | 'none' | 'sent';
+export type RespondAfter = 'confirmed' | 'sent' | 'signed';
 
 /**
  * Parameters for signing and sending a transaction.
  */
 export interface SignAndSendTransactionRequest {
-    /** Optional broadcast wait mode (defaults to "confirmed") */
-    confirmation?: ConfirmationMode;
+    /** Optional milestone to wait for before responding (defaults to "confirmed") */
+    respond_after?: RespondAfter;
     /** Optional signer verification during transaction simulation (defaults to false) */
     sig_verify?: boolean;
     /** Optional signer address for the transaction */

--- a/sdks/ts/test/unit.test.ts
+++ b/sdks/ts/test/unit.test.ts
@@ -318,10 +318,10 @@ describe('KoraClient Unit Tests', () => {
             );
         });
 
-        it('should pass the confirmation mode through to the RPC request', async () => {
+        it('should pass the respond_after milestone through to the RPC request', async () => {
             const request: SignAndSendTransactionRequest = {
                 transaction: 'base64_encoded_transaction',
-                confirmation: 'none',
+                respond_after: 'signed',
             };
             const mockResponse: SignAndSendTransactionResponse = {
                 signature: 'transaction_signature',

--- a/sdks/ts/test/unit.test.ts
+++ b/sdks/ts/test/unit.test.ts
@@ -317,6 +317,25 @@ describe('KoraClient Unit Tests', () => {
                 request,
             );
         });
+
+        it('should pass the confirmation mode through to the RPC request', async () => {
+            const request: SignAndSendTransactionRequest = {
+                transaction: 'base64_encoded_transaction',
+                confirmation: 'none',
+            };
+            const mockResponse: SignAndSendTransactionResponse = {
+                signature: 'transaction_signature',
+                signed_transaction: 'base64_signed_transaction',
+                signer_pubkey: 'test_signer_pubkey',
+            };
+
+            await testSuccessfulRpcMethod(
+                'signAndSendTransaction',
+                () => client.signAndSendTransaction(request),
+                mockResponse,
+                request,
+            );
+        });
     });
 
     describe('signBundle', () => {

--- a/tests/rpc/transaction_signing.rs
+++ b/tests/rpc/transaction_signing.rs
@@ -190,6 +190,47 @@ async fn test_sign_and_send_transaction_confirmation_sent() {
 }
 
 #[tokio::test]
+async fn test_sign_and_send_transaction_confirmation_sent_rejects_missing_signature() {
+    let sender = SenderTestHelper::get_test_sender_keypair();
+    let recipient = RecipientTestHelper::get_recipient_pubkey();
+    let fee_payer = FeePayerTestHelper::get_fee_payer_pubkey();
+    let token_mint = USDCMintTestHelper::get_test_usdc_mint_pubkey();
+
+    let ctx = TestContext::new().await.expect("Failed to create test context");
+
+    // The sender is a required signer but never signs, leaving a default
+    // signature slot. With sig_verify=false nothing upstream catches it, and
+    // confirmation=sent skips preflight — so the server must reject it instead
+    // of returning a signature for a transaction validators will drop.
+    let test_tx = ctx
+        .transaction_builder()
+        .with_fee_payer(fee_payer)
+        .with_spl_transfer(
+            &token_mint,
+            &sender.pubkey(),
+            &fee_payer,
+            tests::common::helpers::get_fee_for_default_transaction_in_usdc(),
+        )
+        .with_transfer(&sender.pubkey(), &recipient, 10)
+        .build()
+        .await
+        .expect("Failed to create unsigned test transaction");
+
+    let result: Result<serde_json::Value, _> = ctx
+        .rpc_call(
+            "signAndSendTransaction",
+            rpc_params![test_tx, None::<String>, false, None::<String>, "sent"],
+        )
+        .await;
+
+    let error = result.expect_err("Expected rejection for transaction with missing signature");
+    assert!(
+        error.to_string().contains("missing required signatures"),
+        "Expected missing-signatures error, got: {error}"
+    );
+}
+
+#[tokio::test]
 async fn test_sign_and_send_transaction_confirmation_none() {
     let sender = SenderTestHelper::get_test_sender_keypair();
     let recipient = RecipientTestHelper::get_recipient_pubkey();

--- a/tests/rpc/transaction_signing.rs
+++ b/tests/rpc/transaction_signing.rs
@@ -148,7 +148,7 @@ async fn test_sign_and_send_transaction_legacy() {
 }
 
 #[tokio::test]
-async fn test_sign_and_send_transaction_confirmation_sent() {
+async fn test_sign_and_send_transaction_respond_after_sent() {
     let sender = SenderTestHelper::get_test_sender_keypair();
     let recipient = RecipientTestHelper::get_recipient_pubkey();
     let fee_payer = FeePayerTestHelper::get_fee_payer_pubkey();
@@ -171,7 +171,7 @@ async fn test_sign_and_send_transaction_confirmation_sent() {
         .await
         .expect("Failed to create signed test transaction");
 
-    // Positional params: [transaction, signer_key, sig_verify, user_id, confirmation]
+    // Positional params: [transaction, signer_key, sig_verify, user_id, respond_after]
     let result: Result<serde_json::Value, _> = ctx
         .rpc_call(
             "signAndSendTransaction",
@@ -179,7 +179,7 @@ async fn test_sign_and_send_transaction_confirmation_sent() {
         )
         .await;
 
-    assert!(result.is_ok(), "Expected signAndSendTransaction with confirmation=sent to succeed");
+    assert!(result.is_ok(), "Expected signAndSendTransaction with respond_after=sent to succeed");
     let response = result.unwrap();
 
     assert!(response["signature"].as_str().is_some(), "Expected signature in response");
@@ -190,7 +190,7 @@ async fn test_sign_and_send_transaction_confirmation_sent() {
 }
 
 #[tokio::test]
-async fn test_sign_and_send_transaction_confirmation_sent_rejects_missing_signature() {
+async fn test_sign_and_send_transaction_respond_after_sent_rejects_missing_signature() {
     let sender = SenderTestHelper::get_test_sender_keypair();
     let recipient = RecipientTestHelper::get_recipient_pubkey();
     let fee_payer = FeePayerTestHelper::get_fee_payer_pubkey();
@@ -200,7 +200,7 @@ async fn test_sign_and_send_transaction_confirmation_sent_rejects_missing_signat
 
     // The sender is a required signer but never signs, leaving a default
     // signature slot. With sig_verify=false nothing upstream catches it, and
-    // confirmation=sent skips preflight — so the server must reject it instead
+    // respond_after=sent skips preflight — so the server must reject it instead
     // of returning a signature for a transaction validators will drop.
     let test_tx = ctx
         .transaction_builder()
@@ -231,7 +231,7 @@ async fn test_sign_and_send_transaction_confirmation_sent_rejects_missing_signat
 }
 
 #[tokio::test]
-async fn test_sign_and_send_transaction_confirmation_none() {
+async fn test_sign_and_send_transaction_respond_after_signed() {
     let sender = SenderTestHelper::get_test_sender_keypair();
     let recipient = RecipientTestHelper::get_recipient_pubkey();
     let fee_payer = FeePayerTestHelper::get_fee_payer_pubkey();
@@ -257,11 +257,11 @@ async fn test_sign_and_send_transaction_confirmation_none() {
     let result: Result<serde_json::Value, _> = ctx
         .rpc_call(
             "signAndSendTransaction",
-            rpc_params![test_tx, None::<String>, false, None::<String>, "none"],
+            rpc_params![test_tx, None::<String>, false, None::<String>, "signed"],
         )
         .await;
 
-    assert!(result.is_ok(), "Expected signAndSendTransaction with confirmation=none to succeed");
+    assert!(result.is_ok(), "Expected signAndSendTransaction with respond_after=signed to succeed");
     let response = result.unwrap();
 
     // The signature is derived from the signed transaction before the background

--- a/tests/rpc/transaction_signing.rs
+++ b/tests/rpc/transaction_signing.rs
@@ -276,6 +276,27 @@ async fn test_sign_and_send_transaction_respond_after_signed() {
         decoded.signatures[0].to_string(),
         "Returned signature should be the transaction's first signature"
     );
+
+    // The response returns before the broadcast runs, so the transaction lands
+    // asynchronously. Poll its signature status to confirm the background broadcast
+    // actually submitted it to the network rather than dropping it silently.
+    let signature = solana_sdk::signature::Signature::from_str(signature)
+        .expect("Returned signature should parse");
+    let rpc_client = ctx.rpc_client();
+
+    let mut landed = false;
+    for _ in 0..20 {
+        let statuses = rpc_client
+            .get_signature_statuses(&[signature])
+            .await
+            .expect("getSignatureStatuses should succeed");
+        if statuses.value.first().and_then(|status| status.as_ref()).is_some() {
+            landed = true;
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+    }
+    assert!(landed, "Background broadcast should have submitted the transaction to the network");
 }
 
 #[tokio::test]

--- a/tests/rpc/transaction_signing.rs
+++ b/tests/rpc/transaction_signing.rs
@@ -148,6 +148,96 @@ async fn test_sign_and_send_transaction_legacy() {
 }
 
 #[tokio::test]
+async fn test_sign_and_send_transaction_confirmation_sent() {
+    let sender = SenderTestHelper::get_test_sender_keypair();
+    let recipient = RecipientTestHelper::get_recipient_pubkey();
+    let fee_payer = FeePayerTestHelper::get_fee_payer_pubkey();
+    let token_mint = USDCMintTestHelper::get_test_usdc_mint_pubkey();
+
+    let ctx = TestContext::new().await.expect("Failed to create test context");
+
+    let test_tx = ctx
+        .transaction_builder()
+        .with_fee_payer(fee_payer)
+        .with_signer(&sender)
+        .with_spl_transfer(
+            &token_mint,
+            &sender.pubkey(),
+            &fee_payer,
+            tests::common::helpers::get_fee_for_default_transaction_in_usdc(),
+        )
+        .with_transfer(&sender.pubkey(), &recipient, 10)
+        .build()
+        .await
+        .expect("Failed to create signed test transaction");
+
+    // Positional params: [transaction, signer_key, sig_verify, user_id, confirmation]
+    let result: Result<serde_json::Value, _> = ctx
+        .rpc_call(
+            "signAndSendTransaction",
+            rpc_params![test_tx, None::<String>, false, None::<String>, "sent"],
+        )
+        .await;
+
+    assert!(result.is_ok(), "Expected signAndSendTransaction with confirmation=sent to succeed");
+    let response = result.unwrap();
+
+    assert!(response["signature"].as_str().is_some(), "Expected signature in response");
+    assert!(
+        response["signed_transaction"].as_str().is_some(),
+        "Expected signed_transaction in response"
+    );
+}
+
+#[tokio::test]
+async fn test_sign_and_send_transaction_confirmation_none() {
+    let sender = SenderTestHelper::get_test_sender_keypair();
+    let recipient = RecipientTestHelper::get_recipient_pubkey();
+    let fee_payer = FeePayerTestHelper::get_fee_payer_pubkey();
+    let token_mint = USDCMintTestHelper::get_test_usdc_mint_pubkey();
+
+    let ctx = TestContext::new().await.expect("Failed to create test context");
+
+    let test_tx = ctx
+        .transaction_builder()
+        .with_fee_payer(fee_payer)
+        .with_signer(&sender)
+        .with_spl_transfer(
+            &token_mint,
+            &sender.pubkey(),
+            &fee_payer,
+            tests::common::helpers::get_fee_for_default_transaction_in_usdc(),
+        )
+        .with_transfer(&sender.pubkey(), &recipient, 10)
+        .build()
+        .await
+        .expect("Failed to create signed test transaction");
+
+    let result: Result<serde_json::Value, _> = ctx
+        .rpc_call(
+            "signAndSendTransaction",
+            rpc_params![test_tx, None::<String>, false, None::<String>, "none"],
+        )
+        .await;
+
+    assert!(result.is_ok(), "Expected signAndSendTransaction with confirmation=none to succeed");
+    let response = result.unwrap();
+
+    // The signature is derived from the signed transaction before the background
+    // broadcast runs, so it must match the transaction's first signature.
+    let signature = response["signature"].as_str().expect("Expected signature in response");
+    let signed_transaction =
+        response["signed_transaction"].as_str().expect("Expected signed_transaction in response");
+    let decoded = TransactionUtil::decode_b64_transaction(signed_transaction)
+        .expect("Returned signed transaction should decode");
+    assert_eq!(
+        signature,
+        decoded.signatures[0].to_string(),
+        "Returned signature should be the transaction's first signature"
+    );
+}
+
+#[tokio::test]
 async fn test_sign_and_send_transaction_v0() {
     let sender = SenderTestHelper::get_test_sender_keypair();
     let recipient = RecipientTestHelper::get_recipient_pubkey();


### PR DESCRIPTION
# What
Adds an optional `confirmation` parameter to `signAndSendTransaction`, letting callers choose how long the server waits on the broadcast before responding:

- `confirmed` (default) — waits for on-chain confirmation
- `sent` — returns once the RPC node accepts the transaction
- `none` — broadcasts in the background and returns as soon as signing completes

# Why
The previous behavior always waited for full on-chain confirmation, adding latency for callers that don't need it. The faster modes let clients trade confirmation guarantees for lower latency.

# How
- New `ConfirmationMode` enum threaded through `sign_and_send_transaction`, defaulting to `Confirmed` for backward compatibility.
- Fast modes (`sent`, `none`) skip preflight since validation already simulates the transaction.
- `none` returns the transaction's first signature immediately and broadcasts via `tokio::spawn`; broadcast failures are logged server-side rather than returned. It rejects transactions missing required signatures up front to avoid silent background failures.
- Exposed in the OpenAPI docs and the TypeScript SDK (`ConfirmationMode` type), with unit and integration test coverage.