### PR TITLE
feat: batch-fetch and cache address lookup tables for V0 transactions

### DIFF
--- a/crates/lib/src/bundle/helper.rs
+++ b/crates/lib/src/bundle/helper.rs
@@ -108,6 +108,8 @@ impl BundleProcessor {
         let mut all_bundle_instructions: Vec<Instruction> = Vec::new();
         let mut txs_missing_payment_count = 0u64;
 
+        let mut alt_cache: HashMap<Pubkey, Vec<Pubkey>> = HashMap::new();
+
         // Phase 1: Decode, resolve, validate, calc fees, collect instructions
         for encoded in encoded_txs {
             let transaction = TransactionUtil::decode_b64_transaction(encoded)?;
@@ -117,6 +119,7 @@ impl BundleProcessor {
                 config,
                 rpc_client,
                 sig_verify,
+                Some(&mut alt_cache),
             )
             .await?;
 

--- a/crates/lib/src/cache.rs
+++ b/crates/lib/src/cache.rs
@@ -670,6 +670,144 @@ impl CacheUtil {
             ))
         })
     }
+
+    /// Get multiple accounts directly from RPC (bypassing cache)
+    async fn get_multiple_accounts_from_rpc(
+        rpc_client: &RpcClient,
+        pubkeys: &[Pubkey],
+    ) -> Result<Vec<Account>, KoraError> {
+        match rpc_client.get_multiple_accounts(pubkeys).await {
+            Ok(accounts_opt) => {
+                let mut result = Vec::with_capacity(pubkeys.len());
+                for (i, acc_opt) in accounts_opt.into_iter().enumerate() {
+                    match acc_opt {
+                        Some(acc) => result.push(acc),
+                        None => return Err(KoraError::AccountNotFound(pubkeys[i].to_string())),
+                    }
+                }
+                Ok(result)
+            }
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    /// Get multiple accounts, using Redis cache when available.
+    pub async fn get_multiple_accounts(
+        config: &Config,
+        rpc_client: &RpcClient,
+        pubkeys: &[Pubkey],
+    ) -> Result<Vec<Account>, KoraError> {
+        if pubkeys.is_empty() {
+            return Ok(vec![]);
+        }
+
+        // If cache is disabled, go directly to RPC
+        if !CacheUtil::is_cache_enabled(config) {
+            return Self::get_multiple_accounts_from_rpc(rpc_client, pubkeys).await;
+        }
+
+        let pool = match CACHE_POOL.get() {
+            Some(Some(pool)) => pool,
+            _ => return Self::get_multiple_accounts_from_rpc(rpc_client, pubkeys).await,
+        };
+
+        let mut conn = match Self::get_connection(pool).await {
+            Ok(c) => c,
+            Err(e) => {
+                log::warn!(
+                    "Failed to get cache connection, falling back to RPC: {}",
+                    sanitize_error!(e)
+                );
+                return Self::get_multiple_accounts_from_rpc(rpc_client, pubkeys).await;
+            }
+        };
+
+        let keys: Vec<String> = pubkeys.iter().map(Self::get_account_key).collect();
+        let raw: Vec<Option<String>> = match conn.mget(&keys).await {
+            Ok(r) => r,
+            Err(e) => {
+                log::warn!("Failed to get multiple accounts from cache: {}", sanitize_error!(e));
+                vec![None; pubkeys.len()]
+            }
+        };
+
+        let current_time = chrono::Utc::now().timestamp();
+        let mut results: Vec<Option<Account>> = vec![None; pubkeys.len()];
+        let mut misses: Vec<(usize, Pubkey)> = Vec::new();
+
+        for (i, (pubkey, cached_str_opt)) in pubkeys.iter().zip(raw.into_iter()).enumerate() {
+            let mut hit = false;
+            if let Some(cached_str) = cached_str_opt {
+                match serde_json::from_str::<CachedAccount>(&cached_str) {
+                    Ok(cached_account) => {
+                        let cache_age = current_time - cached_account.cached_at;
+                        if cache_age < config.kora.cache.account_ttl as i64 {
+                            results[i] = Some(cached_account.account);
+                            hit = true;
+                        }
+                    }
+                    Err(e) => {
+                        log::warn!(
+                            "Failed to deserialize cached account for {}: {}",
+                            pubkey,
+                            sanitize_error!(e)
+                        );
+                    }
+                }
+            }
+            if !hit {
+                misses.push((i, *pubkey));
+            }
+        }
+
+        if !misses.is_empty() {
+            let miss_pubkeys: Vec<Pubkey> = misses.iter().map(|(_, pk)| *pk).collect();
+            let accounts_opt = match rpc_client.get_multiple_accounts(&miss_pubkeys).await {
+                Ok(a) => a,
+                Err(e) => return Err(e.into()),
+            };
+
+            let mut pipe = redis::pipe();
+            let mut has_pipe_ops = false;
+
+            for (miss_idx, acc_opt) in accounts_opt.into_iter().enumerate() {
+                let (orig_idx, pubkey) = misses[miss_idx];
+                match acc_opt {
+                    Some(acc) => {
+                        results[orig_idx] = Some(acc.clone());
+                        let cached_account =
+                            CachedAccount { account: acc, cached_at: current_time };
+                        match serde_json::to_string(&cached_account) {
+                            Ok(serialized) => {
+                                pipe.set_ex(
+                                    &keys[orig_idx],
+                                    serialized,
+                                    config.kora.cache.account_ttl,
+                                );
+                                has_pipe_ops = true;
+                            }
+                            Err(e) => {
+                                log::warn!(
+                                    "Failed to serialize cache data for {}: {}",
+                                    pubkey,
+                                    sanitize_error!(e)
+                                );
+                            }
+                        }
+                    }
+                    None => return Err(KoraError::AccountNotFound(pubkey.to_string())),
+                }
+            }
+
+            if has_pipe_ops {
+                if let Err(e) = pipe.query_async::<()>(&mut conn).await {
+                    log::warn!("Failed to cache accounts in batch: {}", sanitize_error!(e));
+                }
+            }
+        }
+
+        Ok(results.into_iter().flatten().collect())
+    }
 }
 
 #[cfg(test)]
@@ -831,6 +969,7 @@ mod tests {
         let _m = ConfigMockBuilder::new()
             .with_cache_enabled(false) // Force RPC fallback for simplicity
             .build_and_setup();
+        let config = get_config().unwrap();
 
         let pubkey = Pubkey::new_unique();
         let expected_account = create_mock_token_account(&pubkey, &Pubkey::new_unique());
@@ -838,12 +977,55 @@ mod tests {
         let rpc_client = RpcMockBuilder::new().with_account_info(&expected_account).build();
 
         // force_refresh = true should always go to RPC
-        let config = get_config().unwrap();
         let result = CacheUtil::get_account(&config, &rpc_client, &pubkey, true).await;
 
         assert!(result.is_ok());
         let account = result.unwrap();
         assert_eq!(account.lamports, expected_account.lamports);
+    }
+
+    #[tokio::test]
+    async fn test_get_multiple_accounts_cache_disabled() {
+        let _m = ConfigMockBuilder::new().with_cache_enabled(false).build_and_setup();
+        let config = get_config().unwrap();
+
+        let pubkey1 = Pubkey::new_unique();
+        let pubkey2 = Pubkey::new_unique();
+        let pubkeys = vec![pubkey1, pubkey2];
+
+        let acc1 = create_mock_token_account(&pubkey1, &Pubkey::new_unique());
+        let acc2 = create_mock_token_account(&pubkey2, &Pubkey::new_unique());
+
+        let rpc_client = RpcMockBuilder::new()
+            .with_multiple_accounts_info(vec![Some(acc1.clone()), Some(acc2.clone())])
+            .build();
+
+        let result =
+            CacheUtil::get_multiple_accounts(&config, &rpc_client, &pubkeys).await.unwrap();
+
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0].lamports, acc1.lamports);
+        assert_eq!(result[1].lamports, acc2.lamports);
+    }
+
+    #[tokio::test]
+    async fn test_get_multiple_accounts_rpc_returns_none() {
+        let _m = ConfigMockBuilder::new().with_cache_enabled(false).build_and_setup();
+        let config = get_config().unwrap();
+
+        let pubkey1 = Pubkey::new_unique();
+        let pubkeys = vec![pubkey1];
+
+        // Rpc returns None for the missing account
+        let rpc_client = RpcMockBuilder::new().with_multiple_accounts_info(vec![None]).build();
+
+        let result = CacheUtil::get_multiple_accounts(&config, &rpc_client, &pubkeys).await;
+
+        assert!(result.is_err());
+        match result.unwrap_err() {
+            KoraError::AccountNotFound(pk) => assert_eq!(pk, pubkey1.to_string()),
+            _ => panic!("Expected AccountNotFound error"),
+        }
     }
 
     #[tokio::test]

--- a/crates/lib/src/cache.rs
+++ b/crates/lib/src/cache.rs
@@ -735,7 +735,7 @@ impl CacheUtil {
         let mut results: Vec<Option<Account>> = vec![None; pubkeys.len()];
         let mut misses: Vec<(usize, Pubkey)> = Vec::new();
 
-        for (i, (pubkey, cached_str_opt)) in pubkeys.iter().zip(raw.into_iter()).enumerate() {
+        for (i, (pubkey, cached_str_opt)) in pubkeys.iter().zip(raw).enumerate() {
             let mut hit = false;
             if let Some(cached_str) = cached_str_opt {
                 match serde_json::from_str::<CachedAccount>(&cached_str) {

--- a/crates/lib/src/cache.rs
+++ b/crates/lib/src/cache.rs
@@ -769,6 +769,7 @@ impl CacheUtil {
 
             let mut pipe = redis::pipe();
             let mut has_pipe_ops = false;
+            let mut pending_error = None;
 
             for (miss_idx, acc_opt) in accounts_opt.into_iter().enumerate() {
                 let (orig_idx, pubkey) = misses[miss_idx];
@@ -795,7 +796,11 @@ impl CacheUtil {
                             }
                         }
                     }
-                    None => return Err(KoraError::AccountNotFound(pubkey.to_string())),
+                    None => {
+                        if pending_error.is_none() {
+                            pending_error = Some(KoraError::AccountNotFound(pubkey.to_string()));
+                        }
+                    }
                 }
             }
 
@@ -804,9 +809,17 @@ impl CacheUtil {
                     log::warn!("Failed to cache accounts in batch: {}", sanitize_error!(e));
                 }
             }
+
+            if let Some(err) = pending_error {
+                return Err(err);
+            }
         }
 
-        Ok(results.into_iter().flatten().collect())
+        results
+            .into_iter()
+            .enumerate()
+            .map(|(i, opt)| opt.ok_or_else(|| KoraError::AccountNotFound(pubkeys[i].to_string())))
+            .collect()
     }
 }
 
@@ -817,6 +830,9 @@ mod tests {
         common::{create_mock_token_account, RpcMockBuilder},
         config_mock::ConfigMockBuilder,
     };
+    use chrono::Utc;
+    use redis::cmd;
+    use std::env;
 
     #[tokio::test]
     async fn test_is_cache_enabled_disabled() {
@@ -1051,5 +1067,118 @@ mod tests {
         assert!(result.is_ok(), "Should successfully fetch blockhash from RPC");
         let hash = result.unwrap();
         assert_ne!(hash, Hash::default(), "Blockhash should not be the default hash");
+    }
+
+    // Run with: KORA_REDIS_URL="redis://127.0.0.1:6379" cargo test -p kora-lib test_redis -- --include-ignored
+    #[tokio::test]
+    #[ignore]
+    async fn test_redis_get_multiple_accounts_all_cache_hits() {
+        let redis_url = env::var("KORA_REDIS_URL")
+            .expect("KORA_REDIS_URL must be set to run Redis integration tests");
+        let _m = ConfigMockBuilder::new()
+            .with_cache_enabled(true)
+            .with_cache_url(Some(redis_url))
+            .build_and_setup();
+
+        let _ = CacheUtil::init().await;
+        let config = get_config().unwrap();
+
+        let pool = CACHE_POOL.get().unwrap().as_ref().unwrap();
+        let pubkey1 = Pubkey::new_unique();
+        let pubkey2 = Pubkey::new_unique();
+
+        let acc1 = create_mock_token_account(&pubkey1, &Pubkey::new_unique());
+        let acc2 = create_mock_token_account(&pubkey2, &Pubkey::new_unique());
+
+        let cached1 = CachedAccount { account: acc1.clone(), cached_at: Utc::now().timestamp() };
+        let cached2 = CachedAccount { account: acc2.clone(), cached_at: Utc::now().timestamp() };
+
+        CacheUtil::set_in_cache(pool, &CacheUtil::get_account_key(&pubkey1), &cached1, 60)
+            .await
+            .unwrap();
+        CacheUtil::set_in_cache(pool, &CacheUtil::get_account_key(&pubkey2), &cached2, 60)
+            .await
+            .unwrap();
+
+        // NO GetMultipleAccounts mock registered, so if it hits RPC it will panic/fail
+        let rpc_client = RpcMockBuilder::new().build();
+
+        let result = CacheUtil::get_multiple_accounts(&config, &rpc_client, &[pubkey1, pubkey2])
+            .await
+            .unwrap();
+
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0].lamports, acc1.lamports);
+        assert_eq!(result[1].lamports, acc2.lamports);
+
+        let mut conn = CacheUtil::get_connection(pool).await.unwrap();
+        let _: () = cmd("DEL")
+            .arg(CacheUtil::get_account_key(&pubkey1))
+            .query_async(&mut conn)
+            .await
+            .unwrap();
+        let _: () = cmd("DEL")
+            .arg(CacheUtil::get_account_key(&pubkey2))
+            .query_async(&mut conn)
+            .await
+            .unwrap();
+    }
+
+    // Run with: KORA_REDIS_URL="redis://127.0.0.1:6379" cargo test -p kora-lib test_redis -- --include-ignored
+    #[tokio::test]
+    #[ignore]
+    async fn test_redis_get_multiple_accounts_partial_cache_miss() {
+        let redis_url = env::var("KORA_REDIS_URL")
+            .expect("KORA_REDIS_URL must be set to run Redis integration tests");
+        let _m = ConfigMockBuilder::new()
+            .with_cache_enabled(true)
+            .with_cache_url(Some(redis_url))
+            .build_and_setup();
+
+        let _ = CacheUtil::init().await;
+        let config = get_config().unwrap();
+
+        let pool = CACHE_POOL.get().unwrap().as_ref().unwrap();
+        let pubkey1 = Pubkey::new_unique(); // cached
+        let pubkey2 = Pubkey::new_unique(); // miss
+
+        let acc1 = create_mock_token_account(&pubkey1, &Pubkey::new_unique());
+        let acc2 = create_mock_token_account(&pubkey2, &Pubkey::new_unique());
+
+        let cached1 = CachedAccount { account: acc1.clone(), cached_at: Utc::now().timestamp() };
+
+        CacheUtil::set_in_cache(pool, &CacheUtil::get_account_key(&pubkey1), &cached1, 60)
+            .await
+            .unwrap();
+
+        let mut conn = CacheUtil::get_connection(pool).await.unwrap();
+        let _: () = cmd("DEL")
+            .arg(CacheUtil::get_account_key(&pubkey2))
+            .query_async(&mut conn)
+            .await
+            .unwrap();
+
+        let rpc_client =
+            RpcMockBuilder::new().with_multiple_accounts_info(vec![Some(acc2.clone())]).build();
+
+        let result = CacheUtil::get_multiple_accounts(&config, &rpc_client, &[pubkey1, pubkey2])
+            .await
+            .unwrap();
+
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0].lamports, acc1.lamports);
+        assert_eq!(result[1].lamports, acc2.lamports);
+
+        let mut conn = CacheUtil::get_connection(pool).await.unwrap();
+        let _: () = cmd("DEL")
+            .arg(CacheUtil::get_account_key(&pubkey1))
+            .query_async(&mut conn)
+            .await
+            .unwrap();
+        let _: () = cmd("DEL")
+            .arg(CacheUtil::get_account_key(&pubkey2))
+            .query_async(&mut conn)
+            .await
+            .unwrap();
     }
 }

--- a/crates/lib/src/rpc_server/method/estimate_transaction_fee.rs
+++ b/crates/lib/src/rpc_server/method/estimate_transaction_fee.rs
@@ -72,6 +72,7 @@ pub async fn estimate_transaction_fee(
         config,
         rpc_client,
         sig_verify,
+        None,
     )
     .await?;
 

--- a/crates/lib/src/rpc_server/method/sign_and_send_transaction.rs
+++ b/crates/lib/src/rpc_server/method/sign_and_send_transaction.rs
@@ -66,6 +66,7 @@ pub async fn sign_and_send_transaction(
         config,
         rpc_client,
         sig_verify,
+        None,
     )
     .await?;
 

--- a/crates/lib/src/rpc_server/method/sign_transaction.rs
+++ b/crates/lib/src/rpc_server/method/sign_transaction.rs
@@ -65,6 +65,7 @@ pub async fn sign_transaction(
         config,
         rpc_client,
         sig_verify,
+        None,
     )
     .await?;
 

--- a/crates/lib/src/tests/rpc_mock.rs
+++ b/crates/lib/src/tests/rpc_mock.rs
@@ -42,6 +42,36 @@ impl RpcMockBuilder {
         self
     }
 
+    pub fn with_multiple_accounts_info(mut self, accounts: Vec<Option<Account>>) -> Self {
+        let mut values = Vec::new();
+        for account_opt in accounts {
+            match account_opt {
+                Some(account) => {
+                    let encoded_data = STANDARD.encode(&account.data);
+                    values.push(json!({
+                        "data": [encoded_data, "base64"],
+                        "executable": account.executable,
+                        "lamports": account.lamports,
+                        "owner": account.owner.to_string(),
+                        "rentEpoch": account.rent_epoch
+                    }));
+                }
+                None => {
+                    values.push(json!(null));
+                }
+            }
+        }
+
+        self.mocks.insert(
+            RpcRequest::GetMultipleAccounts,
+            json!({
+                "context": { "slot": 1 },
+                "value": values
+            }),
+        );
+        self
+    }
+
     pub fn with_account_not_found(mut self) -> Self {
         self.mocks.insert(
             RpcRequest::GetAccountInfo,

--- a/crates/lib/src/token/token.rs
+++ b/crates/lib/src/token/token.rs
@@ -1197,7 +1197,7 @@ mod tests_token {
 
     #[tokio::test]
     async fn test_get_mint_account_not_found() {
-        let _lock = ConfigMockBuilder::new().build_and_setup();
+        let _lock = ConfigMockBuilder::new().with_cache_enabled(false).build_and_setup();
         let mint = Pubkey::from_str(WSOL_DEVNET_MINT).unwrap();
         let rpc_client = RpcMockBuilder::new().with_account_not_found().build();
 
@@ -1208,7 +1208,7 @@ mod tests_token {
 
     #[tokio::test]
     async fn test_get_mint_decimals_valid() {
-        let _lock = ConfigMockBuilder::new().build_and_setup();
+        let _lock = ConfigMockBuilder::new().with_cache_enabled(false).build_and_setup();
         let mint = Pubkey::from_str(WSOL_DEVNET_MINT).unwrap();
         let rpc_client = RpcMockBuilder::new().with_mint_account(6).build();
 
@@ -1248,7 +1248,7 @@ mod tests_token {
 
     #[tokio::test]
     async fn test_get_token_price_and_decimals_account_not_found() {
-        let _lock = ConfigMockBuilder::new().build_and_setup();
+        let _lock = ConfigMockBuilder::new().with_cache_enabled(false).build_and_setup();
         let config = get_config().unwrap();
         let mint = Pubkey::from_str(WSOL_DEVNET_MINT).unwrap();
         let rpc_client = RpcMockBuilder::new().with_account_not_found().build();

--- a/crates/lib/src/transaction/versioned_transaction.rs
+++ b/crates/lib/src/transaction/versioned_transaction.rs
@@ -652,18 +652,20 @@ impl LookupTableUtil {
     ) -> Result<Vec<Pubkey>, KoraError> {
         let mut resolved_addresses = Vec::new();
 
-        // Maybe we can use caching here, there's a chance the lookup tables get updated though, so tbd
-        for lookup in lookup_table_lookups {
-            let lookup_table_account =
-                CacheUtil::get_account(config, rpc_client, &lookup.account_key, false)
-                    .await
-                    .map_err(|e| {
-                        KoraError::RpcError(format!(
-                            "Failed to fetch lookup table: {}",
-                            sanitize_error!(e)
-                        ))
-                    })?;
+        if lookup_table_lookups.is_empty() {
+            return Ok(resolved_addresses);
+        }
 
+        let pubkeys: Vec<Pubkey> = lookup_table_lookups.iter().map(|l| l.account_key).collect();
+
+        let lookup_table_accounts =
+            CacheUtil::get_multiple_accounts(config, rpc_client, &pubkeys).await.map_err(|e| {
+                KoraError::RpcError(format!("Failed to fetch lookup table: {}", sanitize_error!(e)))
+            })?;
+
+        for (lookup, lookup_table_account) in
+            lookup_table_lookups.iter().zip(lookup_table_accounts.iter())
+        {
             // Parse the lookup table account data to get the actual addresses
             let address_lookup_table = AddressLookupTable::deserialize(&lookup_table_account.data)
                 .map_err(|e| {
@@ -1148,16 +1150,18 @@ mod tests {
         let encoded_data = base64::engine::general_purpose::STANDARD.encode(&serialized_data);
 
         mocks.insert(
-            RpcRequest::GetAccountInfo,
+            RpcRequest::GetMultipleAccounts,
             json!({
                 "context": { "slot": 1 },
-                "value": {
-                    "data": [encoded_data, "base64"],
-                    "executable": false,
-                    "lamports": 0,
-                    "owner": "AddressLookupTab1e1111111111111111111111111".to_string(),
-                    "rentEpoch": 0
-                }
+                "value": [
+                    {
+                        "data": [encoded_data, "base64"],
+                        "executable": false,
+                        "lamports": 0,
+                        "owner": "AddressLookupTab1e1111111111111111111111111".to_string(),
+                        "rentEpoch": 0
+                    }
+                ]
             }),
         );
 
@@ -1414,13 +1418,13 @@ mod tests {
         let serialized_data = lookup_table.serialize_for_tests().unwrap();
 
         let rpc_client = RpcMockBuilder::new()
-            .with_account_info(&Account {
+            .with_multiple_accounts_info(vec![Some(Account {
                 data: serialized_data,
                 executable: false,
                 lamports: 0,
                 owner: Pubkey::new_unique(),
                 rent_epoch: 0,
-            })
+            })])
             .build();
 
         let lookups = vec![solana_message::v0::MessageAddressTableLookup {
@@ -1445,7 +1449,7 @@ mod tests {
         let config = setup_test_config();
         let _m = setup_config_mock(config.clone());
 
-        let rpc_client = RpcMockBuilder::new().with_account_not_found().build();
+        let rpc_client = RpcMockBuilder::new().with_multiple_accounts_info(vec![]).build();
         let lookups = vec![];
 
         let resolved_addresses =
@@ -1461,7 +1465,7 @@ mod tests {
         let config = setup_test_config();
         let _m = setup_config_mock(config.clone());
 
-        let rpc_client = RpcMockBuilder::new().with_account_not_found().build();
+        let rpc_client = RpcMockBuilder::new().with_multiple_accounts_info(vec![None]).build();
         let lookups = vec![solana_message::v0::MessageAddressTableLookup {
             account_key: Pubkey::new_unique(),
             writable_indexes: vec![0],
@@ -1498,13 +1502,13 @@ mod tests {
 
         let serialized_data = lookup_table.serialize_for_tests().unwrap();
         let rpc_client = RpcMockBuilder::new()
-            .with_account_info(&Account {
+            .with_multiple_accounts_info(vec![Some(Account {
                 data: serialized_data,
                 executable: false,
                 lamports: 0,
                 owner: Pubkey::new_unique(),
                 rent_epoch: 0,
-            })
+            })])
             .build();
 
         // Try to access index 1 which doesn't exist
@@ -1545,13 +1549,13 @@ mod tests {
 
         let serialized_data = lookup_table.serialize_for_tests().unwrap();
         let rpc_client = RpcMockBuilder::new()
-            .with_account_info(&Account {
+            .with_multiple_accounts_info(vec![Some(Account {
                 data: serialized_data,
                 executable: false,
                 lamports: 0,
                 owner: Pubkey::new_unique(),
                 rent_epoch: 0,
-            })
+            })])
             .build();
 
         let lookups = vec![solana_message::v0::MessageAddressTableLookup {

--- a/crates/lib/src/transaction/versioned_transaction.rs
+++ b/crates/lib/src/transaction/versioned_transaction.rs
@@ -137,6 +137,7 @@ impl VersionedTransactionResolved {
         config: &Config,
         rpc_client: &RpcClient,
         sig_verify: bool,
+        alt_cache: Option<&mut HashMap<Pubkey, Vec<Pubkey>>>,
     ) -> Result<Self, KoraError> {
         let mut resolved = Self {
             transaction: transaction.clone(),
@@ -162,6 +163,7 @@ impl VersionedTransactionResolved {
                     config,
                     rpc_client,
                     &v0_message.address_table_lookups,
+                    alt_cache,
                 )
                 .await?
             }
@@ -649,6 +651,7 @@ impl LookupTableUtil {
         config: &Config,
         rpc_client: &RpcClient,
         lookup_table_lookups: &[MessageAddressTableLookup],
+        alt_cache: Option<&mut HashMap<Pubkey, Vec<Pubkey>>>,
     ) -> Result<Vec<Pubkey>, KoraError> {
         let mut resolved_addresses = Vec::new();
 
@@ -656,28 +659,100 @@ impl LookupTableUtil {
             return Ok(resolved_addresses);
         }
 
-        let pubkeys: Vec<Pubkey> = lookup_table_lookups.iter().map(|l| l.account_key).collect();
+        let mut full_address_lists: Vec<Vec<Pubkey>> =
+            Vec::with_capacity(lookup_table_lookups.len());
 
-        let lookup_table_accounts =
-            CacheUtil::get_multiple_accounts(config, rpc_client, &pubkeys).await.map_err(|e| {
+        if let Some(cache) = alt_cache {
+            let mut misses_set = HashSet::new();
+            for lookup in lookup_table_lookups {
+                if !cache.contains_key(&lookup.account_key) {
+                    misses_set.insert(lookup.account_key);
+                }
+            }
+            let misses: Vec<Pubkey> = misses_set.into_iter().collect();
+
+            if !misses.is_empty() {
+                let lookup_table_accounts =
+                    CacheUtil::get_multiple_accounts(config, rpc_client, &misses).await.map_err(
+                        |e| {
+                            KoraError::RpcError(format!(
+                                "Failed to fetch lookup table: {}",
+                                sanitize_error!(e)
+                            ))
+                        },
+                    )?;
+
+                for (miss_pubkey, account) in misses.into_iter().zip(lookup_table_accounts) {
+                    let address_lookup_table = AddressLookupTable::deserialize(&account.data)
+                        .map_err(|e| {
+                            KoraError::InvalidTransaction(format!(
+                                "Failed to deserialize lookup table: {}",
+                                sanitize_error!(e)
+                            ))
+                        })?;
+                    cache.insert(miss_pubkey, address_lookup_table.addresses.into_owned());
+                }
+            }
+
+            for lookup in lookup_table_lookups {
+                full_address_lists.push(
+                    cache
+                        .get(&lookup.account_key)
+                        .ok_or_else(|| {
+                            KoraError::RpcError(format!(
+                                "Failed to fetch lookup table: {}",
+                                lookup.account_key
+                            ))
+                        })?
+                        .clone(),
+                );
+            }
+        } else {
+            let mut pubkeys_set = HashSet::new();
+            for lookup in lookup_table_lookups {
+                pubkeys_set.insert(lookup.account_key);
+            }
+            let pubkeys: Vec<Pubkey> = pubkeys_set.into_iter().collect();
+
+            let lookup_table_accounts = CacheUtil::get_multiple_accounts(
+                config, rpc_client, &pubkeys,
+            )
+            .await
+            .map_err(|e| {
                 KoraError::RpcError(format!("Failed to fetch lookup table: {}", sanitize_error!(e)))
             })?;
 
-        for (lookup, lookup_table_account) in
-            lookup_table_lookups.iter().zip(lookup_table_accounts.iter())
-        {
-            // Parse the lookup table account data to get the actual addresses
-            let address_lookup_table = AddressLookupTable::deserialize(&lookup_table_account.data)
-                .map_err(|e| {
-                    KoraError::InvalidTransaction(format!(
-                        "Failed to deserialize lookup table: {}",
-                        sanitize_error!(e)
-                    ))
-                })?;
+            let mut fetched_cache = HashMap::new();
+            for (pubkey, account) in pubkeys.into_iter().zip(lookup_table_accounts) {
+                let address_lookup_table =
+                    AddressLookupTable::deserialize(&account.data).map_err(|e| {
+                        KoraError::InvalidTransaction(format!(
+                            "Failed to deserialize lookup table: {}",
+                            sanitize_error!(e)
+                        ))
+                    })?;
+                fetched_cache.insert(pubkey, address_lookup_table.addresses.into_owned());
+            }
 
+            for lookup in lookup_table_lookups {
+                full_address_lists.push(
+                    fetched_cache
+                        .get(&lookup.account_key)
+                        .ok_or_else(|| {
+                            KoraError::RpcError(format!(
+                                "Failed to fetch lookup table: {}",
+                                lookup.account_key
+                            ))
+                        })?
+                        .clone(),
+                );
+            }
+        }
+
+        for (lookup, addresses) in lookup_table_lookups.iter().zip(full_address_lists.iter()) {
             // Resolve writable addresses
             for &index in &lookup.writable_indexes {
-                if let Some(address) = address_lookup_table.addresses.get(index as usize) {
+                if let Some(address) = addresses.get(index as usize) {
                     resolved_addresses.push(*address);
                 } else {
                     return Err(KoraError::InvalidTransaction(format!(
@@ -688,7 +763,7 @@ impl LookupTableUtil {
 
             // Resolve readonly addresses
             for &index in &lookup.readonly_indexes {
-                if let Some(address) = address_lookup_table.addresses.get(index as usize) {
+                if let Some(address) = addresses.get(index as usize) {
                     resolved_addresses.push(*address);
                 } else {
                     return Err(KoraError::InvalidTransaction(format!(
@@ -1078,6 +1153,7 @@ mod tests {
             &config,
             &rpc_client,
             true,
+            None,
         )
         .await
         .unwrap();
@@ -1186,6 +1262,7 @@ mod tests {
             &config,
             &rpc_client,
             true,
+            None,
         )
         .await
         .unwrap();
@@ -1235,6 +1312,7 @@ mod tests {
             &config,
             &rpc_client,
             true,
+            None,
         )
         .await;
 
@@ -1434,7 +1512,7 @@ mod tests {
         }];
 
         let resolved_addresses =
-            LookupTableUtil::resolve_lookup_table_addresses(&config, &rpc_client, &lookups)
+            LookupTableUtil::resolve_lookup_table_addresses(&config, &rpc_client, &lookups, None)
                 .await
                 .unwrap();
 
@@ -1453,7 +1531,7 @@ mod tests {
         let lookups = vec![];
 
         let resolved_addresses =
-            LookupTableUtil::resolve_lookup_table_addresses(&config, &rpc_client, &lookups)
+            LookupTableUtil::resolve_lookup_table_addresses(&config, &rpc_client, &lookups, None)
                 .await
                 .unwrap();
 
@@ -1473,7 +1551,8 @@ mod tests {
         }];
 
         let result =
-            LookupTableUtil::resolve_lookup_table_addresses(&config, &rpc_client, &lookups).await;
+            LookupTableUtil::resolve_lookup_table_addresses(&config, &rpc_client, &lookups, None)
+                .await;
         assert!(matches!(result, Err(KoraError::RpcError(_))));
 
         if let Err(KoraError::RpcError(msg)) = result {
@@ -1519,7 +1598,8 @@ mod tests {
         }];
 
         let result =
-            LookupTableUtil::resolve_lookup_table_addresses(&config, &rpc_client, &lookups).await;
+            LookupTableUtil::resolve_lookup_table_addresses(&config, &rpc_client, &lookups, None)
+                .await;
         assert!(matches!(result, Err(KoraError::InvalidTransaction(_))));
 
         if let Err(KoraError::InvalidTransaction(msg)) = result {
@@ -1565,12 +1645,55 @@ mod tests {
         }];
 
         let result =
-            LookupTableUtil::resolve_lookup_table_addresses(&config, &rpc_client, &lookups).await;
+            LookupTableUtil::resolve_lookup_table_addresses(&config, &rpc_client, &lookups, None)
+                .await;
         assert!(matches!(result, Err(KoraError::InvalidTransaction(_))));
 
         if let Err(KoraError::InvalidTransaction(msg)) = result {
             assert!(msg.contains("index 5 out of bounds"));
             assert!(msg.contains("readonly addresses"));
         }
+    }
+
+    #[tokio::test]
+    async fn test_resolve_lookup_table_addresses_reuses_cache() {
+        let config = setup_test_config();
+        let _m = setup_config_mock(config.clone());
+
+        let lookup_account_key = Pubkey::new_unique();
+        let address1 = Pubkey::new_unique();
+        let address2 = Pubkey::new_unique();
+
+        let mut alt_cache: HashMap<Pubkey, Vec<Pubkey>> = HashMap::new();
+        alt_cache.insert(lookup_account_key, vec![address1, address2]);
+
+        // Mock builder with no get_multiple_accounts mocked. If it hits RPC, it will fail/panic.
+        let rpc_client = RpcMockBuilder::new().build();
+
+        let lookups = vec![
+            solana_message::v0::MessageAddressTableLookup {
+                account_key: lookup_account_key,
+                writable_indexes: vec![0],
+                readonly_indexes: vec![],
+            },
+            solana_message::v0::MessageAddressTableLookup {
+                account_key: lookup_account_key,
+                writable_indexes: vec![],
+                readonly_indexes: vec![1],
+            },
+        ];
+
+        let resolved_addresses = LookupTableUtil::resolve_lookup_table_addresses(
+            &config,
+            &rpc_client,
+            &lookups,
+            Some(&mut alt_cache),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(resolved_addresses.len(), 2);
+        assert_eq!(resolved_addresses[0], address1);
+        assert_eq!(resolved_addresses[1], address2);
     }
 }

--- a/crates/lib/src/transaction/versioned_transaction.rs
+++ b/crates/lib/src/transaction/versioned_transaction.rs
@@ -661,9 +661,6 @@ impl LookupTableUtil {
             return Ok(resolved_addresses);
         }
 
-        let mut full_address_lists: Vec<Vec<Pubkey>> =
-            Vec::with_capacity(lookup_table_lookups.len());
-
         let mut local = HashMap::new();
         let cache = alt_cache.unwrap_or(&mut local);
 
@@ -697,21 +694,10 @@ impl LookupTableUtil {
         }
 
         for lookup in lookup_table_lookups {
-            full_address_lists.push(
-                cache
-                    .get(&lookup.account_key)
-                    .ok_or_else(|| {
-                        KoraError::RpcError(format!(
-                            "Failed to fetch lookup table: {}",
-                            lookup.account_key
-                        ))
-                    })?
-                    .clone(),
-            );
-        }
+            let addresses = cache.get(&lookup.account_key).ok_or_else(|| {
+                KoraError::RpcError(format!("Failed to fetch lookup table: {}", lookup.account_key))
+            })?;
 
-        for (lookup, addresses) in lookup_table_lookups.iter().zip(full_address_lists.iter()) {
-            // Resolve writable addresses
             for &index in &lookup.writable_indexes {
                 if let Some(address) = addresses.get(index as usize) {
                     resolved_addresses.push(*address);
@@ -722,7 +708,6 @@ impl LookupTableUtil {
                 }
             }
 
-            // Resolve readonly addresses
             for &index in &lookup.readonly_indexes {
                 if let Some(address) = addresses.get(index as usize) {
                     resolved_addresses.push(*address);

--- a/crates/lib/src/transaction/versioned_transaction.rs
+++ b/crates/lib/src/transaction/versioned_transaction.rs
@@ -46,6 +46,8 @@ use solana_address_lookup_table_interface::state::AddressLookupTable;
 
 use super::retry_util::sign_with_retry;
 
+type AltCache<'a> = Option<&'a mut HashMap<Pubkey, Vec<Pubkey>>>;
+
 /// A fully resolved transaction with lookup tables and inner instructions resolved
 pub struct VersionedTransactionResolved {
     pub transaction: VersionedTransaction,
@@ -137,7 +139,7 @@ impl VersionedTransactionResolved {
         config: &Config,
         rpc_client: &RpcClient,
         sig_verify: bool,
-        alt_cache: Option<&mut HashMap<Pubkey, Vec<Pubkey>>>,
+        alt_cache: AltCache<'_>,
     ) -> Result<Self, KoraError> {
         let mut resolved = Self {
             transaction: transaction.clone(),
@@ -651,7 +653,7 @@ impl LookupTableUtil {
         config: &Config,
         rpc_client: &RpcClient,
         lookup_table_lookups: &[MessageAddressTableLookup],
-        alt_cache: Option<&mut HashMap<Pubkey, Vec<Pubkey>>>,
+        alt_cache: AltCache<'_>,
     ) -> Result<Vec<Pubkey>, KoraError> {
         let mut resolved_addresses = Vec::new();
 
@@ -662,68 +664,27 @@ impl LookupTableUtil {
         let mut full_address_lists: Vec<Vec<Pubkey>> =
             Vec::with_capacity(lookup_table_lookups.len());
 
-        if let Some(cache) = alt_cache {
-            let mut misses_set = HashSet::new();
-            for lookup in lookup_table_lookups {
-                if !cache.contains_key(&lookup.account_key) {
-                    misses_set.insert(lookup.account_key);
-                }
-            }
-            let misses: Vec<Pubkey> = misses_set.into_iter().collect();
+        let mut local = HashMap::new();
+        let cache = alt_cache.unwrap_or(&mut local);
 
-            if !misses.is_empty() {
-                let lookup_table_accounts =
-                    CacheUtil::get_multiple_accounts(config, rpc_client, &misses).await.map_err(
-                        |e| {
-                            KoraError::RpcError(format!(
-                                "Failed to fetch lookup table: {}",
-                                sanitize_error!(e)
-                            ))
-                        },
-                    )?;
-
-                for (miss_pubkey, account) in misses.into_iter().zip(lookup_table_accounts) {
-                    let address_lookup_table = AddressLookupTable::deserialize(&account.data)
-                        .map_err(|e| {
-                            KoraError::InvalidTransaction(format!(
-                                "Failed to deserialize lookup table: {}",
-                                sanitize_error!(e)
-                            ))
-                        })?;
-                    cache.insert(miss_pubkey, address_lookup_table.addresses.into_owned());
-                }
+        let mut misses_set = HashSet::new();
+        for lookup in lookup_table_lookups {
+            if !cache.contains_key(&lookup.account_key) {
+                misses_set.insert(lookup.account_key);
             }
+        }
+        let misses: Vec<Pubkey> = misses_set.into_iter().collect();
 
-            for lookup in lookup_table_lookups {
-                full_address_lists.push(
-                    cache
-                        .get(&lookup.account_key)
-                        .ok_or_else(|| {
-                            KoraError::RpcError(format!(
-                                "Failed to fetch lookup table: {}",
-                                lookup.account_key
-                            ))
-                        })?
-                        .clone(),
-                );
-            }
-        } else {
-            let mut pubkeys_set = HashSet::new();
-            for lookup in lookup_table_lookups {
-                pubkeys_set.insert(lookup.account_key);
-            }
-            let pubkeys: Vec<Pubkey> = pubkeys_set.into_iter().collect();
-
+        if !misses.is_empty() {
             let lookup_table_accounts = CacheUtil::get_multiple_accounts(
-                config, rpc_client, &pubkeys,
+                config, rpc_client, &misses,
             )
             .await
             .map_err(|e| {
                 KoraError::RpcError(format!("Failed to fetch lookup table: {}", sanitize_error!(e)))
             })?;
 
-            let mut fetched_cache = HashMap::new();
-            for (pubkey, account) in pubkeys.into_iter().zip(lookup_table_accounts) {
+            for (miss_pubkey, account) in misses.into_iter().zip(lookup_table_accounts) {
                 let address_lookup_table =
                     AddressLookupTable::deserialize(&account.data).map_err(|e| {
                         KoraError::InvalidTransaction(format!(
@@ -731,22 +692,22 @@ impl LookupTableUtil {
                             sanitize_error!(e)
                         ))
                     })?;
-                fetched_cache.insert(pubkey, address_lookup_table.addresses.into_owned());
+                cache.insert(miss_pubkey, address_lookup_table.addresses.into_owned());
             }
+        }
 
-            for lookup in lookup_table_lookups {
-                full_address_lists.push(
-                    fetched_cache
-                        .get(&lookup.account_key)
-                        .ok_or_else(|| {
-                            KoraError::RpcError(format!(
-                                "Failed to fetch lookup table: {}",
-                                lookup.account_key
-                            ))
-                        })?
-                        .clone(),
-                );
-            }
+        for lookup in lookup_table_lookups {
+            full_address_lists.push(
+                cache
+                    .get(&lookup.account_key)
+                    .ok_or_else(|| {
+                        KoraError::RpcError(format!(
+                            "Failed to fetch lookup table: {}",
+                            lookup.account_key
+                        ))
+                    })?
+                    .clone(),
+            );
         }
 
         for (lookup, addresses) in lookup_table_lookups.iter().zip(full_address_lists.iter()) {


### PR DESCRIPTION
V0 transactions resolved ALTs one at a time via `CacheUtil::get_account`, with a TODO comment noting caching was never added. Bundles re-resolved the same ALT for every transaction that referenced it.
 
- Added `CacheUtil::get_multiple_accounts` cache-aware batch fetch using Redis `mget` + RPC `get_multiple_accounts` for misses
- `resolve_lookup_table_addresses` now batches all ALT pubkeys into one call instead of looping; both paths deduplicate via `HashSet` before fetching
- Bundle processing shares one `AltCache` (`HashMap<Pubkey, Vec<Pubkey>>`) across all transactions in the same bundle repeated ALT fetched once per bundle, not once per tx. Single-transaction RPC handlers unaffected (pass `None`)
- Deduped miss pubkeys before batch fetch (same ALT referenced twice in one tx)
- Cache partial results before returning error successfully fetched accounts are written to Redis even if one account in the batch is missing