### PR TITLE
ci: restore Rust toolchain and cache for integration jobs

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -62,6 +62,15 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - uses: dtolnay/rust-toolchain@stable
+
+      # test_runner shells out to `cargo test` per phase, so the integration
+      # jobs need the toolchain and the incremental build cache even though
+      # they download prebuilt kora/test_runner binaries
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "rust-integration"
+
       - name: Download build artifacts
         uses: actions/download-artifact@v8
         with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -69,7 +69,7 @@ jobs:
       # they download prebuilt kora/test_runner binaries
       - uses: Swatinem/rust-cache@v2
         with:
-          shared-key: "rust-integration"
+          shared-key: "rust-integration-build"
 
       - name: Download build artifacts
         uses: actions/download-artifact@v8


### PR DESCRIPTION
## Summary
- `test_runner` shells out to `cargo test` once per phase, so the rust integration jobs depend on the Rust toolchain and the incremental build cache — even though they download prebuilt `kora`/`test_runner` binaries.
- #560 removed `dtolnay/rust-toolchain` + `Swatinem/rust-cache` from the integration jobs on the assumption no Cargo invocation remained. The per-phase `cargo test` output is buffered by the runner (shown only on failure), so the resulting full recompile was invisible in logs.
- Effect, measured on the #560 branch: the auth integration job went **85s → 316s** on the exact commit that dropped the cache. This restores both steps on the rust integration job.
- The TypeScript integration job runs `pnpm test` (no `cargo test`), so it correctly keeps neither step — that's why it stayed fast and masked the regression.

## Test Plan
- CI on this PR: rust integration jobs should return to ~85-130s; confirm all phases pass

## Note
- The underlying smell — `test_runner` invoking `cargo test` at runtime, requiring a toolchain inside a "run prebuilt binaries" job — is left for a separate refactor.