### PR TITLE
feat(examples): add devnet paymaster Databricks dashboard

### DIFF
--- a/examples/devnet-deploy-paymaster/dashboard/.gitignore
+++ b/examples/devnet-deploy-paymaster/dashboard/.gitignore
@@ -1,0 +1,2 @@
+prod.yml
+kora_devnet.lvdash.json

--- a/examples/devnet-deploy-paymaster/dashboard/databricks.yml
+++ b/examples/devnet-deploy-paymaster/dashboard/databricks.yml
@@ -1,0 +1,54 @@
+bundle:
+  name: kora-devnet-dashboard
+
+include:
+  - prod.yml
+
+variables:
+  catalog:
+    description: Unity Catalog catalog holding the Kora tables.
+  schema:
+    description: Schema inside the catalog.
+  address:
+    description: Paymaster fee-payer pubkey to track.
+  warehouse_id:
+    description: SQL warehouse id backing the dashboard datasets.
+  rpc_url:
+    description: Solana devnet RPC endpoint.
+    default: https://api.devnet.solana.com
+  max_signatures:
+    description: Max signatures to pull on a cold backfill.
+    default: "5000"
+
+targets:
+  prod:
+    mode: production
+    default: true
+    workspace:
+      root_path: /Workspace/Users/${workspace.current_user.userName}/.bundle/${bundle.name}/${bundle.target}
+
+resources:
+  jobs:
+    kora_devnet_ingest:
+      name: kora-devnet-ingest
+      description: "Poll devnet RPC for the paymaster fee payer; append new transactions, instructions, and a balance snapshot."
+      tasks:
+        - task_key: ingest
+          notebook_task:
+            notebook_path: ./ingest.py
+            base_parameters:
+              catalog: ${var.catalog}
+              schema: ${var.schema}
+              address: ${var.address}
+              rpc_url: ${var.rpc_url}
+              max_signatures: ${var.max_signatures}
+      schedule:
+        quartz_cron_expression: "0 0 9 * * ?"
+        timezone_id: UTC
+        pause_status: UNPAUSED
+
+  dashboards:
+    kora_devnet_dashboard:
+      display_name: Kora devnet paymaster
+      file_path: ./kora_devnet.lvdash.json
+      warehouse_id: ${var.warehouse_id}

--- a/examples/devnet-deploy-paymaster/dashboard/ingest.py
+++ b/examples/devnet-deploy-paymaster/dashboard/ingest.py
@@ -1,0 +1,176 @@
+# Databricks notebook source
+import re
+import time
+from datetime import datetime, timezone
+
+import requests
+from pyspark.sql.types import (
+    BooleanType,
+    DoubleType,
+    IntegerType,
+    LongType,
+    StringType,
+    StructField,
+    StructType,
+    TimestampType,
+)
+
+dbutils.widgets.text("catalog", "")
+dbutils.widgets.text("schema", "")
+dbutils.widgets.text("address", "")
+dbutils.widgets.text("rpc_url", "https://api.devnet.solana.com")
+dbutils.widgets.text("max_signatures", "5000")
+
+CATALOG = dbutils.widgets.get("catalog")
+SCHEMA = dbutils.widgets.get("schema")
+ADDR = dbutils.widgets.get("address")
+RPC = dbutils.widgets.get("rpc_url")
+MAX_SIGNATURES = int(dbutils.widgets.get("max_signatures"))
+
+if not (CATALOG and SCHEMA and ADDR):
+    raise ValueError("catalog, schema, and address parameters are required")
+if not all(re.fullmatch(r"[A-Za-z0-9_]+", x) for x in (CATALOG, SCHEMA)):
+    raise ValueError("catalog and schema must be plain identifiers")
+
+NS = f"`{CATALOG}`.`{SCHEMA}`"
+TX = f"{CATALOG}.{SCHEMA}.transactions"
+IX = f"{CATALOG}.{SCHEMA}.instructions"
+BAL = f"{CATALOG}.{SCHEMA}.balance_snapshots"
+
+spark.sql(f"CREATE SCHEMA IF NOT EXISTS {NS}")
+spark.sql(
+    f"CREATE TABLE IF NOT EXISTS {NS}.`balance_snapshots` "
+    "(snapshot_at TIMESTAMP, address STRING, lamports BIGINT, sol DOUBLE) USING DELTA"
+)
+spark.sql(
+    f"CREATE TABLE IF NOT EXISTS {NS}.`transactions` "
+    "(signature STRING, block_time TIMESTAMP, slot BIGINT, success BOOLEAN, err STRING, "
+    "fee_lamports BIGINT, num_instructions INT, fetched_at TIMESTAMP) USING DELTA"
+)
+spark.sql(
+    f"CREATE TABLE IF NOT EXISTS {NS}.`instructions` "
+    "(signature STRING, ix_index INT, is_inner BOOLEAN, program STRING, program_id STRING, "
+    "ix_type STRING, block_time TIMESTAMP) USING DELTA"
+)
+
+
+def rpc(method, params):
+    for attempt in range(6):
+        try:
+            r = requests.post(
+                RPC,
+                json={"jsonrpc": "2.0", "id": 1, "method": method, "params": params},
+                timeout=30,
+            )
+            out = r.json()
+            if "error" in out:
+                raise RuntimeError(out["error"])
+            return out["result"]
+        except Exception:
+            if attempt == 5:
+                raise
+            time.sleep(1.5 * (attempt + 1))
+
+
+def newest_stored_sig():
+    rows = spark.sql(f"SELECT signature FROM {TX} ORDER BY block_time DESC LIMIT 1").collect()
+    return rows[0].signature if rows else None
+
+
+def new_signatures(until_sig):
+    collected, before = [], None
+    while True:
+        opts = {"limit": 1000}
+        if before:
+            opts["before"] = before
+        if until_sig:
+            opts["until"] = until_sig
+        page = rpc("getSignaturesForAddress", [ADDR, opts])
+        if not page:
+            break
+        for s in page:
+            collected.append(s["signature"])
+            if len(collected) >= MAX_SIGNATURES:
+                print(f"hit max_signatures cap {MAX_SIGNATURES}; older history skipped")
+                return collected
+        if len(page) < 1000:
+            break
+        before = page[-1]["signature"]
+    return collected
+
+
+def parse_ix(ins):
+    parsed = ins.get("parsed")
+    ix_type = parsed.get("type") if isinstance(parsed, dict) else None
+    return ins.get("program"), ins.get("programId"), ix_type
+
+
+def ts(epoch):
+    return datetime.fromtimestamp(epoch, tz=timezone.utc) if epoch is not None else None
+
+
+sigs = new_signatures(newest_stored_sig())
+print(f"new signatures: {len(sigs)}")
+
+now = datetime.now(timezone.utc)
+tx_rows, ix_rows = [], []
+for sig in sigs:
+    tx = rpc(
+        "getTransaction",
+        [sig, {"encoding": "jsonParsed", "maxSupportedTransactionVersion": 0}],
+    )
+    if tx is None:
+        continue
+    meta = tx.get("meta") or {}
+    bt = ts(tx.get("blockTime"))
+    err = meta.get("err")
+    top = tx["transaction"]["message"].get("instructions", [])
+    tx_rows.append(
+        (sig, bt, tx.get("slot"), err is None, str(err) if err is not None else None,
+         meta.get("fee"), len(top), now)
+    )
+    for i, ins in enumerate(top):
+        p, pid, t = parse_ix(ins)
+        ix_rows.append((sig, i, False, p, pid, t, bt))
+    for group in meta.get("innerInstructions", []) or []:
+        for j, ins in enumerate(group.get("instructions", [])):
+            p, pid, t = parse_ix(ins)
+            ix_rows.append((sig, group["index"] * 1000 + j, True, p, pid, t, bt))
+
+tx_schema = StructType([
+    StructField("signature", StringType()),
+    StructField("block_time", TimestampType()),
+    StructField("slot", LongType()),
+    StructField("success", BooleanType()),
+    StructField("err", StringType()),
+    StructField("fee_lamports", LongType()),
+    StructField("num_instructions", IntegerType()),
+    StructField("fetched_at", TimestampType()),
+])
+ix_schema = StructType([
+    StructField("signature", StringType()),
+    StructField("ix_index", IntegerType()),
+    StructField("is_inner", BooleanType()),
+    StructField("program", StringType()),
+    StructField("program_id", StringType()),
+    StructField("ix_type", StringType()),
+    StructField("block_time", TimestampType()),
+])
+
+if tx_rows:
+    spark.createDataFrame(tx_rows, tx_schema).write.format("delta").mode("append").saveAsTable(TX)
+if ix_rows:
+    spark.createDataFrame(ix_rows, ix_schema).write.format("delta").mode("append").saveAsTable(IX)
+
+bal = rpc("getBalance", [ADDR])["value"]
+bal_schema = StructType([
+    StructField("snapshot_at", TimestampType()),
+    StructField("address", StringType()),
+    StructField("lamports", LongType()),
+    StructField("sol", DoubleType()),
+])
+spark.createDataFrame(
+    [(now, ADDR, bal, bal / 1_000_000_000)], bal_schema
+).write.format("delta").mode("append").saveAsTable(BAL)
+
+print(f"appended {len(tx_rows)} tx, {len(ix_rows)} ix, balance {bal / 1e9} SOL")

--- a/examples/devnet-deploy-paymaster/dashboard/kora_devnet.example.lvdash.json
+++ b/examples/devnet-deploy-paymaster/dashboard/kora_devnet.example.lvdash.json
@@ -1,0 +1,297 @@
+{
+  "datasets": [
+    {
+      "name": "balance_latest",
+      "displayName": "Latest balance",
+      "queryLines": [
+        "SELECT sol, snapshot_at\n",
+        "FROM balance_snapshots\n",
+        "ORDER BY snapshot_at DESC LIMIT 1"
+      ]
+    },
+    {
+      "name": "tx_totals",
+      "displayName": "Transaction totals",
+      "queryLines": [
+        "SELECT\n",
+        "  count(*) AS total_tx,\n",
+        "  round(100.0 * sum(CASE WHEN success THEN 1 ELSE 0 END) / count(*), 1) AS success_pct,\n",
+        "  sum(fee_lamports) / 1e9 AS fees_sol\n",
+        "FROM transactions"
+      ]
+    },
+    {
+      "name": "balance_series",
+      "displayName": "Balance over time",
+      "queryLines": [
+        "SELECT snapshot_at, sol\n",
+        "FROM balance_snapshots\n",
+        "ORDER BY snapshot_at"
+      ]
+    },
+    {
+      "name": "tx_daily",
+      "displayName": "Transactions per day",
+      "queryLines": [
+        "SELECT date(block_time) AS day, count(*) AS txns\n",
+        "FROM transactions\n",
+        "GROUP BY 1 ORDER BY 1"
+      ]
+    },
+    {
+      "name": "ix_breakdown",
+      "displayName": "Instruction types",
+      "queryLines": [
+        "SELECT\n",
+        "  concat(coalesce(program, program_id), ' / ', coalesce(ix_type, '(unparsed)')) AS instruction,\n",
+        "  count(*) AS calls\n",
+        "FROM instructions\n",
+        "WHERE NOT is_inner\n",
+        "GROUP BY 1 ORDER BY calls DESC"
+      ]
+    },
+    {
+      "name": "recent_tx",
+      "displayName": "Recent transactions",
+      "queryLines": [
+        "SELECT signature, block_time, slot, success, fee_lamports, num_instructions\n",
+        "FROM transactions\n",
+        "ORDER BY block_time DESC LIMIT 50"
+      ]
+    }
+  ],
+  "pages": [
+    {
+      "name": "overview",
+      "displayName": "Overview",
+      "layout": [
+        {
+          "widget": {
+            "name": "hdr_title",
+            "textbox_spec": "# Kora devnet deploy paymaster\n\nFee-payer activity on Solana devnet. Source: devnet RPC, refreshed by the `kora-devnet-ingest` job."
+          },
+          "position": { "x": 0, "y": 0, "width": 6, "height": 1 }
+        },
+        {
+          "widget": {
+            "name": "counter_balance",
+            "queries": [
+              {
+                "name": "main_query",
+                "query": {
+                  "datasetName": "balance_latest",
+                  "fields": [{ "name": "sol", "expression": "`sol`" }],
+                  "disaggregated": true
+                }
+              }
+            ],
+            "spec": {
+              "version": 2,
+              "widgetType": "counter",
+              "encodings": { "value": { "fieldName": "sol", "displayName": "Balance (SOL)" } },
+              "frame": { "title": "Balance (SOL)", "showTitle": true }
+            }
+          },
+          "position": { "x": 0, "y": 1, "width": 3, "height": 3 }
+        },
+        {
+          "widget": {
+            "name": "counter_total_tx",
+            "queries": [
+              {
+                "name": "main_query",
+                "query": {
+                  "datasetName": "tx_totals",
+                  "fields": [{ "name": "total_tx", "expression": "`total_tx`" }],
+                  "disaggregated": true
+                }
+              }
+            ],
+            "spec": {
+              "version": 2,
+              "widgetType": "counter",
+              "encodings": { "value": { "fieldName": "total_tx", "displayName": "Transactions" } },
+              "frame": { "title": "Transactions (times called)", "showTitle": true }
+            }
+          },
+          "position": { "x": 3, "y": 1, "width": 3, "height": 3 }
+        },
+        {
+          "widget": {
+            "name": "counter_success",
+            "queries": [
+              {
+                "name": "main_query",
+                "query": {
+                  "datasetName": "tx_totals",
+                  "fields": [{ "name": "success_pct", "expression": "`success_pct`" }],
+                  "disaggregated": true
+                }
+              }
+            ],
+            "spec": {
+              "version": 2,
+              "widgetType": "counter",
+              "encodings": { "value": { "fieldName": "success_pct", "displayName": "Success %" } },
+              "frame": { "title": "Success rate (%)", "showTitle": true }
+            }
+          },
+          "position": { "x": 0, "y": 4, "width": 3, "height": 3 }
+        },
+        {
+          "widget": {
+            "name": "counter_fees",
+            "queries": [
+              {
+                "name": "main_query",
+                "query": {
+                  "datasetName": "tx_totals",
+                  "fields": [{ "name": "fees_sol", "expression": "`fees_sol`" }],
+                  "disaggregated": true
+                }
+              }
+            ],
+            "spec": {
+              "version": 2,
+              "widgetType": "counter",
+              "encodings": { "value": { "fieldName": "fees_sol", "displayName": "Fees paid (SOL)" } },
+              "frame": { "title": "Fees paid by payer (SOL)", "showTitle": true }
+            }
+          },
+          "position": { "x": 3, "y": 4, "width": 3, "height": 3 }
+        },
+        {
+          "widget": { "name": "hdr_activity", "textbox_spec": "# Activity" },
+          "position": { "x": 0, "y": 7, "width": 6, "height": 1 }
+        },
+        {
+          "widget": {
+            "name": "line_balance",
+            "queries": [
+              {
+                "name": "main_query",
+                "query": {
+                  "datasetName": "balance_series",
+                  "fields": [
+                    { "name": "snapshot_at", "expression": "`snapshot_at`" },
+                    { "name": "sol", "expression": "`sol`" }
+                  ],
+                  "disaggregated": true
+                }
+              }
+            ],
+            "spec": {
+              "version": 3,
+              "widgetType": "line",
+              "encodings": {
+                "x": { "fieldName": "snapshot_at", "scale": { "type": "temporal" }, "displayName": "Time" },
+                "y": { "fieldName": "sol", "scale": { "type": "quantitative" }, "displayName": "Balance (SOL)" }
+              },
+              "frame": { "title": "Balance over time", "showTitle": true }
+            }
+          },
+          "position": { "x": 0, "y": 8, "width": 6, "height": 6 }
+        },
+        {
+          "widget": {
+            "name": "line_tx_daily",
+            "queries": [
+              {
+                "name": "main_query",
+                "query": {
+                  "datasetName": "tx_daily",
+                  "fields": [
+                    { "name": "day", "expression": "`day`" },
+                    { "name": "txns", "expression": "`txns`" }
+                  ],
+                  "disaggregated": true
+                }
+              }
+            ],
+            "spec": {
+              "version": 3,
+              "widgetType": "line",
+              "encodings": {
+                "x": { "fieldName": "day", "scale": { "type": "temporal" }, "displayName": "Day" },
+                "y": { "fieldName": "txns", "scale": { "type": "quantitative" }, "displayName": "Transactions" }
+              },
+              "frame": { "title": "Transactions per day", "showTitle": true }
+            }
+          },
+          "position": { "x": 0, "y": 14, "width": 6, "height": 6 }
+        },
+        {
+          "widget": { "name": "hdr_instructions", "textbox_spec": "# Instructions" },
+          "position": { "x": 0, "y": 20, "width": 6, "height": 1 }
+        },
+        {
+          "widget": {
+            "name": "bar_ix_breakdown",
+            "queries": [
+              {
+                "name": "main_query",
+                "query": {
+                  "datasetName": "ix_breakdown",
+                  "fields": [
+                    { "name": "instruction", "expression": "`instruction`" },
+                    { "name": "calls", "expression": "`calls`" }
+                  ],
+                  "disaggregated": true
+                }
+              }
+            ],
+            "spec": {
+              "version": 3,
+              "widgetType": "bar",
+              "encodings": {
+                "x": { "fieldName": "calls", "scale": { "type": "quantitative" }, "displayName": "Calls" },
+                "y": { "fieldName": "instruction", "scale": { "type": "categorical" }, "displayName": "Instruction" }
+              },
+              "frame": { "title": "Instruction types (top-level)", "showTitle": true }
+            }
+          },
+          "position": { "x": 0, "y": 21, "width": 6, "height": 7 }
+        },
+        {
+          "widget": {
+            "name": "table_recent_tx",
+            "queries": [
+              {
+                "name": "main_query",
+                "query": {
+                  "datasetName": "recent_tx",
+                  "fields": [
+                    { "name": "signature", "expression": "`signature`" },
+                    { "name": "block_time", "expression": "`block_time`" },
+                    { "name": "slot", "expression": "`slot`" },
+                    { "name": "success", "expression": "`success`" },
+                    { "name": "fee_lamports", "expression": "`fee_lamports`" },
+                    { "name": "num_instructions", "expression": "`num_instructions`" }
+                  ],
+                  "disaggregated": true
+                }
+              }
+            ],
+            "spec": {
+              "version": 2,
+              "widgetType": "table",
+              "encodings": {
+                "columns": [
+                  { "fieldName": "signature", "displayName": "Signature" },
+                  { "fieldName": "block_time", "displayName": "Block time" },
+                  { "fieldName": "slot", "displayName": "Slot" },
+                  { "fieldName": "success", "displayName": "OK" },
+                  { "fieldName": "fee_lamports", "displayName": "Fee (lamports)" },
+                  { "fieldName": "num_instructions", "displayName": "Instructions" }
+                ]
+              },
+              "frame": { "title": "Recent transactions", "showTitle": true }
+            }
+          },
+          "position": { "x": 0, "y": 28, "width": 6, "height": 8 }
+        }
+      ]
+    }
+  ],
+  "uiSettings": { "theme": { "widgetHeaderAlignment": "ALIGN_LEFT" } }
+}

--- a/examples/devnet-deploy-paymaster/dashboard/prod.example.yml
+++ b/examples/devnet-deploy-paymaster/dashboard/prod.example.yml
@@ -1,0 +1,8 @@
+targets:
+  prod:
+    variables:
+      catalog: <unity_catalog>        # e.g. prod
+      schema: <schema>                # e.g. kora_devnet
+      address: <paymaster_pubkey>     # devnet fee-payer to track
+      warehouse_id: <sql_warehouse_id>
+      rpc_url: <devnet_rpc_url>       # optional; defaults to https://api.devnet.solana.com


### PR DESCRIPTION
## Summary
- Add a Databricks analytics dashboard for the devnet deploy paymaster fee payer: balance, transaction count, instruction-type breakdown, and fees paid.
- Commercial Solana datasets in Unity Catalog are mainnet-only, so this ships its own pipeline: a daily serverless job polls devnet RPC (`getSignaturesForAddress` + `getTransaction` jsonParsed + `getBalance`) into Delta tables, and a Lakeview dashboard reads them.
- `ingest.py` creates the schema/tables if absent and appends incrementally (dedupes against stored signatures) with a `max_signatures` cold-backfill cap.
- Deployment-specific ids (catalog/schema/address/warehouse_id, RPC URL) stay out of git via gitignored `prod.yml` + the real `kora_devnet.lvdash.json`; only `*.example.*` templates are committed (same pattern as solana-mcp).

## Test Plan
- `databricks bundle validate` passes.
- Deployed to the `prod` target; `kora-devnet-ingest` run completed SUCCESS and populated the tables; dashboard published and rendering live data.

No Linear ticket.
