### PR TITLE
feat: implement identity-aware rate limiting and configurable CORS

### DIFF
--- a/crates/lib/src/config.rs
+++ b/crates/lib/src/config.rs
@@ -707,7 +707,8 @@ pub struct PluginsConfig {
 #[derive(Clone, Serialize, Deserialize, ToSchema)]
 #[serde(default, deny_unknown_fields)]
 pub struct KoraConfig {
-    pub rate_limit: u64,
+    pub rate_limit: Option<u64>,
+    pub global_rate_limit: Option<u64>,
     pub cors_allow_origins: Vec<String>,
     pub max_request_body_size: usize,
     pub enabled_methods: EnabledMethods,
@@ -734,7 +735,8 @@ pub struct KoraConfig {
 impl Default for KoraConfig {
     fn default() -> Self {
         Self {
-            rate_limit: 100,
+            rate_limit: Some(100),
+            global_rate_limit: None,
             cors_allow_origins: vec!["*".to_string()],
             max_request_body_size: DEFAULT_MAX_REQUEST_BODY_SIZE,
             enabled_methods: EnabledMethods::default(),
@@ -994,7 +996,7 @@ mod tests {
         );
         assert_eq!(config.validation.disallowed_accounts, vec!["account1"]);
         assert_eq!(config.validation.price_source, PriceSource::Jupiter);
-        assert_eq!(config.kora.rate_limit, 100);
+        assert_eq!(config.kora.rate_limit, Some(100));
         assert!(config.kora.enabled_methods.estimate_transaction_fee);
         assert!(config.kora.enabled_methods.sign_and_send_transaction);
     }
@@ -1021,7 +1023,7 @@ mod tests {
             .build_config()
             .unwrap();
 
-        assert_eq!(config.kora.rate_limit, 100);
+        assert_eq!(config.kora.rate_limit, Some(100));
         assert!(config.kora.enabled_methods.liveness);
         assert!(!config.kora.enabled_methods.estimate_transaction_fee);
         assert!(config.kora.enabled_methods.get_supported_tokens);

--- a/crates/lib/src/config.rs
+++ b/crates/lib/src/config.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use solana_sdk::pubkey::Pubkey;
 use spl_token_2022_interface::extension::ExtensionType;
-use std::{fs, path::Path, str::FromStr};
+use std::{env, fs, path::Path, str::FromStr};
 use toml;
 use utoipa::ToSchema;
 
@@ -686,7 +686,7 @@ impl CacheConfig {
     /// Resolve the Redis URL to use. Priority: `KORA_REDIS_URL` env var over the `url`
     /// field from the TOML config. Returns `None` when neither is set.
     pub fn resolved_url(&self) -> Option<String> {
-        std::env::var("KORA_REDIS_URL").ok().or_else(|| self.url.clone())
+        env::var("KORA_REDIS_URL").ok().or_else(|| self.url.clone())
     }
 }
 
@@ -852,12 +852,12 @@ impl AuthConfig {
     /// Resolve a secret env-first: a non-empty environment variable overrides the config value.
     /// This is the same precedence the running server applies, so validation and runtime agree.
     pub(crate) fn resolve_secret(env_var: &str, config_value: Option<&str>) -> Option<String> {
-        Self::normalize_optional_secret(std::env::var(env_var).ok())
+        Self::normalize_optional_secret(env::var(env_var).ok())
             .or_else(|| Self::normalize_optional_secret(config_value.map(str::to_string)))
     }
 
     pub(crate) fn resolved_api_keys(&self) -> Option<Vec<String>> {
-        let env_value = Self::normalize_optional_secret(std::env::var(Self::API_KEY_ENV).ok());
+        let env_value = Self::normalize_optional_secret(env::var(Self::API_KEY_ENV).ok());
         if let Some(env_key) = env_value {
             Some(vec![env_key])
         } else {
@@ -880,28 +880,46 @@ impl AuthConfig {
 
     /// Auth fields where a non-empty environment variable overrides a *different* non-empty
     /// kora.toml value. Returns `(env_var, config_field_label)`; never returns secret contents.
-    pub(crate) fn env_overridden_fields(&self) -> Vec<(&'static str, &'static str)> {
-        [
-            (
-                Self::API_KEY_ENV,
-                "[kora.auth].api_keys",
-                self.api_keys.as_ref().and_then(|keys| keys.first().map(|s| s.as_str())),
-            ),
-            (Self::HMAC_SECRET_ENV, "[kora.auth].hmac_secret", self.hmac_secret.as_deref()),
-            (
-                Self::RECAPTCHA_SECRET_ENV,
-                "[kora.auth].recaptcha_secret",
-                self.recaptcha_secret.as_deref(),
-            ),
-        ]
-        .into_iter()
-        .filter(|(env_var, _, config_value)| {
-            let env_value = Self::normalize_optional_secret(std::env::var(env_var).ok());
-            let config_value = Self::normalize_optional_secret(config_value.map(str::to_string));
-            matches!((env_value, config_value), (Some(env), Some(cfg)) if env != cfg)
-        })
-        .map(|(env_var, label, _)| (env_var, label))
-        .collect()
+    pub(crate) fn env_overridden_fields(&self) -> Vec<String> {
+        let mut overridden = Vec::new();
+
+        let env_api_key = Self::normalize_optional_secret(env::var(Self::API_KEY_ENV).ok());
+        if let Some(env_key) = env_api_key {
+            if let Some(keys) = &self.api_keys {
+                let valid_keys: Vec<_> = keys.iter().filter(|k| !k.is_empty()).collect();
+                if valid_keys.len() > 1 {
+                    overridden.push(format!("{} is set and overrides all api_keys configured in TOML ({} keys) — only the environment variable key is active", Self::API_KEY_ENV, valid_keys.len()));
+                } else if valid_keys.len() == 1 && valid_keys[0] != &env_key {
+                    overridden.push(format!("environment variable {} overrides [kora.auth].api_keys. The environment value takes precedence at runtime; if you rotated the secret in kora.toml, the stale environment value is still in effect. Unset {} or align it with the config.", Self::API_KEY_ENV, Self::API_KEY_ENV));
+                }
+            }
+        }
+
+        let check_override = |env_var: &'static str,
+                              config_label: &'static str,
+                              config_val: Option<&String>| {
+            let env_val = Self::normalize_optional_secret(env::var(env_var).ok());
+            let cfg_val = Self::normalize_optional_secret(config_val.cloned());
+            matches!((env_val, cfg_val), (Some(env), Some(cfg)) if env != cfg)
+                .then_some(format!("environment variable {} overrides {}. The environment value takes precedence at runtime; if you rotated the secret in kora.toml, the stale environment value is still in effect. Unset {} or align it with the config.", env_var, config_label, env_var))
+        };
+
+        if let Some(msg) = check_override(
+            Self::HMAC_SECRET_ENV,
+            "[kora.auth].hmac_secret",
+            self.hmac_secret.as_ref(),
+        ) {
+            overridden.push(msg);
+        }
+        if let Some(msg) = check_override(
+            Self::RECAPTCHA_SECRET_ENV,
+            "[kora.auth].recaptcha_secret",
+            self.recaptcha_secret.as_ref(),
+        ) {
+            overridden.push(msg);
+        }
+
+        overridden
     }
 }
 
@@ -1405,15 +1423,15 @@ allow_create = true
     }
 
     fn scoped_redis_env<F: FnOnce()>(value: Option<&str>, f: F) {
-        let previous = std::env::var("KORA_REDIS_URL").ok();
+        let previous = env::var("KORA_REDIS_URL").ok();
         match value {
-            Some(v) => std::env::set_var("KORA_REDIS_URL", v),
-            None => std::env::remove_var("KORA_REDIS_URL"),
+            Some(v) => env::set_var("KORA_REDIS_URL", v),
+            None => env::remove_var("KORA_REDIS_URL"),
         }
         f();
         match previous {
-            Some(v) => std::env::set_var("KORA_REDIS_URL", v),
-            None => std::env::remove_var("KORA_REDIS_URL"),
+            Some(v) => env::set_var("KORA_REDIS_URL", v),
+            None => env::remove_var("KORA_REDIS_URL"),
         }
     }
 
@@ -1532,5 +1550,28 @@ api_keys = ["", "  "]
             )
             .build_config();
         assert_unknown_field_error(result, "unknown_rule_field");
+    #[test]
+    #[serial_test::serial]
+    fn test_env_overridden_fields_multiple_keys_backup_dropped() {
+        let auth_config = AuthConfig {
+            api_keys: Some(vec!["key1".to_string(), "key2".to_string()]),
+            ..Default::default()
+        };
+
+        let previous = env::var("KORA_API_KEY").ok();
+        env::set_var("KORA_API_KEY", "key1");
+
+        let warnings = auth_config.env_overridden_fields();
+
+        if let Some(v) = previous {
+            env::set_var("KORA_API_KEY", v);
+        } else {
+            env::remove_var("KORA_API_KEY");
+        }
+
+        assert_eq!(warnings.len(), 1);
+        assert!(warnings[0].contains(
+            "KORA_API_KEY is set and overrides all api_keys configured in TOML (2 keys)"
+        ));
     }
 }

--- a/crates/lib/src/config.rs
+++ b/crates/lib/src/config.rs
@@ -793,10 +793,22 @@ where
     let opt = Option::<StringOrVec>::deserialize(deserializer)?;
     Ok(match opt {
         Some(StringOrVec::String(s)) => {
-            log::warn!("DEPRECATION WARNING: 'api_key' as a single string is deprecated. Please migrate to using 'api_keys' as an array in your configuration.");
-            Some(vec![s])
+            let s = s.trim();
+            if s.is_empty() {
+                None
+            } else {
+                log::warn!("DEPRECATION WARNING: 'api_key' as a single string is deprecated. Please migrate to using 'api_keys' as an array in your configuration.");
+                Some(vec![s.to_string()])
+            }
         }
-        Some(StringOrVec::Vec(v)) => Some(v),
+        Some(StringOrVec::Vec(v)) => {
+            let filtered: Vec<String> = v.into_iter().filter(|s| !s.trim().is_empty()).collect();
+            if filtered.is_empty() {
+                None
+            } else {
+                Some(filtered)
+            }
+        }
         None => None,
     })
 }
@@ -1410,6 +1422,26 @@ allow_create = true
         scoped_redis_env(Some("redis://from-env:6379"), || {
             assert_eq!(cfg.resolved_url(), Some("redis://from-env:6379".into()));
         });
+    }
+
+    #[test]
+    fn test_api_keys_with_empty_strings_filtered() {
+        let toml_str = r#"
+api_keys = ["valid-key", ""]
+        "#;
+        let config: AuthConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.api_keys, Some(vec!["valid-key".to_string()]));
+        assert!(config.has_auth());
+    }
+
+    #[test]
+    fn test_api_keys_all_empty_strings_filtered() {
+        let toml_str = r#"
+api_keys = ["", "  "]
+        "#;
+        let config: AuthConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.api_keys, None);
+        assert!(!config.has_auth());
     }
 
     #[test]

--- a/crates/lib/src/config.rs
+++ b/crates/lib/src/config.rs
@@ -708,6 +708,7 @@ pub struct PluginsConfig {
 #[serde(default, deny_unknown_fields)]
 pub struct KoraConfig {
     pub rate_limit: u64,
+    pub cors_allow_origins: Vec<String>,
     pub max_request_body_size: usize,
     pub enabled_methods: EnabledMethods,
     pub auth: AuthConfig,
@@ -734,6 +735,7 @@ impl Default for KoraConfig {
     fn default() -> Self {
         Self {
             rate_limit: 100,
+            cors_allow_origins: vec!["*".to_string()],
             max_request_body_size: DEFAULT_MAX_REQUEST_BODY_SIZE,
             enabled_methods: EnabledMethods::default(),
             auth: AuthConfig::default(),
@@ -777,10 +779,33 @@ impl Default for LighthouseConfig {
     }
 }
 
+fn deserialize_api_keys<'de, D>(deserializer: D) -> Result<Option<Vec<String>>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum StringOrVec {
+        String(String),
+        Vec(Vec<String>),
+    }
+
+    let opt = Option::<StringOrVec>::deserialize(deserializer)?;
+    Ok(match opt {
+        Some(StringOrVec::String(s)) => {
+            log::warn!("DEPRECATION WARNING: 'api_key' as a single string is deprecated. Please migrate to using 'api_keys' as an array in your configuration.");
+            Some(vec![s])
+        }
+        Some(StringOrVec::Vec(v)) => Some(v),
+        None => None,
+    })
+}
+
 #[derive(Clone, Serialize, Deserialize, ToSchema)]
 #[serde(default, deny_unknown_fields)]
 pub struct AuthConfig {
-    pub api_key: Option<String>,
+    #[serde(alias = "api_key", deserialize_with = "deserialize_api_keys")]
+    pub api_keys: Option<Vec<String>>,
     pub hmac_secret: Option<String>,
     pub recaptcha_secret: Option<String>,
     pub recaptcha_score_threshold: f64,
@@ -791,7 +816,7 @@ pub struct AuthConfig {
 impl Default for AuthConfig {
     fn default() -> Self {
         Self {
-            api_key: None,
+            api_keys: None,
             hmac_secret: None,
             recaptcha_secret: None,
             recaptcha_score_threshold: DEFAULT_RECAPTCHA_SCORE_THRESHOLD,
@@ -817,8 +842,13 @@ impl AuthConfig {
             .or_else(|| Self::normalize_optional_secret(config_value.map(str::to_string)))
     }
 
-    pub(crate) fn resolved_api_key(&self) -> Option<String> {
-        Self::resolve_secret(Self::API_KEY_ENV, self.api_key.as_deref())
+    pub(crate) fn resolved_api_keys(&self) -> Option<Vec<String>> {
+        let env_value = Self::normalize_optional_secret(std::env::var(Self::API_KEY_ENV).ok());
+        if let Some(env_key) = env_value {
+            Some(vec![env_key])
+        } else {
+            self.api_keys.clone()
+        }
     }
 
     pub(crate) fn resolved_hmac_secret(&self) -> Option<String> {
@@ -831,14 +861,18 @@ impl AuthConfig {
 
     /// Whether API-key or HMAC auth is in effect after env-first resolution (what the server enforces).
     pub(crate) fn has_resolved_auth(&self) -> bool {
-        self.resolved_api_key().is_some() || self.resolved_hmac_secret().is_some()
+        self.resolved_api_keys().is_some() || self.resolved_hmac_secret().is_some()
     }
 
     /// Auth fields where a non-empty environment variable overrides a *different* non-empty
     /// kora.toml value. Returns `(env_var, config_field_label)`; never returns secret contents.
     pub(crate) fn env_overridden_fields(&self) -> Vec<(&'static str, &'static str)> {
         [
-            (Self::API_KEY_ENV, "[kora.auth].api_key", self.api_key.as_deref()),
+            (
+                Self::API_KEY_ENV,
+                "[kora.auth].api_keys",
+                self.api_keys.as_ref().and_then(|keys| keys.first().map(|s| s.as_str())),
+            ),
             (Self::HMAC_SECRET_ENV, "[kora.auth].hmac_secret", self.hmac_secret.as_deref()),
             (
                 Self::RECAPTCHA_SECRET_ENV,
@@ -907,6 +941,23 @@ mod tests {
     };
 
     use super::*;
+
+    #[test]
+    fn test_legacy_api_key_backward_compatibility() {
+        // Test that the old `api_key = "single-key"` format is successfully deserialized
+        // into `api_keys = ["single-key"]`.
+        let toml_str = r#"
+            rate_limit = 100
+            max_request_body_size = 1024
+            
+            [auth]
+            api_key = "legacy-single-key"
+        "#;
+
+        let config: KoraConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.auth.api_keys, Some(vec!["legacy-single-key".to_string()]));
+        assert!(config.auth.has_resolved_auth());
+    }
 
     #[test]
     fn test_load_valid_config() {

--- a/crates/lib/src/config.rs
+++ b/crates/lib/src/config.rs
@@ -1431,7 +1431,7 @@ api_keys = ["valid-key", ""]
         "#;
         let config: AuthConfig = toml::from_str(toml_str).unwrap();
         assert_eq!(config.api_keys, Some(vec!["valid-key".to_string()]));
-        assert!(config.has_auth());
+        assert!(config.has_resolved_auth());
     }
 
     #[test]
@@ -1441,7 +1441,7 @@ api_keys = ["", "  "]
         "#;
         let config: AuthConfig = toml::from_str(toml_str).unwrap();
         assert_eq!(config.api_keys, None);
-        assert!(!config.has_auth());
+        assert!(!config.has_resolved_auth());
     }
 
     #[test]

--- a/crates/lib/src/config.rs
+++ b/crates/lib/src/config.rs
@@ -1550,6 +1550,8 @@ api_keys = ["", "  "]
             )
             .build_config();
         assert_unknown_field_error(result, "unknown_rule_field");
+    }
+
     #[test]
     #[serial_test::serial]
     fn test_env_overridden_fields_multiple_keys_backup_dropped() {

--- a/crates/lib/src/metrics/middleware.rs
+++ b/crates/lib/src/metrics/middleware.rs
@@ -13,6 +13,7 @@ const ERROR_STATUS: &str = "error";
 pub struct HttpMetrics {
     pub requests_total: CounterVec,
     pub request_duration_seconds: HistogramVec,
+    pub http_rejections_total: CounterVec,
 }
 
 impl HttpMetrics {
@@ -40,6 +41,15 @@ impl HttpMetrics {
             panic!("Metrics initialization failed - cannot continue")
         });
 
+        let http_rejections_total = CounterVec::new(
+            Opts::new("http_rejections_total", "Total number of HTTP rejections").namespace("kora"),
+            &["method", "reason"],
+        )
+        .unwrap_or_else(|e| {
+            log::error!("Failed to create http_rejections_total metric: {e:?}");
+            panic!("Metrics initialization failed - cannot continue")
+        });
+
         prometheus::register(Box::new(requests_total.clone())).unwrap_or_else(|e| {
             log::error!("Failed to register http_requests_total metric: {e:?}");
             panic!("Metrics initialization failed - cannot continue")
@@ -48,8 +58,12 @@ impl HttpMetrics {
             log::error!("Failed to register http_request_duration_seconds metric: {e:?}");
             panic!("Metrics initialization failed - cannot continue")
         });
+        prometheus::register(Box::new(http_rejections_total.clone())).unwrap_or_else(|e| {
+            log::error!("Failed to register http_rejections_total metric: {e:?}");
+            panic!("Metrics initialization failed - cannot continue")
+        });
 
-        Self { requests_total, request_duration_seconds }
+        Self { requests_total, request_duration_seconds, http_rejections_total }
     }
 
     pub fn get() -> &'static HttpMetrics {
@@ -131,6 +145,15 @@ where
                         .request_duration_seconds
                         .with_label_values(&[&method])
                         .observe(duration.as_secs_f64());
+
+                    if let Some(reason) =
+                        response.extensions().get::<crate::rpc_server::auth::RejectionReason>()
+                    {
+                        metrics
+                            .http_rejections_total
+                            .with_label_values(&[&method, reason.as_str()])
+                            .inc();
+                    }
                 }
                 Err(_) => {
                     metrics

--- a/crates/lib/src/metrics/middleware.rs
+++ b/crates/lib/src/metrics/middleware.rs
@@ -1,8 +1,11 @@
-use crate::rpc_server::middleware_utils::{extract_parts_and_body_bytes, get_jsonrpc_method};
+use crate::rpc_server::{
+    auth::RejectionReason,
+    middleware_utils::{extract_parts_and_body_bytes, get_jsonrpc_method},
+};
 use http::{Request, Response};
 use jsonrpsee::server::logger::Body;
 use prometheus::{CounterVec, HistogramVec, Opts};
-use std::{sync::OnceLock, time::Instant};
+use std::{future::Future, pin::Pin, sync::OnceLock, time::Instant};
 use tower::Layer;
 
 static HTTP_METRICS: OnceLock<HttpMetrics> = OnceLock::new();
@@ -107,9 +110,7 @@ where
 {
     type Response = S::Response;
     type Error = S::Error;
-    type Future = std::pin::Pin<
-        Box<dyn std::future::Future<Output = Result<Self::Response, Self::Error>> + Send>,
-    >;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
 
     fn poll_ready(
         &mut self,
@@ -146,9 +147,7 @@ where
                         .with_label_values(&[&method])
                         .observe(duration.as_secs_f64());
 
-                    if let Some(reason) =
-                        response.extensions().get::<crate::rpc_server::auth::RejectionReason>()
-                    {
+                    if let Some(reason) = response.extensions().get::<RejectionReason>() {
                         metrics
                             .http_rejections_total
                             .with_label_values(&[&method, reason.as_str()])

--- a/crates/lib/src/rpc_server/auth.rs
+++ b/crates/lib/src/rpc_server/auth.rs
@@ -10,27 +10,45 @@ use jsonrpsee::server::logger::Body;
 use sha2::Sha256;
 use subtle::ConstantTimeEq;
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ClientIdentity(pub String);
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum RejectionReason {
+    AuthFailure,
+    RateLimit,
+}
+
+impl RejectionReason {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            RejectionReason::AuthFailure => "auth_failure",
+            RejectionReason::RateLimit => "rate_limit",
+        }
+    }
+}
+
 #[derive(Clone)]
 pub struct ApiKeyAuthLayer {
-    api_key: String,
+    api_keys: Vec<String>,
 }
 
 impl ApiKeyAuthLayer {
-    pub fn new(api_key: String) -> Self {
-        Self { api_key }
+    pub fn new(api_keys: Vec<String>) -> Self {
+        Self { api_keys }
     }
 }
 
 #[derive(Clone)]
 pub struct ApiKeyAuthService<S> {
     inner: S,
-    api_key: String,
+    api_keys: Vec<String>,
 }
 
 impl<S> tower::Layer<S> for ApiKeyAuthLayer {
     type Service = ApiKeyAuthService<S>;
     fn layer(&self, inner: S) -> Self::Service {
-        ApiKeyAuthService { inner, api_key: self.api_key.clone() }
+        ApiKeyAuthService { inner, api_keys: self.api_keys.clone() }
     }
 }
 
@@ -53,12 +71,13 @@ where
     }
 
     fn call(&mut self, request: Request<Body>) -> Self::Future {
-        let api_key = self.api_key.clone();
+        let api_keys = self.api_keys.clone();
         let mut inner = self.inner.clone();
 
         Box::pin(async move {
-            let unauthorized_response =
+            let mut unauthorized_response =
                 build_response_with_graceful_error(None, StatusCode::UNAUTHORIZED, "");
+            unauthorized_response.extensions_mut().insert(RejectionReason::AuthFailure);
 
             let (parts, body_bytes) = extract_parts_and_body_bytes(request).await;
 
@@ -72,10 +91,22 @@ where
             }
 
             // Check for API key header
-            let req = Request::from_parts(parts, Body::from(body_bytes));
-            if let Some(provided_key) = req.headers().get(X_API_KEY) {
+            let mut req = Request::from_parts(parts, Body::from(body_bytes));
+            let provided_key = req.headers().get(X_API_KEY).cloned();
+            if let Some(provided_key) = provided_key {
                 // Constant-time comparison prevents timing attacks
-                if provided_key.as_bytes().ct_eq(api_key.as_bytes()).into() {
+                let mut matched = false;
+                for key in &api_keys {
+                    if provided_key.as_bytes().ct_eq(key.as_bytes()).into() {
+                        matched = true;
+                        break;
+                    }
+                }
+
+                if matched {
+                    if let Ok(key_str) = provided_key.to_str() {
+                        req.extensions_mut().insert(ClientIdentity(format!("apikey:{}", key_str)));
+                    }
                     return inner.call(req).await;
                 }
             }
@@ -140,8 +171,9 @@ where
         let mut inner = self.inner.clone();
 
         Box::pin(async move {
-            let unauthorized_response =
+            let mut unauthorized_response =
                 build_response_with_graceful_error(None, StatusCode::UNAUTHORIZED, "");
+            unauthorized_response.extensions_mut().insert(RejectionReason::AuthFailure);
 
             let signature_header = request.headers().get(X_HMAC_SIGNATURE).cloned();
             let timestamp_header = request.headers().get(X_TIMESTAMP).cloned();
@@ -157,14 +189,20 @@ where
                 }
             }
 
-            let (signature, timestamp) =
-                match (signature_header.as_ref(), timestamp_header.as_ref()) {
-                    (Some(sig), Some(ts)) => (sig, ts),
-                    _ => return Ok(unauthorized_response),
-                };
-
-            let signature = signature.to_str().unwrap_or("");
-            let timestamp = timestamp.to_str().unwrap_or("");
+            let (signature, timestamp) = match (signature_header, timestamp_header) {
+                (Some(sig), Some(ts)) => {
+                    let sig_str = match sig.to_str() {
+                        Ok(s) => s.to_string(),
+                        Err(_) => return Ok(unauthorized_response),
+                    };
+                    let ts_str = match ts.to_str() {
+                        Ok(s) => s.to_string(),
+                        Err(_) => return Ok(unauthorized_response),
+                    };
+                    (sig_str, ts_str)
+                }
+                _ => return Ok(unauthorized_response),
+            };
 
             // Verify timestamp is within allowed age
             let ts = match timestamp.parse::<i64>() {
@@ -219,7 +257,9 @@ where
 
             // Reconstruct the request with the consumed body
             let new_body = Body::from(body_bytes);
-            let new_request = Request::from_parts(parts, new_body);
+            let mut new_request = Request::from_parts(parts, new_body);
+            // HMAC currently uses a single global shared secret, so all HMAC clients share one rate-limit bucket
+            new_request.extensions_mut().insert(ClientIdentity("hmac:global".to_string()));
 
             inner.call(new_request).await
         })
@@ -235,6 +275,7 @@ mod tests {
     use jsonrpsee::server::logger::Body;
     use sha2::Sha256;
     use std::{
+        convert::Infallible,
         future::Ready,
         task::{Context, Poll},
     };
@@ -244,23 +285,27 @@ mod tests {
     #[derive(Clone)]
     struct MockService;
 
-    impl tower::Service<Request<Body>> for MockService {
+    impl Service<Request<Body>> for MockService {
         type Response = Response<Body>;
-        type Error = std::convert::Infallible;
+        type Error = Infallible;
         type Future = Ready<Result<Self::Response, Self::Error>>;
 
-        fn poll_ready(&mut self, _: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
             Poll::Ready(Ok(()))
         }
 
-        fn call(&mut self, _: Request<Body>) -> Self::Future {
-            std::future::ready(Ok(Response::builder().status(200).body(Body::empty()).unwrap()))
+        fn call(&mut self, req: Request<Body>) -> Self::Future {
+            let mut res = Response::builder().status(200).body(Body::empty()).unwrap();
+            if let Some(identity) = req.extensions().get::<ClientIdentity>() {
+                res.extensions_mut().insert(identity.clone());
+            }
+            std::future::ready(Ok(res))
         }
     }
 
     #[tokio::test]
     async fn test_api_key_auth_valid_key() {
-        let layer = ApiKeyAuthLayer::new("test-key".to_string());
+        let layer = ApiKeyAuthLayer::new(vec!["test-key".to_string()]);
         let mut service = layer.layer(MockService);
         let body = r#"{"jsonrpc":"2.0","method":"getConfig","id":1}"#;
         let request = Request::builder()
@@ -271,11 +316,12 @@ mod tests {
 
         let response = service.ready().await.unwrap().call(request).await.unwrap();
         assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(response.extensions().get::<ClientIdentity>().unwrap().0, "apikey:test-key");
     }
 
     #[tokio::test]
     async fn test_api_key_auth_invalid_key() {
-        let layer = ApiKeyAuthLayer::new("test-key".to_string());
+        let layer = ApiKeyAuthLayer::new(vec!["test-key".to_string()]);
         let mut service = layer.layer(MockService);
         let body = r#"{"jsonrpc":"2.0","method":"getConfig","id":1}"#;
         let request = Request::builder()
@@ -290,7 +336,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_api_key_auth_missing_header() {
-        let layer = ApiKeyAuthLayer::new("test-key".to_string());
+        let layer = ApiKeyAuthLayer::new(vec!["test-key".to_string()]);
         let mut service = layer.layer(MockService);
         let body = r#"{"jsonrpc":"2.0","method":"getConfig","id":1}"#;
         let request = Request::builder().uri("/test").body(Body::from(body)).unwrap();
@@ -301,7 +347,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_api_key_auth_liveness_bypass() {
-        let layer = ApiKeyAuthLayer::new("test-key".to_string());
+        let layer = ApiKeyAuthLayer::new(vec!["test-key".to_string()]);
         let mut service = layer.layer(MockService);
         let liveness_body = r#"{"jsonrpc":"2.0","method":"liveness","params":[],"id":1}"#;
         let request = Request::builder()
@@ -343,6 +389,7 @@ mod tests {
 
         let response = service.ready().await.unwrap().call(request).await.unwrap();
         assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(response.extensions().get::<ClientIdentity>().unwrap().0, "hmac:global");
     }
 
     #[tokio::test]
@@ -369,6 +416,10 @@ mod tests {
 
         let response = service.ready().await.unwrap().call(request).await.unwrap();
         assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+        assert_eq!(
+            response.extensions().get::<RejectionReason>(),
+            Some(&RejectionReason::AuthFailure)
+        );
     }
 
     #[tokio::test]
@@ -383,6 +434,10 @@ mod tests {
 
         let response = service.ready().await.unwrap().call(request).await.unwrap();
         assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+        assert_eq!(
+            response.extensions().get::<RejectionReason>(),
+            Some(&RejectionReason::AuthFailure)
+        );
     }
 
     #[tokio::test]
@@ -414,6 +469,10 @@ mod tests {
 
         let response = service.ready().await.unwrap().call(request).await.unwrap();
         assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+        assert_eq!(
+            response.extensions().get::<RejectionReason>(),
+            Some(&RejectionReason::AuthFailure)
+        );
     }
 
     #[tokio::test]

--- a/crates/lib/src/rpc_server/auth.rs
+++ b/crates/lib/src/rpc_server/auth.rs
@@ -97,10 +97,8 @@ where
                 // Constant-time comparison prevents timing attacks
                 let mut matched = false;
                 for key in &api_keys {
-                    if provided_key.as_bytes().ct_eq(key.as_bytes()).into() {
-                        matched = true;
-                        break;
-                    }
+                    let is_match: bool = provided_key.as_bytes().ct_eq(key.as_bytes()).into();
+                    matched |= is_match;
                 }
 
                 if matched {

--- a/crates/lib/src/rpc_server/auth.rs
+++ b/crates/lib/src/rpc_server/auth.rs
@@ -10,8 +10,17 @@ use jsonrpsee::server::logger::Body;
 use sha2::Sha256;
 use subtle::ConstantTimeEq;
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct ClientIdentity(pub String);
+
+impl std::fmt::Debug for ClientIdentity {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self.0.split_once(':') {
+            Some((prefix, _)) => write!(f, "ClientIdentity({prefix}:***)"),
+            None => write!(f, "ClientIdentity(***)"),
+        }
+    }
+}
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum RejectionReason {

--- a/crates/lib/src/rpc_server/auth.rs
+++ b/crates/lib/src/rpc_server/auth.rs
@@ -104,16 +104,16 @@ where
             let provided_key = req.headers().get(X_API_KEY).cloned();
             if let Some(provided_key) = provided_key {
                 // Constant-time comparison prevents timing attacks
-                let mut matched = false;
-                for key in &api_keys {
+                let mut matched_index = None;
+                for (index, key) in api_keys.iter().enumerate() {
                     let is_match: bool = provided_key.as_bytes().ct_eq(key.as_bytes()).into();
-                    matched |= is_match;
+                    if is_match {
+                        matched_index = Some(index);
+                    }
                 }
 
-                if matched {
-                    if let Ok(key_str) = provided_key.to_str() {
-                        req.extensions_mut().insert(ClientIdentity(format!("apikey:{}", key_str)));
-                    }
+                if let Some(index) = matched_index {
+                    req.extensions_mut().insert(ClientIdentity(format!("apikey:{}", index)));
                     return inner.call(req).await;
                 }
             }
@@ -266,7 +266,9 @@ where
             let new_body = Body::from(body_bytes);
             let mut new_request = Request::from_parts(parts, new_body);
             // HMAC currently uses a single global shared secret, so all HMAC clients share one rate-limit bucket
-            new_request.extensions_mut().insert(ClientIdentity("hmac:global".to_string()));
+            if new_request.extensions().get::<ClientIdentity>().is_none() {
+                new_request.extensions_mut().insert(ClientIdentity("hmac:global".to_string()));
+            }
 
             inner.call(new_request).await
         })
@@ -323,7 +325,7 @@ mod tests {
 
         let response = service.ready().await.unwrap().call(request).await.unwrap();
         assert_eq!(response.status(), StatusCode::OK);
-        assert_eq!(response.extensions().get::<ClientIdentity>().unwrap().0, "apikey:test-key");
+        assert_eq!(response.extensions().get::<ClientIdentity>().unwrap().0, "apikey:0");
     }
 
     #[tokio::test]

--- a/crates/lib/src/rpc_server/auth.rs
+++ b/crates/lib/src/rpc_server/auth.rs
@@ -8,6 +8,7 @@ use hmac::{Hmac, KeyInit, Mac};
 use http::{Request, Response, StatusCode};
 use jsonrpsee::server::logger::Body;
 use sha2::Sha256;
+use std::{future::Future, pin::Pin};
 use subtle::ConstantTimeEq;
 
 #[derive(Clone, PartialEq, Eq)]
@@ -68,9 +69,7 @@ where
 {
     type Response = S::Response;
     type Error = S::Error;
-    type Future = std::pin::Pin<
-        Box<dyn std::future::Future<Output = Result<Self::Response, Self::Error>> + Send>,
-    >;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
 
     fn poll_ready(
         &mut self,
@@ -161,9 +160,7 @@ where
 {
     type Response = S::Response;
     type Error = S::Error;
-    type Future = std::pin::Pin<
-        Box<dyn std::future::Future<Output = Result<Self::Response, Self::Error>> + Send>,
-    >;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
 
     fn poll_ready(
         &mut self,
@@ -285,7 +282,7 @@ mod tests {
     use sha2::Sha256;
     use std::{
         convert::Infallible,
-        future::Ready,
+        future::{ready, Ready},
         task::{Context, Poll},
     };
     use tower::{Layer, Service, ServiceExt};
@@ -308,7 +305,7 @@ mod tests {
             if let Some(identity) = req.extensions().get::<ClientIdentity>() {
                 res.extensions_mut().insert(identity.clone());
             }
-            std::future::ready(Ok(res))
+            ready(Ok(res))
         }
     }
 

--- a/crates/lib/src/rpc_server/mod.rs
+++ b/crates/lib/src/rpc_server/mod.rs
@@ -4,6 +4,7 @@ pub mod method;
 pub mod middleware_utils;
 #[cfg(feature = "docs")]
 pub mod openapi;
+pub mod rate_limit;
 pub mod recaptcha;
 pub mod recaptcha_util;
 pub mod rpc;

--- a/crates/lib/src/rpc_server/rate_limit.rs
+++ b/crates/lib/src/rpc_server/rate_limit.rs
@@ -70,6 +70,7 @@ impl<S> Layer<S> for IdentityRateLimitLayer {
 pub struct IdentityRateLimitService<S> {
     inner: S,
     rate_limit: u64,
+    // Bounded by configured identities (API keys + hmac + unauthenticated), no eviction needed
     state: Arc<RwLock<HashMap<String, TokenBucket>>>,
 }
 

--- a/crates/lib/src/rpc_server/rate_limit.rs
+++ b/crates/lib/src/rpc_server/rate_limit.rs
@@ -1,0 +1,192 @@
+use crate::rpc_server::{
+    auth::{ClientIdentity, RejectionReason},
+    middleware_utils::build_response_with_graceful_error,
+};
+use http::{Request, Response, StatusCode};
+use jsonrpsee::server::logger::Body;
+use parking_lot::RwLock;
+use std::{
+    collections::HashMap,
+    sync::Arc,
+    task::{Context, Poll},
+    time::Instant,
+};
+use tower::{Layer, Service};
+
+const UNAUTHENTICATED_IDENTITY: &str = "unauthenticated";
+
+#[derive(Clone, Debug)]
+pub struct TokenBucket {
+    pub capacity: f64,
+    pub tokens: f64,
+    pub last_refill: Instant,
+    pub refill_rate: f64, // tokens per second
+}
+
+impl TokenBucket {
+    pub fn new(capacity: f64, refill_rate: f64) -> Self {
+        Self { capacity, tokens: capacity, last_refill: Instant::now(), refill_rate }
+    }
+
+    pub fn consume(&mut self, amount: f64) -> bool {
+        let now = Instant::now();
+        let elapsed = now.duration_since(self.last_refill).as_secs_f64();
+        self.tokens += elapsed * self.refill_rate;
+        if self.tokens > self.capacity {
+            self.tokens = self.capacity;
+        }
+        self.last_refill = now;
+
+        if self.tokens >= amount {
+            self.tokens -= amount;
+            true
+        } else {
+            false
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct IdentityRateLimitLayer {
+    rate_limit: u64,
+    state: Arc<RwLock<HashMap<String, TokenBucket>>>,
+}
+
+impl IdentityRateLimitLayer {
+    pub fn new(rate_limit: u64) -> Self {
+        Self { rate_limit, state: Arc::new(RwLock::new(HashMap::new())) }
+    }
+}
+
+impl<S> Layer<S> for IdentityRateLimitLayer {
+    type Service = IdentityRateLimitService<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        IdentityRateLimitService { inner, rate_limit: self.rate_limit, state: self.state.clone() }
+    }
+}
+
+#[derive(Clone)]
+pub struct IdentityRateLimitService<S> {
+    inner: S,
+    rate_limit: u64,
+    state: Arc<RwLock<HashMap<String, TokenBucket>>>,
+}
+
+impl<S> Service<Request<Body>> for IdentityRateLimitService<S>
+where
+    S: Service<Request<Body>, Response = Response<Body>> + Clone + Send + 'static,
+    S::Future: Send + 'static,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = std::pin::Pin<
+        Box<dyn std::future::Future<Output = Result<Self::Response, Self::Error>> + Send>,
+    >;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, request: Request<Body>) -> Self::Future {
+        // rate_limit=0 disables per-identity limiting
+        if self.rate_limit == 0 {
+            return Box::pin(self.inner.call(request));
+        }
+
+        let identity = match request.extensions().get::<ClientIdentity>() {
+            Some(id) => id.0.clone(),
+            None => UNAUTHENTICATED_IDENTITY.to_string(),
+        };
+
+        let allowed = {
+            let mut map = self.state.write();
+            let bucket = map.entry(identity).or_insert_with(|| {
+                TokenBucket::new(self.rate_limit as f64, self.rate_limit as f64)
+            });
+            bucket.consume(1.0)
+        };
+
+        if !allowed {
+            let mut response =
+                build_response_with_graceful_error(None, StatusCode::TOO_MANY_REQUESTS, "");
+            response.extensions_mut().insert(RejectionReason::RateLimit);
+            return Box::pin(async move { Ok(response) });
+        }
+
+        let mut inner = self.inner.clone();
+        Box::pin(async move { inner.call(request).await })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use http::StatusCode;
+    use std::future::Ready;
+    use tower::{Service, ServiceExt};
+
+    #[derive(Clone)]
+    struct MockService;
+
+    impl Service<Request<Body>> for MockService {
+        type Response = Response<Body>;
+        type Error = std::convert::Infallible;
+        type Future = Ready<Result<Self::Response, Self::Error>>;
+
+        fn poll_ready(&mut self, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn call(&mut self, _req: Request<Body>) -> Self::Future {
+            std::future::ready(Ok(Response::new(Body::empty())))
+        }
+    }
+
+    #[tokio::test]
+    async fn test_identity_rate_limit_exceed_quota() {
+        let layer = IdentityRateLimitLayer::new(2); // 2 requests per second
+        let mut service = layer.layer(MockService);
+
+        let mut req1 = Request::builder().body(Body::empty()).unwrap();
+        req1.extensions_mut().insert(ClientIdentity("clientA".to_string()));
+        let res1 = service.ready().await.unwrap().call(req1).await.unwrap();
+        assert_eq!(res1.status(), StatusCode::OK);
+
+        let mut req2 = Request::builder().body(Body::empty()).unwrap();
+        req2.extensions_mut().insert(ClientIdentity("clientA".to_string()));
+        let res2 = service.ready().await.unwrap().call(req2).await.unwrap();
+        assert_eq!(res2.status(), StatusCode::OK);
+
+        // Third request should be rate limited
+        let mut req3 = Request::builder().body(Body::empty()).unwrap();
+        req3.extensions_mut().insert(ClientIdentity("clientA".to_string()));
+        let res3 = service.ready().await.unwrap().call(req3).await.unwrap();
+        assert_eq!(res3.status(), StatusCode::TOO_MANY_REQUESTS);
+        assert_eq!(res3.extensions().get::<RejectionReason>(), Some(&RejectionReason::RateLimit));
+    }
+
+    #[tokio::test]
+    async fn test_independent_identities() {
+        let layer = IdentityRateLimitLayer::new(1); // 1 request per second
+        let mut service = layer.layer(MockService);
+
+        // ClientA uses their 1 quota
+        let mut req1 = Request::builder().body(Body::empty()).unwrap();
+        req1.extensions_mut().insert(ClientIdentity("clientA".to_string()));
+        let res1 = service.ready().await.unwrap().call(req1).await.unwrap();
+        assert_eq!(res1.status(), StatusCode::OK);
+
+        // ClientA is now rate limited
+        let mut req2 = Request::builder().body(Body::empty()).unwrap();
+        req2.extensions_mut().insert(ClientIdentity("clientA".to_string()));
+        let res2 = service.ready().await.unwrap().call(req2).await.unwrap();
+        assert_eq!(res2.status(), StatusCode::TOO_MANY_REQUESTS);
+
+        // ClientB has their own independent quota
+        let mut req3 = Request::builder().body(Body::empty()).unwrap();
+        req3.extensions_mut().insert(ClientIdentity("clientB".to_string()));
+        let res3 = service.ready().await.unwrap().call(req3).await.unwrap();
+        assert_eq!(res3.status(), StatusCode::OK);
+    }
+}

--- a/crates/lib/src/rpc_server/rate_limit.rs
+++ b/crates/lib/src/rpc_server/rate_limit.rs
@@ -103,6 +103,8 @@ where
 
         let allowed = {
             let mut map = self.state.write();
+            // Some(0) creates a zero-capacity bucket; consume() always returns false,
+            // blocking all requests — validator warns operators about this case.
             let bucket =
                 map.entry(identity).or_insert_with(|| TokenBucket::new(limit as f64, limit as f64));
             bucket.consume(1.0)

--- a/crates/lib/src/rpc_server/rate_limit.rs
+++ b/crates/lib/src/rpc_server/rate_limit.rs
@@ -48,12 +48,12 @@ impl TokenBucket {
 
 #[derive(Clone)]
 pub struct IdentityRateLimitLayer {
-    rate_limit: u64,
+    rate_limit: Option<u64>,
     state: Arc<RwLock<HashMap<String, TokenBucket>>>,
 }
 
 impl IdentityRateLimitLayer {
-    pub fn new(rate_limit: u64) -> Self {
+    pub fn new(rate_limit: Option<u64>) -> Self {
         Self { rate_limit, state: Arc::new(RwLock::new(HashMap::new())) }
     }
 }
@@ -69,7 +69,7 @@ impl<S> Layer<S> for IdentityRateLimitLayer {
 #[derive(Clone)]
 pub struct IdentityRateLimitService<S> {
     inner: S,
-    rate_limit: u64,
+    rate_limit: Option<u64>,
     // Bounded by configured identities (API keys + hmac + unauthenticated), no eviction needed
     state: Arc<RwLock<HashMap<String, TokenBucket>>>,
 }
@@ -90,10 +90,11 @@ where
     }
 
     fn call(&mut self, request: Request<Body>) -> Self::Future {
-        // rate_limit=0 disables per-identity limiting
-        if self.rate_limit == 0 {
-            return Box::pin(self.inner.call(request));
-        }
+        // rate_limit=None disables per-identity limiting
+        let limit = match self.rate_limit {
+            Some(l) => l,
+            None => return Box::pin(self.inner.call(request)),
+        };
 
         let identity = match request.extensions().get::<ClientIdentity>() {
             Some(id) => id.0.clone(),
@@ -102,9 +103,8 @@ where
 
         let allowed = {
             let mut map = self.state.write();
-            let bucket = map.entry(identity).or_insert_with(|| {
-                TokenBucket::new(self.rate_limit as f64, self.rate_limit as f64)
-            });
+            let bucket =
+                map.entry(identity).or_insert_with(|| TokenBucket::new(limit as f64, limit as f64));
             bucket.consume(1.0)
         };
 
@@ -146,7 +146,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_identity_rate_limit_exceed_quota() {
-        let layer = IdentityRateLimitLayer::new(2); // 2 requests per second
+        let layer = IdentityRateLimitLayer::new(Some(2)); // 2 requests per second
         let mut service = layer.layer(MockService);
 
         let mut req1 = Request::builder().body(Body::empty()).unwrap();
@@ -169,7 +169,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_independent_identities() {
-        let layer = IdentityRateLimitLayer::new(1); // 1 request per second
+        let layer = IdentityRateLimitLayer::new(Some(1)); // 1 request per second
         let mut service = layer.layer(MockService);
 
         // ClientA uses their 1 quota

--- a/crates/lib/src/rpc_server/rate_limit.rs
+++ b/crates/lib/src/rpc_server/rate_limit.rs
@@ -7,6 +7,8 @@ use jsonrpsee::server::logger::Body;
 use parking_lot::RwLock;
 use std::{
     collections::HashMap,
+    future::Future,
+    pin::Pin,
     sync::Arc,
     task::{Context, Poll},
     time::Instant,
@@ -62,13 +64,19 @@ impl<S> Layer<S> for IdentityRateLimitLayer {
     type Service = IdentityRateLimitService<S>;
 
     fn layer(&self, inner: S) -> Self::Service {
-        IdentityRateLimitService { inner, rate_limit: self.rate_limit, state: self.state.clone() }
+        IdentityRateLimitService {
+            inner,
+            inner_ready: None,
+            rate_limit: self.rate_limit,
+            state: self.state.clone(),
+        }
     }
 }
 
 #[derive(Clone)]
 pub struct IdentityRateLimitService<S> {
     inner: S,
+    inner_ready: Option<S>,
     rate_limit: Option<u64>,
     // Bounded by configured identities (API keys + hmac + unauthenticated), no eviction needed
     state: Arc<RwLock<HashMap<String, TokenBucket>>>,
@@ -81,19 +89,27 @@ where
 {
     type Response = S::Response;
     type Error = S::Error;
-    type Future = std::pin::Pin<
-        Box<dyn std::future::Future<Output = Result<Self::Response, Self::Error>> + Send>,
-    >;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
 
     fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
-        self.inner.poll_ready(cx)
+        match self.inner.poll_ready(cx) {
+            Poll::Ready(Ok(())) => {
+                self.inner_ready = Some(self.inner.clone());
+                Poll::Ready(Ok(()))
+            }
+            other => other,
+        }
     }
 
     fn call(&mut self, request: Request<Body>) -> Self::Future {
+        // Take the readied service, falling back to cloning `inner` if `poll_ready` was bypassed.
+        // Tower contract expects `poll_ready` to be called first.
+        let mut inner = self.inner_ready.take().unwrap_or_else(|| self.inner.clone());
+
         // rate_limit=None disables per-identity limiting
         let limit = match self.rate_limit {
             Some(l) => l,
-            None => return Box::pin(self.inner.call(request)),
+            None => return Box::pin(inner.call(request)),
         };
 
         let identity = match request.extensions().get::<ClientIdentity>() {
@@ -117,7 +133,6 @@ where
             return Box::pin(async move { Ok(response) });
         }
 
-        let mut inner = self.inner.clone();
         Box::pin(async move { inner.call(request).await })
     }
 }
@@ -126,7 +141,7 @@ where
 mod tests {
     use super::*;
     use http::StatusCode;
-    use std::future::Ready;
+    use std::future::{ready, Ready};
     use tower::{Service, ServiceExt};
 
     #[derive(Clone)]
@@ -142,7 +157,7 @@ mod tests {
         }
 
         fn call(&mut self, _req: Request<Body>) -> Self::Future {
-            std::future::ready(Ok(Response::new(Body::empty())))
+            ready(Ok(Response::new(Body::empty())))
         }
     }
 

--- a/crates/lib/src/rpc_server/server.rs
+++ b/crates/lib/src/rpc_server/server.rs
@@ -430,14 +430,14 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_identity_rate_limit_zero_bypasses_limiter() {
+    async fn test_identity_rate_limit_none_disables_limiter() {
         let listener = TcpListener::bind("127.0.0.1:0").unwrap();
         let port = listener.local_addr().unwrap().port();
         drop(listener);
 
         let auth_config =
             AuthConfigBuilder::new().with_api_keys(vec!["key-zero".to_string()]).build();
-        // Set limit to 0 (disabled)
+        // rate_limit = None disables the limiter entirely
         let kora_config =
             KoraConfigBuilder::new().with_rate_limit(None).with_auth(auth_config).build();
         let _m = ConfigMockBuilder::new().with_kora(kora_config).build_and_setup();

--- a/crates/lib/src/rpc_server/server.rs
+++ b/crates/lib/src/rpc_server/server.rs
@@ -456,6 +456,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial]
     async fn test_empty_kora_api_key_disables_auth() {
         let listener = TcpListener::bind("127.0.0.1:0").unwrap();
         let port = listener.local_addr().unwrap().port();

--- a/crates/lib/src/rpc_server/server.rs
+++ b/crates/lib/src/rpc_server/server.rs
@@ -32,7 +32,7 @@ use jsonrpsee::{
 };
 use std::{net::SocketAddr, time::Duration};
 use tokio::task::JoinHandle;
-use tower_http::cors::CorsLayer;
+use tower_http::cors::{AllowOrigin, CorsLayer};
 
 pub struct ServerHandles {
     pub rpc_handle: ServerHandle,
@@ -114,9 +114,12 @@ fn get_value_by_priority(env_var: &str, config_value: Option<String>) -> Option<
     AuthConfig::resolve_secret(env_var, config_value.as_deref())
 }
 
-fn build_allow_origin(origins: &[String]) -> tower_http::cors::AllowOrigin {
+fn build_allow_origin(origins: &[String]) -> AllowOrigin {
     if origins.iter().any(|o| o == "*") {
-        tower_http::cors::AllowOrigin::any()
+        if origins.len() > 1 {
+            log::warn!("CORS allow origins contains '*' alongside specific origins. The specific origins are redundant and will be silently ignored.");
+        }
+        AllowOrigin::any()
     } else {
         let parsed_origins: Vec<_> = origins
             .iter()
@@ -133,7 +136,7 @@ fn build_allow_origin(origins: &[String]) -> tower_http::cors::AllowOrigin {
             );
         }
 
-        tower_http::cors::AllowOrigin::list(parsed_origins)
+        AllowOrigin::list(parsed_origins)
     }
 }
 

--- a/crates/lib/src/rpc_server/server.rs
+++ b/crates/lib/src/rpc_server/server.rs
@@ -10,8 +10,13 @@ use crate::{
         recaptcha_util::RecaptchaConfig,
         rpc::KoraRpc,
     },
-    usage_limit::UsageTracker,
 };
+
+#[cfg(not(test))]
+use crate::usage_limit::UsageTracker;
+
+#[cfg(test)]
+use crate::tests::usage_limiter_mock::MockUsageTracker as UsageTracker;
 
 use crate::state::drain_background_tasks;
 
@@ -109,6 +114,29 @@ fn get_value_by_priority(env_var: &str, config_value: Option<String>) -> Option<
     AuthConfig::resolve_secret(env_var, config_value.as_deref())
 }
 
+fn build_allow_origin(origins: &[String]) -> tower_http::cors::AllowOrigin {
+    if origins.iter().any(|o| o == "*") {
+        tower_http::cors::AllowOrigin::any()
+    } else {
+        let parsed_origins: Vec<_> = origins
+            .iter()
+            .filter_map(|o| {
+                o.parse::<http::HeaderValue>()
+                    .map_err(|e| log::warn!("Invalid CORS origin '{}': {}", o, e))
+                    .ok()
+            })
+            .collect();
+
+        if parsed_origins.is_empty() {
+            log::warn!(
+                "No valid CORS origins configured. All cross-origin requests will be blocked."
+            );
+        }
+
+        tower_http::cors::AllowOrigin::list(parsed_origins)
+    }
+}
+
 pub async fn run_rpc_server(rpc: KoraRpc, port: u16) -> Result<ServerHandles, anyhow::Error> {
     let addr = SocketAddr::from(([0, 0, 0, 0], port));
     log::info!("RPC server started on {addr}, port {port}");
@@ -121,28 +149,7 @@ pub async fn run_rpc_server(rpc: KoraRpc, port: u16) -> Result<ServerHandles, an
 
     let config = get_config()?;
 
-    let allow_origins = if config.kora.cors_allow_origins.iter().any(|o| o == "*") {
-        tower_http::cors::AllowOrigin::any()
-    } else {
-        let origins = config
-            .kora
-            .cors_allow_origins
-            .iter()
-            .filter_map(|o| {
-                o.parse::<http::HeaderValue>()
-                    .map_err(|e| log::warn!("Invalid CORS origin '{}': {}", o, e))
-                    .ok()
-            })
-            .collect::<Vec<_>>();
-
-        if origins.is_empty() {
-            log::warn!(
-                "No valid CORS origins configured. All cross-origin requests will be blocked."
-            );
-        }
-
-        tower_http::cors::AllowOrigin::list(origins)
-    };
+    let allow_origins = build_allow_origin(&config.kora.cors_allow_origins);
 
     // Build middleware stack with tracing and CORS
     let cors = CorsLayer::new()
@@ -187,6 +194,8 @@ pub async fn run_rpc_server(rpc: KoraRpc, port: u16) -> Result<ServerHandles, an
         .option_layer(metrics_layers.as_ref().and_then(|layers| layers.http_metrics_layer.clone()))
         // cors
         .layer(cors)
+        // Global pre-auth rate limit (using IdentityRateLimitLayer, which uses 'unauthenticated' identity before auth layers)
+        .layer(IdentityRateLimitLayer::new(config.kora.global_rate_limit))
         // Method validation layer - to fail fast
         .layer(MethodValidationLayer::new(allowed_methods.clone()))
         // Add authentication layer for API key if configured
@@ -363,7 +372,7 @@ mod tests {
             .build();
         // Set limit to 1 request per second
         let kora_config =
-            KoraConfigBuilder::new().with_rate_limit(1).with_auth(auth_config).build();
+            KoraConfigBuilder::new().with_rate_limit(Some(1)).with_auth(auth_config).build();
         let _m = ConfigMockBuilder::new().with_kora(kora_config).build_and_setup();
         let _ = setup_or_get_test_signer();
 
@@ -430,7 +439,7 @@ mod tests {
             AuthConfigBuilder::new().with_api_keys(vec!["key-zero".to_string()]).build();
         // Set limit to 0 (disabled)
         let kora_config =
-            KoraConfigBuilder::new().with_rate_limit(0).with_auth(auth_config).build();
+            KoraConfigBuilder::new().with_rate_limit(None).with_auth(auth_config).build();
         let _m = ConfigMockBuilder::new().with_kora(kora_config).build_and_setup();
         let _ = setup_or_get_test_signer();
 
@@ -453,6 +462,45 @@ mod tests {
                 .expect("Failed to send request");
             assert_eq!(res.status(), reqwest::StatusCode::OK);
         }
+    }
+
+    #[tokio::test]
+    async fn test_global_rate_limit() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        drop(listener);
+
+        // Global rate limit: 1 per second
+        let kora_config = KoraConfigBuilder::new().with_global_rate_limit(Some(1)).build();
+        let _m = ConfigMockBuilder::new().with_kora(kora_config).build_and_setup();
+        let _ = setup_or_get_test_signer();
+
+        let rpc_client = RpcMockBuilder::new().build();
+        let _handles =
+            run_rpc_server(KoraRpc::new(rpc_client), port).await.expect("Failed to start server");
+
+        let client = Client::new();
+        let url = format!("http://127.0.0.1:{}", port);
+
+        // Request 1: Should pass
+        let res1 = client
+            .post(&url)
+            .header("content-type", "application/json")
+            .body(r#"{"jsonrpc":"2.0","method":"getConfig","params":[],"id":1}"#)
+            .send()
+            .await
+            .expect("Failed to send request");
+        assert_eq!(res1.status(), reqwest::StatusCode::OK);
+
+        // Request 2: Immediately after, should be throttled by global limiter
+        let res2 = client
+            .post(&url)
+            .header("content-type", "application/json")
+            .body(r#"{"jsonrpc":"2.0","method":"getConfig","params":[],"id":2}"#)
+            .send()
+            .await
+            .expect("Failed to send request");
+        assert_eq!(res2.status(), reqwest::StatusCode::TOO_MANY_REQUESTS);
     }
 
     #[tokio::test]

--- a/crates/lib/src/rpc_server/server.rs
+++ b/crates/lib/src/rpc_server/server.rs
@@ -134,6 +134,13 @@ pub async fn run_rpc_server(rpc: KoraRpc, port: u16) -> Result<ServerHandles, an
                     .ok()
             })
             .collect::<Vec<_>>();
+
+        if origins.is_empty() {
+            log::warn!(
+                "No valid CORS origins configured. All cross-origin requests will be blocked."
+            );
+        }
+
         tower_http::cors::AllowOrigin::list(origins)
     };
 
@@ -446,6 +453,61 @@ mod tests {
                 .expect("Failed to send request");
             assert_eq!(res.status(), reqwest::StatusCode::OK);
         }
+    }
+
+    #[tokio::test]
+    async fn test_empty_kora_api_key_disables_auth() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        drop(listener);
+
+        // No api_keys in config
+        let auth_config = AuthConfigBuilder::new().build();
+        let kora_config = KoraConfigBuilder::new().with_auth(auth_config).build();
+        let _m = ConfigMockBuilder::new().with_kora(kora_config).build_and_setup();
+        let _ = setup_or_get_test_signer();
+
+        let rpc_client = RpcMockBuilder::new().build();
+
+        // Set env var to empty string
+        env::set_var("KORA_API_KEY", "");
+
+        let _handles =
+            run_rpc_server(KoraRpc::new(rpc_client), port).await.expect("Failed to start server");
+
+        let client = Client::new();
+        let url = format!("http://127.0.0.1:{}", port);
+
+        // Request without X-API-Key should succeed (auth disabled)
+        let res = client
+            .post(&url)
+            .header("content-type", "application/json")
+            .body(r#"{"jsonrpc":"2.0","method":"getConfig","params":[],"id":1}"#)
+            .send()
+            .await
+            .expect("Failed to send request");
+
+        assert_eq!(res.status(), reqwest::StatusCode::OK);
+
+        env::remove_var("KORA_API_KEY");
+    }
+
+    #[tokio::test]
+    async fn test_empty_cors_origins_does_not_panic() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        drop(listener);
+
+        // cors_allow_origins = []
+        let kora_config = KoraConfigBuilder::new().with_cors_allow_origins(vec![]).build();
+        let _m = ConfigMockBuilder::new().with_kora(kora_config).build_and_setup();
+        let _ = setup_or_get_test_signer();
+
+        let rpc_client = RpcMockBuilder::new().build();
+
+        // This should not panic and should start successfully
+        let result = run_rpc_server(KoraRpc::new(rpc_client), port).await;
+        assert!(result.is_ok(), "Server failed to start with empty cors_allow_origins");
     }
 
     #[test]

--- a/crates/lib/src/rpc_server/server.rs
+++ b/crates/lib/src/rpc_server/server.rs
@@ -493,6 +493,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[serial_test::serial]
     async fn test_empty_api_key_string_disables_auth() {
         let listener = TcpListener::bind("127.0.0.1:0").unwrap();
         let port = listener.local_addr().unwrap().port();
@@ -506,7 +507,7 @@ api_key = ""
 
         // Assertions for config parsing
         assert_eq!(auth_config.api_keys, None);
-        assert!(!auth_config.has_auth());
+        assert!(!auth_config.has_resolved_auth());
 
         // We need to set rate_limit explicitly for the mock builder if we want it to be 0 or bypass
         // but we'll just pass the parsed KoraConfig directly.
@@ -532,6 +533,61 @@ api_key = ""
             .expect("Failed to send request");
 
         assert_eq!(res.status(), reqwest::StatusCode::OK);
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn test_api_keys_env_var_takes_precedence_over_toml() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        drop(listener);
+
+        // Parse TOML with some api_keys
+        let toml_str = r#"
+api_keys = ["toml-key-1", "toml-key-2"]
+        "#;
+        let auth_config: crate::config::AuthConfig = toml::from_str(toml_str).unwrap();
+
+        let kora_config = KoraConfigBuilder::new().with_auth(auth_config).build();
+        let _m = ConfigMockBuilder::new().with_kora(kora_config).build_and_setup();
+        let _ = setup_or_get_test_signer();
+
+        let rpc_client = RpcMockBuilder::new().build();
+
+        // Set KORA_API_KEY env var
+        env::set_var("KORA_API_KEY", "env-key");
+
+        let _handles =
+            run_rpc_server(KoraRpc::new(rpc_client), port).await.expect("Failed to start server");
+
+        let client = Client::new();
+        let url = format!("http://127.0.0.1:{}", port);
+
+        // The request should only succeed with "env-key"
+        let res = client
+            .post(&url)
+            .header(X_API_KEY, "env-key")
+            .header("content-type", "application/json")
+            .body(r#"{"jsonrpc":"2.0","method":"getConfig","params":[],"id":1}"#)
+            .send()
+            .await
+            .expect("Failed to send request");
+
+        assert_eq!(res.status(), reqwest::StatusCode::OK);
+
+        // The request with "toml-key-1" should be rejected
+        let res_rejected = client
+            .post(&url)
+            .header(X_API_KEY, "toml-key-1")
+            .header("content-type", "application/json")
+            .body(r#"{"jsonrpc":"2.0","method":"getConfig","params":[],"id":1}"#)
+            .send()
+            .await
+            .expect("Failed to send request");
+
+        assert_eq!(res_rejected.status(), reqwest::StatusCode::UNAUTHORIZED);
+
+        env::remove_var("KORA_API_KEY");
     }
 
     #[tokio::test]

--- a/crates/lib/src/rpc_server/server.rs
+++ b/crates/lib/src/rpc_server/server.rs
@@ -493,6 +493,48 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_empty_api_key_string_disables_auth() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        drop(listener);
+
+        // Parse TOML with empty api_key string
+        let toml_str = r#"
+api_key = ""
+        "#;
+        let auth_config: crate::config::AuthConfig = toml::from_str(toml_str).unwrap();
+
+        // Assertions for config parsing
+        assert_eq!(auth_config.api_keys, None);
+        assert!(!auth_config.has_auth());
+
+        // We need to set rate_limit explicitly for the mock builder if we want it to be 0 or bypass
+        // but we'll just pass the parsed KoraConfig directly.
+        let kora_config = KoraConfigBuilder::new().with_auth(auth_config).build();
+        let _m = ConfigMockBuilder::new().with_kora(kora_config).build_and_setup();
+        let _ = setup_or_get_test_signer();
+
+        let rpc_client = RpcMockBuilder::new().build();
+
+        let _handles =
+            run_rpc_server(KoraRpc::new(rpc_client), port).await.expect("Failed to start server");
+
+        let client = Client::new();
+        let url = format!("http://127.0.0.1:{}", port);
+
+        // Request without X-API-Key should succeed (auth disabled)
+        let res = client
+            .post(&url)
+            .header("content-type", "application/json")
+            .body(r#"{"jsonrpc":"2.0","method":"getConfig","params":[],"id":1}"#)
+            .send()
+            .await
+            .expect("Failed to send request");
+
+        assert_eq!(res.status(), reqwest::StatusCode::OK);
+    }
+
+    #[tokio::test]
     async fn test_empty_cors_origins_does_not_panic() {
         let listener = TcpListener::bind("127.0.0.1:0").unwrap();
         let port = listener.local_addr().unwrap().port();

--- a/crates/lib/src/rpc_server/server.rs
+++ b/crates/lib/src/rpc_server/server.rs
@@ -5,6 +5,7 @@ use crate::{
     rpc_server::{
         auth::{ApiKeyAuthLayer, HmacAuthLayer},
         middleware_utils::MethodValidationLayer,
+        rate_limit::IdentityRateLimitLayer,
         recaptcha::RecaptchaLayer,
         recaptcha_util::RecaptchaConfig,
         rpc::KoraRpc,
@@ -26,7 +27,6 @@ use jsonrpsee::{
 };
 use std::{net::SocketAddr, time::Duration};
 use tokio::task::JoinHandle;
-use tower::limit::RateLimitLayer;
 use tower_http::cors::CorsLayer;
 
 pub struct ServerHandles {
@@ -119,9 +119,27 @@ pub async fn run_rpc_server(rpc: KoraRpc, port: u16) -> Result<ServerHandles, an
         return Err(anyhow::anyhow!("Usage limiter initialization failed: {e}"));
     }
 
+    let config = get_config()?;
+
+    let allow_origins = if config.kora.cors_allow_origins.iter().any(|o| o == "*") {
+        tower_http::cors::AllowOrigin::any()
+    } else {
+        let origins = config
+            .kora
+            .cors_allow_origins
+            .iter()
+            .filter_map(|o| {
+                o.parse::<http::HeaderValue>()
+                    .map_err(|e| log::warn!("Invalid CORS origin '{}': {}", o, e))
+                    .ok()
+            })
+            .collect::<Vec<_>>();
+        tower_http::cors::AllowOrigin::list(origins)
+    };
+
     // Build middleware stack with tracing and CORS
     let cors = CorsLayer::new()
-        .allow_origin(tower_http::cors::Any)
+        .allow_origin(allow_origins)
         .allow_methods([Method::POST, Method::GET])
         .allow_headers([
             header::CONTENT_TYPE,
@@ -131,8 +149,6 @@ pub async fn run_rpc_server(rpc: KoraRpc, port: u16) -> Result<ServerHandles, an
             header::HeaderName::from_static(X_TIMESTAMP),
         ])
         .max_age(Duration::from_secs(3600));
-
-    let config = get_config()?;
 
     // Get the RPC client from KoraRpc to pass to metrics initialization
     let rpc_client = rpc.get_rpc_client().clone();
@@ -151,29 +167,30 @@ pub async fn run_rpc_server(rpc: KoraRpc, port: u16) -> Result<ServerHandles, an
         )
     });
 
+    let api_keys_config = config.kora.auth.resolved_api_keys();
+
     let middleware = tower::ServiceBuilder::new()
         // Add metrics handler first (before other layers) so it can intercept /metrics
         .layer(ProxyGetRequestLayer::new("/liveness", "liveness")?)
-        .layer(RateLimitLayer::new(config.kora.rate_limit, Duration::from_secs(1)))
         // Add metrics handler layer for Prometheus metrics
         .option_layer(
             metrics_layers.as_ref().and_then(|layers| layers.metrics_handler_layer.clone()),
         )
+        // Add metrics collection layer
+        .option_layer(metrics_layers.as_ref().and_then(|layers| layers.http_metrics_layer.clone()))
+        // cors
         .layer(cors)
         // Method validation layer - to fail fast
         .layer(MethodValidationLayer::new(allowed_methods.clone()))
-        // Add metrics collection layer
-        .option_layer(metrics_layers.as_ref().and_then(|layers| layers.http_metrics_layer.clone()))
         // Add authentication layer for API key if configured
-        .option_layer(
-            get_value_by_priority("KORA_API_KEY", config.kora.auth.api_key.clone())
-                .map(ApiKeyAuthLayer::new),
-        )
+        .option_layer(api_keys_config.map(ApiKeyAuthLayer::new))
         // Add authentication layer for HMAC if configured
         .option_layer(
             get_value_by_priority("KORA_HMAC_SECRET", config.kora.auth.hmac_secret.clone())
                 .map(|secret| HmacAuthLayer::new(secret, config.kora.auth.max_timestamp_age)),
         )
+        // Identity-aware rate limiting
+        .layer(IdentityRateLimitLayer::new(config.kora.rate_limit))
         // Add reCAPTCHA verification layer if configured
         .option_layer(recaptcha_config.map(RecaptchaLayer::new));
 
@@ -318,13 +335,118 @@ mod tests {
     use super::*;
     use crate::{
         config::EnabledMethods,
+        constant::X_API_KEY,
         tests::{
             common::setup_or_get_test_signer,
-            config_mock::{ConfigMockBuilder, KoraConfigBuilder},
+            config_mock::{AuthConfigBuilder, ConfigMockBuilder, KoraConfigBuilder},
             rpc_mock::RpcMockBuilder,
         },
     };
-    use std::env;
+    use reqwest::Client;
+    use std::{env, net::TcpListener, time::Instant};
+
+    #[tokio::test]
+    async fn test_identity_rate_limit_behaviors() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        drop(listener);
+
+        let auth_config = AuthConfigBuilder::new()
+            .with_api_keys(vec!["key-a".to_string(), "key-b".to_string()])
+            .build();
+        // Set limit to 1 request per second
+        let kora_config =
+            KoraConfigBuilder::new().with_rate_limit(1).with_auth(auth_config).build();
+        let _m = ConfigMockBuilder::new().with_kora(kora_config).build_and_setup();
+        let _ = setup_or_get_test_signer();
+
+        let rpc_client = RpcMockBuilder::new().build();
+        let _handles =
+            run_rpc_server(KoraRpc::new(rpc_client), port).await.expect("Failed to start server");
+
+        let client = Client::new();
+        let url = format!("http://127.0.0.1:{}", port);
+
+        // --- Test 1: Independent identities don't throttle each other ---
+
+        // Request 1: Valid key-a
+        let res1 = client
+            .post(&url)
+            .header(X_API_KEY, "key-a")
+            .header("content-type", "application/json")
+            .body(r#"{"jsonrpc":"2.0","method":"getConfig","params":[],"id":1}"#)
+            .send()
+            .await
+            .expect("Failed to send request");
+        assert_eq!(res1.status(), reqwest::StatusCode::OK);
+
+        let start = Instant::now();
+
+        // Request 2: Different valid key-b
+        let res2 = client
+            .post(&url)
+            .header(X_API_KEY, "key-b")
+            .header("content-type", "application/json")
+            .body(r#"{"jsonrpc":"2.0","method":"getConfig","params":[],"id":2}"#)
+            .send()
+            .await
+            .expect("Failed to send request");
+
+        // Identity rate limiter uses separate buckets; key-b does NOT wait for key-a's usage
+        assert!(
+            start.elapsed().as_millis() < 200,
+            "Expected no throttling delay for independent identity"
+        );
+        assert_eq!(res2.status(), reqwest::StatusCode::OK);
+
+        // --- Test 2: Same identity is throttled correctly ---
+
+        // Request 3: key-a AGAIN, should be rate limited immediately (HTTP 429)
+        let res3 = client
+            .post(&url)
+            .header(X_API_KEY, "key-a")
+            .header("content-type", "application/json")
+            .body(r#"{"jsonrpc":"2.0","method":"getConfig","params":[],"id":3}"#)
+            .send()
+            .await
+            .expect("Failed to send request");
+        assert_eq!(res3.status(), reqwest::StatusCode::TOO_MANY_REQUESTS);
+    }
+
+    #[tokio::test]
+    async fn test_identity_rate_limit_zero_bypasses_limiter() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        drop(listener);
+
+        let auth_config =
+            AuthConfigBuilder::new().with_api_keys(vec!["key-zero".to_string()]).build();
+        // Set limit to 0 (disabled)
+        let kora_config =
+            KoraConfigBuilder::new().with_rate_limit(0).with_auth(auth_config).build();
+        let _m = ConfigMockBuilder::new().with_kora(kora_config).build_and_setup();
+        let _ = setup_or_get_test_signer();
+
+        let rpc_client = RpcMockBuilder::new().build();
+        let _handles =
+            run_rpc_server(KoraRpc::new(rpc_client), port).await.expect("Failed to start server");
+
+        let client = Client::new();
+        let url = format!("http://127.0.0.1:{}", port);
+
+        // Send 10 rapid requests
+        for i in 1..=10 {
+            let res = client
+                .post(&url)
+                .header(X_API_KEY, "key-zero")
+                .header("content-type", "application/json")
+                .body(format!(r#"{{"jsonrpc":"2.0","method":"getConfig","params":[],"id":{}}}"#, i))
+                .send()
+                .await
+                .expect("Failed to send request");
+            assert_eq!(res.status(), reqwest::StatusCode::OK);
+        }
+    }
 
     #[test]
     fn test_get_value_by_priority_env_var_takes_precedence() {

--- a/crates/lib/src/tests/config_mock.rs
+++ b/crates/lib/src/tests/config_mock.rs
@@ -441,6 +441,11 @@ impl KoraConfigBuilder {
         self.config.cache = cache;
         self
     }
+
+    pub fn with_cors_allow_origins(mut self, origins: Vec<String>) -> Self {
+        self.config.cors_allow_origins = origins;
+        self
+    }
 }
 
 pub struct CacheConfigBuilder {

--- a/crates/lib/src/tests/config_mock.rs
+++ b/crates/lib/src/tests/config_mock.rs
@@ -103,6 +103,7 @@ impl ConfigMockBuilder {
                 },
                 kora: KoraConfig {
                     rate_limit: 100,
+                    cors_allow_origins: vec!["*".to_string()],
                     max_request_body_size: DEFAULT_MAX_REQUEST_BODY_SIZE,
                     enabled_methods: EnabledMethods::default(),
                     auth: AuthConfig::default(),
@@ -202,8 +203,8 @@ impl ConfigMockBuilder {
         self
     }
 
-    pub fn with_api_key_auth(mut self, api_key: String) -> Self {
-        self.config.kora.auth.api_key = Some(api_key);
+    pub fn with_api_key(mut self, api_key: String) -> Self {
+        self.config.kora.auth.api_keys = Some(vec![api_key]);
         self
     }
 
@@ -389,6 +390,7 @@ impl KoraConfigBuilder {
         Self {
             config: KoraConfig {
                 rate_limit: 100,
+                cors_allow_origins: vec!["*".to_string()],
                 max_request_body_size: DEFAULT_MAX_REQUEST_BODY_SIZE,
                 enabled_methods: EnabledMethods::default(),
                 auth: AuthConfig::default(),
@@ -520,7 +522,7 @@ impl AuthConfigBuilder {
     pub fn new() -> Self {
         Self {
             config: AuthConfig {
-                api_key: None,
+                api_keys: None,
                 hmac_secret: None,
                 recaptcha_secret: None,
                 recaptcha_score_threshold: crate::constant::DEFAULT_RECAPTCHA_SCORE_THRESHOLD,
@@ -538,7 +540,16 @@ impl AuthConfigBuilder {
     }
 
     pub fn with_api_key(mut self, api_key: String) -> Self {
-        self.config.api_key = Some(api_key);
+        if let Some(ref mut keys) = self.config.api_keys {
+            keys.push(api_key);
+        } else {
+            self.config.api_keys = Some(vec![api_key]);
+        }
+        self
+    }
+
+    pub fn with_api_keys(mut self, api_keys: Vec<String>) -> Self {
+        self.config.api_keys = Some(api_keys);
         self
     }
 
@@ -548,7 +559,7 @@ impl AuthConfigBuilder {
     }
 
     pub fn with_both_auth(mut self, api_key: String, hmac_secret: String) -> Self {
-        self.config.api_key = Some(api_key);
+        self.config.api_keys = Some(vec![api_key]);
         self.config.hmac_secret = Some(hmac_secret);
         self
     }
@@ -974,7 +985,7 @@ pub fn get_default_config_with_cache() -> Config {
 
 pub fn get_default_config_with_auth() -> Config {
     ConfigMockBuilder::new()
-        .with_api_key_auth("test-api-key".to_string())
+        .with_api_key("test-api-key".to_string())
         .with_hmac_auth("test-hmac-secret".to_string())
         .build()
 }

--- a/crates/lib/src/tests/config_mock.rs
+++ b/crates/lib/src/tests/config_mock.rs
@@ -102,7 +102,8 @@ impl ConfigMockBuilder {
                     cross_cluster_endpoints: vec![],
                 },
                 kora: KoraConfig {
-                    rate_limit: 100,
+                    rate_limit: Some(100),
+                    global_rate_limit: None,
                     cors_allow_origins: vec!["*".to_string()],
                     max_request_body_size: DEFAULT_MAX_REQUEST_BODY_SIZE,
                     enabled_methods: EnabledMethods::default(),
@@ -163,8 +164,13 @@ impl ConfigMockBuilder {
         self
     }
 
-    pub fn with_rate_limit(mut self, rate_limit: u64) -> Self {
+    pub fn with_rate_limit(mut self, rate_limit: Option<u64>) -> Self {
         self.config.kora.rate_limit = rate_limit;
+        self
+    }
+
+    pub fn with_global_rate_limit(mut self, global_rate_limit: Option<u64>) -> Self {
+        self.config.kora.global_rate_limit = global_rate_limit;
         self
     }
 
@@ -389,7 +395,8 @@ impl KoraConfigBuilder {
     pub fn new() -> Self {
         Self {
             config: KoraConfig {
-                rate_limit: 100,
+                rate_limit: Some(100),
+                global_rate_limit: None,
                 cors_allow_origins: vec!["*".to_string()],
                 max_request_body_size: DEFAULT_MAX_REQUEST_BODY_SIZE,
                 enabled_methods: EnabledMethods::default(),
@@ -417,8 +424,13 @@ impl KoraConfigBuilder {
         self.config
     }
 
-    pub fn with_rate_limit(mut self, rate_limit: u64) -> Self {
+    pub fn with_rate_limit(mut self, rate_limit: Option<u64>) -> Self {
         self.config.rate_limit = rate_limit;
+        self
+    }
+
+    pub fn with_global_rate_limit(mut self, global_rate_limit: Option<u64>) -> Self {
+        self.config.global_rate_limit = global_rate_limit;
         self
     }
 

--- a/crates/lib/src/tests/mod.rs
+++ b/crates/lib/src/tests/mod.rs
@@ -21,3 +21,6 @@ pub mod transaction_mock;
 
 #[cfg(test)]
 pub mod oracle_mock;
+
+#[cfg(test)]
+pub mod usage_limiter_mock;

--- a/crates/lib/src/tests/usage_limiter_mock.rs
+++ b/crates/lib/src/tests/usage_limiter_mock.rs
@@ -1,0 +1,9 @@
+use crate::error::KoraError;
+
+pub struct MockUsageTracker;
+
+impl MockUsageTracker {
+    pub async fn init_usage_limiter() -> Result<(), KoraError> {
+        Ok(())
+    }
+}

--- a/crates/lib/src/usage_limit/usage_tracker.rs
+++ b/crates/lib/src/usage_limit/usage_tracker.rs
@@ -365,18 +365,9 @@ impl UsageTracker {
         let usage_config = &config.kora.usage_limit;
 
         let set_limiter = |limiter| {
-            if USAGE_LIMITER.set(limiter).is_err() {
-                #[cfg(test)]
-                {
-                    log::debug!("Usage limiter already initialized (ignored in tests)");
-                    return Ok(());
-                }
-                #[cfg(not(test))]
-                return Err(KoraError::InternalServerError(
-                    "Usage limiter already initialized".to_string(),
-                ));
-            }
-            Ok(())
+            USAGE_LIMITER.set(limiter).map_err(|_| {
+                KoraError::InternalServerError("Usage limiter already initialized".to_string())
+            })
         };
 
         if !usage_config.enabled {

--- a/crates/lib/src/usage_limit/usage_tracker.rs
+++ b/crates/lib/src/usage_limit/usage_tracker.rs
@@ -365,9 +365,18 @@ impl UsageTracker {
         let usage_config = &config.kora.usage_limit;
 
         let set_limiter = |limiter| {
-            USAGE_LIMITER.set(limiter).map_err(|_| {
-                KoraError::InternalServerError("Usage limiter already initialized".to_string())
-            })
+            if USAGE_LIMITER.set(limiter).is_err() {
+                #[cfg(test)]
+                {
+                    log::debug!("Usage limiter already initialized (ignored in tests)");
+                    return Ok(());
+                }
+                #[cfg(not(test))]
+                return Err(KoraError::InternalServerError(
+                    "Usage limiter already initialized".to_string(),
+                ));
+            }
+            Ok(())
         };
 
         if !usage_config.enabled {

--- a/crates/lib/src/validator/config_validator.rs
+++ b/crates/lib/src/validator/config_validator.rs
@@ -423,7 +423,7 @@ impl ConfigValidator {
 
         // Validate rate limit (warn if 0)
         if config.kora.rate_limit == 0 {
-            warnings.push("Rate limit is set to 0 - this will block all requests".to_string());
+            warnings.push("Rate limit is set to 0 - per-identity rate limiting is disabled; all requests will be allowed without throttling".to_string());
         }
 
         // Validate CORS origins

--- a/crates/lib/src/validator/config_validator.rs
+++ b/crates/lib/src/validator/config_validator.rs
@@ -426,6 +426,10 @@ impl ConfigValidator {
             warnings.push("Rate limit is disabled (set to None) - per-identity rate limiting is disabled; all requests will be allowed without throttling".to_string());
         }
 
+        if config.kora.rate_limit == Some(0) {
+            warnings.push("Per-identity rate limit is set to 0 - all authenticated requests will be rejected immediately with 429".to_string());
+        }
+
         // Validate global rate limit (warn if Some(0))
         if config.kora.global_rate_limit == Some(0) {
             warnings.push("Global rate limit is set to 0 - all requests will be throttled and rejected immediately".to_string());
@@ -1460,7 +1464,7 @@ mod tests {
         };
 
         // Initialize global config
-        let _ = update_config(config);
+        let _ = update_config(config.clone());
 
         let rpc_client = RpcClient::new_with_commitment(
             "http://localhost:8899".to_string(),
@@ -1479,6 +1483,16 @@ mod tests {
         assert!(warnings.iter().any(|w| w.contains("Max allowed lamports is 0")));
         assert!(warnings.iter().any(|w| w.contains("Max signatures is 0")));
         assert!(warnings.iter().any(|w| w.contains("Using Mock price source")));
+
+        // Test rate_limit == Some(0)
+        let mut config_some_0 = config.clone();
+        config_some_0.kora.rate_limit = Some(0);
+        let _ = update_config(config_some_0);
+
+        let result_some_0 = ConfigValidator::validate_with_result(&rpc_client, true).await;
+        let warnings_some_0 = result_some_0.unwrap();
+        assert!(warnings_some_0.iter().any(|w| w.contains("Per-identity rate limit is set to 0")));
+
         assert!(warnings.iter().any(|w| w.contains("No allowed programs configured")));
     }
 

--- a/crates/lib/src/validator/config_validator.rs
+++ b/crates/lib/src/validator/config_validator.rs
@@ -453,6 +453,8 @@ impl ConfigValidator {
             } else if invalid_count > 0 {
                 warnings.push(format!("cors_allow_origins contains {} invalid origin(s) that will be silently filtered out at runtime", invalid_count));
             }
+        } else if config.kora.cors_allow_origins.len() > 1 {
+            warnings.push("cors_allow_origins contains '*' alongside specific origins. The specific origins are redundant and will be silently ignored.".to_string());
         }
 
         // Validate payment address
@@ -1507,6 +1509,18 @@ mod tests {
         assert!(warnings_cors.iter().any(|w| w.contains(
             "cors_allow_origins contains 1 invalid origin(s) that will be silently filtered out"
         )));
+
+        // Test wildcard with redundant specific origins
+        let mut config_cors_wildcard = config.clone();
+        config_cors_wildcard.kora.cors_allow_origins =
+            vec!["*".to_string(), "https://redundant.com".to_string()];
+        let _ = update_config(config_cors_wildcard);
+
+        let result_cors_wildcard = ConfigValidator::validate_with_result(&rpc_client, true).await;
+        let warnings_cors_wildcard = result_cors_wildcard.unwrap();
+        assert!(warnings_cors_wildcard
+            .iter()
+            .any(|w| w.contains("cors_allow_origins contains '*' alongside specific origins")));
 
         assert!(warnings.iter().any(|w| w.contains("No allowed programs configured")));
     }

--- a/crates/lib/src/validator/config_validator.rs
+++ b/crates/lib/src/validator/config_validator.rs
@@ -427,7 +427,7 @@ impl ConfigValidator {
         }
 
         if config.kora.rate_limit == Some(0) {
-            warnings.push("Per-identity rate limit is set to 0 - all authenticated requests will be rejected immediately with 429".to_string());
+            warnings.push("Per-identity rate limit is set to 0 - all requests for each identity will be rejected immediately with 429".to_string());
         }
 
         // Validate global rate limit (warn if Some(0))

--- a/crates/lib/src/validator/config_validator.rs
+++ b/crates/lib/src/validator/config_validator.rs
@@ -422,6 +422,8 @@ impl ConfigValidator {
         };
 
         // Validate rate limit (warn if None)
+        // Note: None is not reachable from TOML (no null type); this warning applies
+        // to programmatic config construction only.
         if config.kora.rate_limit.is_none() {
             warnings.push("Rate limit is disabled (set to None) - per-identity rate limiting is disabled; all requests will be allowed without throttling".to_string());
         }

--- a/crates/lib/src/validator/config_validator.rs
+++ b/crates/lib/src/validator/config_validator.rs
@@ -1136,7 +1136,7 @@ mod tests {
             validation: validation_config_with_auth(),
             kora: KoraConfig {
                 auth: AuthConfig {
-                    api_key: Some("rotated-config-key".to_string()),
+                    api_keys: Some(vec!["rotated-config-key".to_string()]),
                     ..Default::default()
                 },
                 ..KoraConfig::default()
@@ -1157,7 +1157,7 @@ mod tests {
         assert!(
             warnings
                 .iter()
-                .any(|w| w.contains("KORA_API_KEY") && w.contains("[kora.auth].api_key")),
+                .any(|w| w.contains("KORA_API_KEY") && w.contains("[kora.auth].api_keys")),
             "expected an env-override warning naming the field, got: {warnings:?}"
         );
         // Auth is in effect, so the no-auth warning must not appear.
@@ -1409,6 +1409,7 @@ mod tests {
             },
             kora: KoraConfig {
                 rate_limit: 0, // Should warn
+                cors_allow_origins: vec!["*".to_string()],
                 max_request_body_size: DEFAULT_MAX_REQUEST_BODY_SIZE,
                 enabled_methods: EnabledMethods {
                     liveness: false,

--- a/crates/lib/src/validator/config_validator.rs
+++ b/crates/lib/src/validator/config_validator.rs
@@ -421,9 +421,14 @@ impl ConfigValidator {
             }
         };
 
-        // Validate rate limit (warn if 0)
-        if config.kora.rate_limit == 0 {
-            warnings.push("Rate limit is set to 0 - per-identity rate limiting is disabled; all requests will be allowed without throttling".to_string());
+        // Validate rate limit (warn if None)
+        if config.kora.rate_limit.is_none() {
+            warnings.push("Rate limit is disabled (set to None) - per-identity rate limiting is disabled; all requests will be allowed without throttling".to_string());
+        }
+
+        // Validate global rate limit (warn if Some(0))
+        if config.kora.global_rate_limit == Some(0) {
+            warnings.push("Global rate limit is set to 0 - all requests will be throttled and rejected immediately".to_string());
         }
 
         // Validate CORS origins
@@ -1095,7 +1100,7 @@ mod tests {
                 cross_cluster_check: false,
                 cross_cluster_endpoints: vec![],
             },
-            kora: KoraConfig::default(),
+            kora: KoraConfig { rate_limit: Some(100), ..KoraConfig::default() },
             metrics: MetricsConfig::default(),
         };
 
@@ -1421,7 +1426,8 @@ mod tests {
                 cross_cluster_endpoints: vec![],
             },
             kora: KoraConfig {
-                rate_limit: 0,              // Should warn
+                rate_limit: None, // Should warn
+                global_rate_limit: None,
                 cors_allow_origins: vec![], // Should warn
                 max_request_body_size: DEFAULT_MAX_REQUEST_BODY_SIZE,
                 enabled_methods: EnabledMethods {
@@ -1465,7 +1471,7 @@ mod tests {
         let warnings = result.unwrap();
 
         assert!(!warnings.is_empty());
-        assert!(warnings.iter().any(|w| w.contains("Rate limit is set to 0")));
+        assert!(warnings.iter().any(|w| w.contains("Rate limit is disabled (set to None)")));
         assert!(warnings
             .iter()
             .any(|w| w.contains("cors_allow_origins is empty or contains no valid origins")));

--- a/crates/lib/src/validator/config_validator.rs
+++ b/crates/lib/src/validator/config_validator.rs
@@ -436,16 +436,21 @@ impl ConfigValidator {
         }
 
         // Validate CORS origins
-        let cors_empty_or_invalid = if config.kora.cors_allow_origins.is_empty() {
-            true
-        } else if !config.kora.cors_allow_origins.iter().any(|o| o == "*") {
-            !config.kora.cors_allow_origins.iter().any(|o| o.parse::<http::HeaderValue>().is_ok())
-        } else {
-            false
-        };
-
-        if cors_empty_or_invalid {
+        if config.kora.cors_allow_origins.is_empty() {
             warnings.push("cors_allow_origins is empty or contains no valid origins - all cross-origin requests will be blocked".to_string());
+        } else if !config.kora.cors_allow_origins.iter().any(|o| o == "*") {
+            let invalid_count = config
+                .kora
+                .cors_allow_origins
+                .iter()
+                .filter(|o| o.parse::<http::HeaderValue>().is_err())
+                .count();
+
+            if invalid_count == config.kora.cors_allow_origins.len() {
+                warnings.push("cors_allow_origins is empty or contains no valid origins - all cross-origin requests will be blocked".to_string());
+            } else if invalid_count > 0 {
+                warnings.push(format!("cors_allow_origins contains {} invalid origin(s) that will be silently filtered out at runtime", invalid_count));
+            }
         }
 
         // Validate payment address
@@ -792,12 +797,8 @@ impl ConfigValidator {
 
         // The running server resolves auth env-first, so a stale KORA_* environment variable
         // silently overrides a rotated kora.toml secret and keeps the retired credential valid.
-        for (env_var, field) in config.kora.auth.env_overridden_fields() {
-            warnings.push(format!(
-                "⚠️  SECURITY: environment variable {env_var} overrides {field}. The environment \
-                 value takes precedence at runtime; if you rotated the secret in kora.toml, the \
-                 stale environment value is still in effect. Unset {env_var} or align it with the config."
-            ));
+        for msg in config.kora.auth.env_overridden_fields() {
+            warnings.push(format!("⚠️  SECURITY: {msg}"));
         }
 
         // Validate usage limit configuration
@@ -1492,6 +1493,18 @@ mod tests {
         let result_some_0 = ConfigValidator::validate_with_result(&rpc_client, true).await;
         let warnings_some_0 = result_some_0.unwrap();
         assert!(warnings_some_0.iter().any(|w| w.contains("Per-identity rate limit is set to 0")));
+
+        // Test partially invalid CORS origins
+        let mut config_cors = config.clone();
+        config_cors.kora.cors_allow_origins =
+            vec!["https://valid.com".to_string(), "invalid\norigin".to_string()];
+        let _ = update_config(config_cors);
+
+        let result_cors = ConfigValidator::validate_with_result(&rpc_client, true).await;
+        let warnings_cors = result_cors.unwrap();
+        assert!(warnings_cors.iter().any(|w| w.contains(
+            "cors_allow_origins contains 1 invalid origin(s) that will be silently filtered out"
+        )));
 
         assert!(warnings.iter().any(|w| w.contains("No allowed programs configured")));
     }

--- a/crates/lib/src/validator/config_validator.rs
+++ b/crates/lib/src/validator/config_validator.rs
@@ -422,8 +422,8 @@ impl ConfigValidator {
         };
 
         // Validate rate limit (warn if None)
-        // Note: None is not reachable from TOML (no null type); this warning applies
-        // to programmatic config construction only.
+        // Note: None is only reachable programmatically, not from TOML (TOML has no null type;
+        // omitting the field uses the default of Some(100)).
         if config.kora.rate_limit.is_none() {
             warnings.push("Rate limit is disabled (set to None) - per-identity rate limiting is disabled; all requests will be allowed without throttling".to_string());
         }

--- a/crates/lib/src/validator/config_validator.rs
+++ b/crates/lib/src/validator/config_validator.rs
@@ -426,6 +426,19 @@ impl ConfigValidator {
             warnings.push("Rate limit is set to 0 - this will block all requests".to_string());
         }
 
+        // Validate CORS origins
+        let cors_empty_or_invalid = if config.kora.cors_allow_origins.is_empty() {
+            true
+        } else if !config.kora.cors_allow_origins.iter().any(|o| o == "*") {
+            !config.kora.cors_allow_origins.iter().any(|o| o.parse::<http::HeaderValue>().is_ok())
+        } else {
+            false
+        };
+
+        if cors_empty_or_invalid {
+            warnings.push("cors_allow_origins is empty or contains no valid origins - all cross-origin requests will be blocked".to_string());
+        }
+
         // Validate payment address
         if let Some(payment_address) = &config.kora.payment_address {
             if let Err(e) = Pubkey::from_str(payment_address) {
@@ -1408,8 +1421,8 @@ mod tests {
                 cross_cluster_endpoints: vec![],
             },
             kora: KoraConfig {
-                rate_limit: 0, // Should warn
-                cors_allow_origins: vec!["*".to_string()],
+                rate_limit: 0,              // Should warn
+                cors_allow_origins: vec![], // Should warn
                 max_request_body_size: DEFAULT_MAX_REQUEST_BODY_SIZE,
                 enabled_methods: EnabledMethods {
                     liveness: false,
@@ -1453,6 +1466,9 @@ mod tests {
 
         assert!(!warnings.is_empty());
         assert!(warnings.iter().any(|w| w.contains("Rate limit is set to 0")));
+        assert!(warnings
+            .iter()
+            .any(|w| w.contains("cors_allow_origins is empty or contains no valid origins")));
         assert!(warnings.iter().any(|w| w.contains("All rpc methods are disabled")));
         assert!(warnings.iter().any(|w| w.contains("Max allowed lamports is 0")));
         assert!(warnings.iter().any(|w| w.contains("Max signatures is 0")));

--- a/examples/deploy/kora.toml
+++ b/examples/deploy/kora.toml
@@ -1,5 +1,22 @@
 [kora]
+# NOTE: rate_limit now applies per-identity (per API key/HMAC client).
+# Previously this was a shared global cap. To enforce a server-wide throughput
+# limit, use global_rate_limit instead.
+# Per-identity rate limit (requests per second per API key/HMAC client).
+# To disable per-identity limiting, remove or comment out this field entirely.
+# Setting to 0 blocks all requests immediately — use with caution.
+# Defaults to 100 if not set.
 rate_limit = 100
+
+# Global pre-auth rate limit (requests per second, applied before authentication).
+# Limits total server throughput to protect against unauthenticated spam.
+# Disabled by default (None).
+# global_rate_limit = 100
+
+# Allowed CORS origins. Defaults to ["*"] (allow all).
+# Set to specific origins for production deployments.
+# cors_allow_origins = ["https://your-app.com", "https://admin.your-app.com"]
+cors_allow_origins = ["*"]
 # Optional: Payment address to receive payment tokens (defaults to signer address)
 # payment_address = "YourPaymentAddressPubkey11111111111111111111"
 

--- a/examples/devnet-deploy-paymaster/kora.toml
+++ b/examples/devnet-deploy-paymaster/kora.toml
@@ -1,6 +1,23 @@
 # Example config for a devnet-deploy paymaster.
 [kora]
+# NOTE: rate_limit now applies per-identity (per API key/HMAC client).
+# Previously this was a shared global cap. To enforce a server-wide throughput
+# limit, use global_rate_limit instead.
+# Per-identity rate limit (requests per second per API key/HMAC client).
+# To disable per-identity limiting, remove or comment out this field entirely.
+# Setting to 0 blocks all requests immediately — use with caution.
+# Defaults to 100 if not set.
 rate_limit = 100
+
+# Global pre-auth rate limit (requests per second, applied before authentication).
+# Limits total server throughput to protect against unauthenticated spam.
+# Disabled by default (None).
+# global_rate_limit = 100
+
+# Allowed CORS origins. Defaults to ["*"] (allow all).
+# Set to specific origins for production deployments.
+# cors_allow_origins = ["https://your-app.com", "https://admin.your-app.com"]
+cors_allow_origins = ["*"]
 
 [kora.auth]
 

--- a/examples/getting-started/demo/server/kora.toml
+++ b/examples/getting-started/demo/server/kora.toml
@@ -1,11 +1,29 @@
 [kora]
+# NOTE: rate_limit now applies per-identity (per API key/HMAC client).
+# Previously this was a shared global cap. To enforce a server-wide throughput
+# limit, use global_rate_limit instead.
+# Per-identity rate limit (requests per second per API key/HMAC client).
+# To disable per-identity limiting, remove or comment out this field entirely.
+# Setting to 0 blocks all requests immediately — use with caution.
+# Defaults to 100 if not set.
 rate_limit = 100
+
+# Global pre-auth rate limit (requests per second, applied before authentication).
+# Limits total server throughput to protect against unauthenticated spam.
+# Disabled by default (None).
+# global_rate_limit = 100
+
+# Allowed CORS origins. Defaults to ["*"] (allow all).
+# Set to specific origins for production deployments.
+# cors_allow_origins = ["https://your-app.com", "https://admin.your-app.com"]
+cors_allow_origins = ["*"]
 # Optional: Payment address to receive payment tokens (defaults to signer address)
 # payment_address = "YourPaymentAddressPubkey11111111111111111111"
 
 [kora.auth]
 # Optional: API key for simple authentication
-# api_key = "your-api-key"
+# api_key = "your-api-key"  # Deprecated: use api_keys array instead
+# api_keys = ["key-1", "key-2"]  # Supports multiple API keys
 
 # Optional: HMAC secret for signed requests
 # hmac_secret = "your-hmac-secret"

--- a/examples/jito-bundles/server/kora.toml
+++ b/examples/jito-bundles/server/kora.toml
@@ -1,11 +1,29 @@
 [kora]
+# NOTE: rate_limit now applies per-identity (per API key/HMAC client).
+# Previously this was a shared global cap. To enforce a server-wide throughput
+# limit, use global_rate_limit instead.
+# Per-identity rate limit (requests per second per API key/HMAC client).
+# To disable per-identity limiting, remove or comment out this field entirely.
+# Setting to 0 blocks all requests immediately — use with caution.
+# Defaults to 100 if not set.
 rate_limit = 100
+
+# Global pre-auth rate limit (requests per second, applied before authentication).
+# Limits total server throughput to protect against unauthenticated spam.
+# Disabled by default (None).
+# global_rate_limit = 100
+
+# Allowed CORS origins. Defaults to ["*"] (allow all).
+# Set to specific origins for production deployments.
+# cors_allow_origins = ["https://your-app.com", "https://admin.your-app.com"]
+cors_allow_origins = ["*"]
 # Optional: Payment address to receive payment tokens (defaults to signer address)
 # payment_address = "YourPaymentAddressPubkey11111111111111111111"
 
 [kora.auth]
 # Optional: API key for simple header-based authentication (use x-api-key header)
-api_key = "kora_facilitator_api_key_example"
+# api_key = "kora_facilitator_api_key_example"  # Deprecated: use api_keys array instead
+api_keys = ["kora_facilitator_api_key_example"]  # Supports multiple API keys
 
 # Optional: HMAC secret for signed requests
 # hmac_secret = "your-hmac-secret"

--- a/examples/x402/demo/kora/kora.toml
+++ b/examples/x402/demo/kora/kora.toml
@@ -1,11 +1,29 @@
 [kora]
+# NOTE: rate_limit now applies per-identity (per API key/HMAC client).
+# Previously this was a shared global cap. To enforce a server-wide throughput
+# limit, use global_rate_limit instead.
+# Per-identity rate limit (requests per second per API key/HMAC client).
+# To disable per-identity limiting, remove or comment out this field entirely.
+# Setting to 0 blocks all requests immediately — use with caution.
+# Defaults to 100 if not set.
 rate_limit = 100
+
+# Global pre-auth rate limit (requests per second, applied before authentication).
+# Limits total server throughput to protect against unauthenticated spam.
+# Disabled by default (None).
+# global_rate_limit = 100
+
+# Allowed CORS origins. Defaults to ["*"] (allow all).
+# Set to specific origins for production deployments.
+# cors_allow_origins = ["https://your-app.com", "https://admin.your-app.com"]
+cors_allow_origins = ["*"]
 # Optional: Payment address to receive payment tokens (defaults to signer address)
 # payment_address = "YourPaymentAddressPubkey11111111111111111111"
 
 [kora.auth]
 # Optional: API key for simple header-based authentication (use x-api-key header)
-api_key = "kora_facilitator_api_key_example"
+# api_key = "kora_facilitator_api_key_example"  # Deprecated: use api_keys array instead
+api_keys = ["kora_facilitator_api_key_example"]  # Supports multiple API keys
 
 # Optional: HMAC secret for request signature authentication (use x-hmac-signature and x-timestamp headers)
 # hmac_secret = "your-hmac-secret"

--- a/kora.toml
+++ b/kora.toml
@@ -1,9 +1,27 @@
 [kora]
+# NOTE: rate_limit now applies per-identity (per API key/HMAC client).
+# Previously this was a shared global cap. To enforce a server-wide throughput
+# limit, use global_rate_limit instead.
+# Per-identity rate limit (requests per second per API key/HMAC client).
+# To disable per-identity limiting, remove or comment out this field entirely.
+# Setting to 0 blocks all requests immediately — use with caution.
+# Defaults to 100 if not set.
 rate_limit = 100
+
+# Global pre-auth rate limit (requests per second, applied before authentication).
+# Limits total server throughput to protect against unauthenticated spam.
+# Disabled by default (None).
+# global_rate_limit = 100
+
+# Allowed CORS origins. Defaults to ["*"] (allow all).
+# Set to specific origins for production deployments.
+# cors_allow_origins = ["https://your-app.com", "https://admin.your-app.com"]
+cors_allow_origins = ["*"]
 
 [kora.auth]
 # Optional: API key for simple authentication
-# api_key = "your-api-key"
+# api_key = "your-api-key"  # Deprecated: use api_keys array instead
+# api_keys = ["key-1", "key-2"]  # Supports multiple API keys
 
 # Optional: HMAC secret for signed requests
 # hmac_secret = "your-hmac-secret"

--- a/tests/src/common/fixtures/auth-test.toml
+++ b/tests/src/common/fixtures/auth-test.toml
@@ -1,9 +1,11 @@
 # Auth test configuration file
 [kora]
 rate_limit = 100
+cors_allow_origins = ["*"]
 
 [kora.auth]
-api_key = "test-api-key-123"
+# api_key = "test-api-key-123"  # Deprecated: use api_keys array instead
+api_keys = ["test-api-key-123"]  # Supports multiple API keys
 hmac_secret = "test-hmac-secret-456"
 
 # Cache configuration - disabled for testing

--- a/tests/src/common/fixtures/fee-payer-policy-test.toml
+++ b/tests/src/common/fixtures/fee-payer-policy-test.toml
@@ -1,6 +1,7 @@
 # Adversarial testing configuration file with restrictive fee payer policies
 [kora]
 rate_limit = 100
+cors_allow_origins = ["*"]
 
 [kora.auth]
 

--- a/tests/src/common/fixtures/gas-swap-plugin-test.toml
+++ b/tests/src/common/fixtures/gas-swap-plugin-test.toml
@@ -1,6 +1,7 @@
 # This file is used for integration testing with the gas_swap plugin enabled
 [kora]
 rate_limit = 100
+cors_allow_origins = ["*"]
 
 [kora.auth]
 

--- a/tests/src/common/fixtures/kora-free-test.toml
+++ b/tests/src/common/fixtures/kora-free-test.toml
@@ -1,6 +1,7 @@
 # This file is used for free pricing tests (no payment validation)
 [kora]
 rate_limit = 100
+cors_allow_origins = ["*"]
 
 [kora.auth]
 

--- a/tests/src/common/fixtures/kora-test.toml
+++ b/tests/src/common/fixtures/kora-test.toml
@@ -1,6 +1,7 @@
 # This file is used for integration testing
 [kora]
 rate_limit = 100
+cors_allow_origins = ["*"]
 
 [kora.auth]
 

--- a/tests/src/common/fixtures/lighthouse-test.toml
+++ b/tests/src/common/fixtures/lighthouse-test.toml
@@ -1,6 +1,7 @@
 # This file is used for lighthouse integration testing
 [kora]
 rate_limit = 100
+cors_allow_origins = ["*"]
 
 [kora.auth]
 

--- a/tests/src/common/fixtures/loader-v3-deploy-test.toml
+++ b/tests/src/common/fixtures/loader-v3-deploy-test.toml
@@ -1,5 +1,6 @@
 [kora]
 rate_limit = 100
+cors_allow_origins = ["*"]
 
 [kora.auth]
 

--- a/tests/src/common/fixtures/paymaster-address-test.toml
+++ b/tests/src/common/fixtures/paymaster-address-test.toml
@@ -1,6 +1,7 @@
 # Payment address test configuration file
 [kora]
 rate_limit = 100
+cors_allow_origins = ["*"]
 payment_address = "CWvWnVwqAb9HzqwCGkn4purGEUuu27aNsPQM252uLerV"
 
 # Cache configuration - disabled for testing

--- a/tests/src/common/fixtures/usage-limit-test.toml
+++ b/tests/src/common/fixtures/usage-limit-test.toml
@@ -2,6 +2,7 @@
 # This file is used for testing usage limit functionality
 [kora]
 rate_limit = 100
+cors_allow_origins = ["*"]
 
 [kora.auth]
 


### PR DESCRIPTION
`rpc_server`: replace global rate limiter with identity-aware limiting and configurable CORS

- Add `global_rate_limit` (pre-auth) to throttle unauthenticated spam cheaply
- Replace shared `RateLimitLayer` with per-identity token buckets (`IdentityRateLimitLayer`)
- Add `cors_allow_origins` config field, replacing hardcoded `allow_origin(Any)`
- Migrate `api_key` -> `api_keys: Vec<String>` with backward-compatible deserialization
- Add `http_rejections_total` Prometheus counter distinguishing `auth_failure` vs `rate_limit`
- Reorder middleware: `metrics` -> `CORS` -> `global limit` -> `auth` -> `per-identity limit` -> `recaptcha`
- Update all `kora.toml` examples with new fields and deprecation notes