### PR TITLE
ci: publish rolling edge Docker image on push to main

### DIFF
--- a/.github/workflows/docker-edge.yml
+++ b/.github/workflows/docker-edge.yml
@@ -1,0 +1,57 @@
+# Build + publish a rolling edge image on every push to main, so downstream deploys can track
+# the latest main (features not yet in a tagged release). Tags: `edge` and the short commit SHA.
+name: Publish Edge Docker Image
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: docker-edge
+  cancel-in-progress: true
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  publish-edge:
+    name: Build and publish edge image
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=edge
+            type=sha,prefix=,format=short
+
+      - name: Build and push
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/docker-edge.yml
+++ b/.github/workflows/docker-edge.yml
@@ -24,13 +24,13 @@ jobs:
     name: Build and publish edge image
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: docker/setup-qemu-action@v3
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-qemu-action@v4
+      - uses: docker/setup-buildx-action@v4
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4.2.0
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}


### PR DESCRIPTION
Adds `docker-edge.yml` — builds + pushes `ghcr.io/solana-foundation/kora:edge` (and `:<short-sha>`) on every push to `main`.

**Why:** downstream deployments (e.g. SDP's Kora paymaster) need features that are on `main` but not yet in a tagged release (`gcp_kms` signer, `KORA_REDIS_URL`), and today must build Kora from source. A rolling `:edge` image lets them track `main` directly.

- GitHub-hosted (`ubuntu-latest`), multi-arch (amd64/arm64), `gha` build cache.
- Complements `docker-publish.yml` (which publishes release-tagged + `latest`/`beta`). This only adds `edge`/`sha` from `main`; no change to the release flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)