### PR TITLE
fix(cli): exit with status 1 on config validation failure

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -124,25 +124,28 @@ async fn main() -> Result<(), KoraError> {
 
     match cli.command {
         Some(Commands::Config { config_command }) => {
-            match config_command {
+            let validation_result = match config_command {
                 ConfigCommands::Validate { signers_config } => {
-                    let _ = ConfigValidator::validate_with_result_and_signers(
+                    ConfigValidator::validate_with_result_and_signers(
                         rpc_client.as_ref(),
                         true,
                         signers_config.as_ref(),
                     )
-                    .await;
+                    .await
                 }
                 ConfigCommands::ValidateWithRpc { signers_config } => {
-                    let _ = ConfigValidator::validate_with_result_and_signers(
+                    ConfigValidator::validate_with_result_and_signers(
                         rpc_client.as_ref(),
                         false,
                         signers_config.as_ref(),
                     )
-                    .await;
+                    .await
                 }
+            };
+            match validation_result {
+                Ok(_) => std::process::exit(0),
+                Err(_) => std::process::exit(1),
             }
-            std::process::exit(0);
         }
         Some(Commands::Rpc { rpc_command }) => {
             match rpc_command {

--- a/crates/cli/tests/integration_tests.rs
+++ b/crates/cli/tests/integration_tests.rs
@@ -1,0 +1,35 @@
+use std::{fs::File, io::Write, process::Command};
+
+#[test]
+fn test_config_validate_invalid_config_file() {
+    let temp_dir = std::env::temp_dir();
+    let config_path = temp_dir.join(format!("test_invalid_config_{}.toml", std::process::id()));
+
+    // Load default config and inject invalid pubkey to trigger validation error
+    let base_config_path =
+        std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../kora.toml");
+    let base_config = std::fs::read_to_string(base_config_path).unwrap();
+    let config_content = base_config.replace(
+        "allowed_programs = [",
+        "allowed_programs = [\n    \"invalid_pubkey_format_that_will_fail\",",
+    );
+
+    let mut file = File::create(&config_path).unwrap();
+    file.write_all(config_content.as_bytes()).unwrap();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_kora"))
+        .arg("--config")
+        .arg(&config_path)
+        .arg("config")
+        .arg("validate")
+        .output()
+        .unwrap();
+
+    let _ = std::fs::remove_file(&config_path);
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("Configuration validation failed"));
+
+    // Expected current behavior (bug): process exits with 0 despite validation failure
+    assert!(output.status.success());
+}

--- a/crates/cli/tests/integration_tests.rs
+++ b/crates/cli/tests/integration_tests.rs
@@ -29,7 +29,5 @@ fn test_config_validate_invalid_config_file() {
 
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("Configuration validation failed"));
-
-    // Expected current behavior (bug): process exits with 0 despite validation failure
-    assert!(output.status.success());
+    assert!(!output.status.success());
 }

--- a/crates/cli/tests/integration_tests.rs
+++ b/crates/cli/tests/integration_tests.rs
@@ -8,10 +8,18 @@ fn test_config_validate_invalid_config_file() {
     // Load default config and inject invalid pubkey to trigger validation error
     let base_config_path =
         std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../kora.toml");
-    let base_config = std::fs::read_to_string(base_config_path).unwrap();
+
+    let base_config = std::fs::read_to_string(&base_config_path)
+        .expect("kora.toml must exist at repo root to run this test");
+
     let config_content = base_config.replace(
         "allowed_programs = [",
         "allowed_programs = [\n    \"invalid_pubkey_format_that_will_fail\",",
+    );
+
+    assert!(
+        config_content.contains("invalid_pubkey_format_that_will_fail"),
+        "Injection guard failed: The string 'allowed_programs = [' was not found in kora.toml."
     );
 
     let mut file = File::create(&config_path).unwrap();


### PR DESCRIPTION
The `config validate` and `config validate-with-rpc` commands previously discarded the validation `Result` and unconditionally exited with `0`, masking configuration errors from CI/CD and deployment scripts.

Changes:

 - Refactored the `Commands::Config` to pattern match the validation result.
 - Command now exits with status `1` on `Err,` aligning behavior with the existing `rpc start` command.