### PR TITLE
chore: update codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,5 @@
-* @dev-jodee @amilz
+* @dev-jodee
+
+# TypeScript SDKs
+/sdks/ @amilz
+*.ts @amilz


### PR DESCRIPTION
move amilz to ts only