### PR TITLE
ci: commit test account cache for genesis preloading

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -62,6 +62,15 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - uses: dtolnay/rust-toolchain@stable
+
+      # test_runner shells out to `cargo test` per phase, so the integration
+      # jobs need the toolchain and the incremental build cache even though
+      # they download prebuilt kora/test_runner binaries
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "rust-integration"
+
       - name: Download build artifacts
         uses: actions/download-artifact@v8
         with:


### PR DESCRIPTION
## Summary
- Integration setup creates ~25 accounts (SPL + Token-2022 mints, ATAs, lookup tables, funded wallets) through transactions. The runner already supports preloading them at validator genesis via `--account`, but `tests/src/common/fixtures/test-accounts/` was gitignored — so CI rebuilt every account via transactions on every run.
- That setup is non-deterministic on CI: measured 20s–270s for the same code depending on validator/runner timing, and it dominated rust integration job wall time after the recompile was removed in #560.
- Commit the cache (26 fixtures) so the validator boots with the accounts already present. Setup becomes near-instant and deterministic.

## Safety / maintenance
- The cache-completeness check falls back to full transaction setup if any required account file is missing, so adding a new required account is self-correcting.
- Lookup-table fixtures are stored genesis-ready (activated at slot 0).
- `just integration-test --force-refresh` regenerates the cache; documented in CLAUDE.md to run it when setup changes an existing account's contents (the one case stale fixtures could mask).

## Test Plan
- Local: `--force-refresh` regenerates 26 fixtures; a subsequent plain run logs `Loading account: ...` for each and all phases pass
- CI on this PR: integration jobs should preload (look for `Loading account` lines) and rust integration wall time should drop to the ~30-40s floor consistently