### PR TITLE
fix(usage-limit): make multi-rule limit enforcement all-or-nothing

### DIFF
--- a/crates/lib/src/usage_limit/usage_store.rs
+++ b/crates/lib/src/usage_limit/usage_store.rs
@@ -29,6 +29,12 @@ pub trait UsageStore: Send + Sync {
         expiry: Option<u64>,
     ) -> Result<bool, KoraError>;
 
+    /// `entries` must contain distinct keys; duplicate keys produce undefined increment behaviour.
+    async fn check_and_increment_many(
+        &self,
+        entries: &[(String, u64, u64, Option<u64>)],
+    ) -> Result<bool, KoraError>;
+
     /// Clear all usage data (mainly for testing)
     async fn clear(&self) -> Result<(), KoraError>;
 }
@@ -44,6 +50,31 @@ static CHECK_AND_INCREMENT_SCRIPT: Lazy<redis::Script> = Lazy::new(|| {
             redis.call('INCRBY', KEYS[1], ARGV[1])
             if ARGV[3] ~= '0' and redis.call('TTL', KEYS[1]) < 0 then
                 redis.call('EXPIREAT', KEYS[1], ARGV[3])
+            end
+            return 1
+            ",
+    )
+});
+
+/// Atomically checks limits for multiple rules and increments only if all pass.
+static CHECK_AND_INCREMENT_MANY_SCRIPT: Lazy<redis::Script> = Lazy::new(|| {
+    redis::Script::new(
+        r"
+            local num_keys = #KEYS
+            for i = 1, num_keys do
+                local current = redis.call('GET', KEYS[i])
+                local count = current and tonumber(current) or 0
+                local delta = tonumber(ARGV[(i - 1) * 3 + 1])
+                local max = tonumber(ARGV[(i - 1) * 3 + 2])
+                if count + delta > max then return 0 end
+            end
+            for i = 1, num_keys do
+                local delta = tonumber(ARGV[(i - 1) * 3 + 1])
+                local expiry = ARGV[(i - 1) * 3 + 3]
+                redis.call('INCRBY', KEYS[i], delta)
+                if expiry ~= '0' and redis.call('TTL', KEYS[i]) < 0 then
+                    redis.call('EXPIREAT', KEYS[i], expiry)
+                end
             end
             return 1
             ",
@@ -140,6 +171,35 @@ impl UsageStore for RedisUsageStore {
                     e
                 )))
             })?;
+
+        Ok(allowed == 1)
+    }
+
+    async fn check_and_increment_many(
+        &self,
+        entries: &[(String, u64, u64, Option<u64>)],
+    ) -> Result<bool, KoraError> {
+        if entries.is_empty() {
+            return Ok(true);
+        }
+
+        let mut conn = self.get_connection().await?;
+        let mut inv = CHECK_AND_INCREMENT_MANY_SCRIPT.key(&entries[0].0);
+
+        for (key, _, _, _) in entries.iter().skip(1) {
+            inv.key(key);
+        }
+
+        for (_, delta, max, expiry) in entries {
+            inv.arg(*delta).arg(*max).arg(expiry.unwrap_or(0));
+        }
+
+        let allowed: i32 = inv.invoke_async(&mut conn).await.map_err(|e| {
+            KoraError::InternalServerError(sanitize_error!(format!(
+                "Failed to execute check_and_increment_many script: {}",
+                e
+            )))
+        })?;
 
         Ok(allowed == 1)
     }
@@ -281,6 +341,60 @@ impl UsageStore for InMemoryUsageStore {
         Ok(true)
     }
 
+    async fn check_and_increment_many(
+        &self,
+        entries: &[(String, u64, u64, Option<u64>)],
+    ) -> Result<bool, KoraError> {
+        let mut data = self.data.lock().map_err(|e| {
+            KoraError::InternalServerError(sanitize_error!(format!(
+                "Failed to lock usage store: {}",
+                e
+            )))
+        })?;
+
+        let now = Self::current_timestamp();
+
+        for (key, delta, max, _expiry) in entries {
+            let current_count = if let Some(entry) = data.get(key) {
+                if let Some(e) = entry.expiry {
+                    if now >= e {
+                        0
+                    } else {
+                        entry.count
+                    }
+                } else {
+                    entry.count
+                }
+            } else {
+                0
+            };
+
+            let new_count = current_count as u64 + delta;
+            if new_count > *max || new_count > u32::MAX as u64 {
+                return Ok(false);
+            }
+        }
+
+        for (key, delta, _max, expiry) in entries {
+            let entry =
+                data.entry(key.to_string()).or_insert(UsageEntry { count: 0, expiry: None });
+            if let Some(e) = entry.expiry {
+                if now >= e {
+                    entry.count = 0;
+                    entry.expiry = None;
+                }
+            }
+            entry.count += *delta as u32;
+            if let Some(e) = expiry {
+                if entry.expiry.is_none() {
+                    entry.expiry = Some(*e);
+                }
+            }
+        }
+
+        Ok(true)
+    }
+
     async fn clear(&self) -> Result<(), KoraError> {
         let mut data = self.data.lock().map_err(|e| {
             KoraError::InternalServerError(sanitize_error!(format!(
@@ -340,6 +454,17 @@ impl UsageStore for ErrorUsageStore {
         _delta: u64,
         _max: u64,
         _expiry: Option<u64>,
+    ) -> Result<bool, KoraError> {
+        if self.should_error_increment {
+            Err(KoraError::InternalServerError("Redis connection failed".to_string()))
+        } else {
+            Ok(true)
+        }
+    }
+
+    async fn check_and_increment_many(
+        &self,
+        _entries: &[(String, u64, u64, Option<u64>)],
     ) -> Result<bool, KoraError> {
         if self.should_error_increment {
             Err(KoraError::InternalServerError("Redis connection failed".to_string()))

--- a/crates/lib/src/usage_limit/usage_store.rs
+++ b/crates/lib/src/usage_limit/usage_store.rs
@@ -356,12 +356,8 @@ impl UsageStore for InMemoryUsageStore {
 
         for (key, delta, max, _expiry) in entries {
             let current_count = if let Some(entry) = data.get(key) {
-                if let Some(e) = entry.expiry {
-                    if now >= e {
-                        0
-                    } else {
-                        entry.count
-                    }
+                if entry.expiry.is_some_and(|e| now >= e) {
+                    0
                 } else {
                     entry.count
                 }

--- a/crates/lib/src/usage_limit/usage_store.rs
+++ b/crates/lib/src/usage_limit/usage_store.rs
@@ -30,6 +30,7 @@ pub trait UsageStore: Send + Sync {
     ) -> Result<bool, KoraError>;
 
     /// `entries` must contain distinct keys; duplicate keys produce undefined increment behaviour.
+    /// Note: this default impl is intentionally non-atomic — override for atomic guarantees.
     async fn check_and_increment_many(
         &self,
         entries: &[(String, u64, u64, Option<u64>)],

--- a/crates/lib/src/usage_limit/usage_store.rs
+++ b/crates/lib/src/usage_limit/usage_store.rs
@@ -33,7 +33,14 @@ pub trait UsageStore: Send + Sync {
     async fn check_and_increment_many(
         &self,
         entries: &[(String, u64, u64, Option<u64>)],
-    ) -> Result<bool, KoraError>;
+    ) -> Result<bool, KoraError> {
+        for (key, delta, max, expiry) in entries {
+            if !self.check_and_increment(key, *delta, *max, *expiry).await? {
+                return Ok(false);
+            }
+        }
+        Ok(true)
+    }
 
     /// Clear all usage data (mainly for testing)
     async fn clear(&self) -> Result<(), KoraError>;
@@ -477,6 +484,8 @@ impl UsageStore for ErrorUsageStore {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use deadpool_redis::{Config, Runtime};
+    use std::env;
 
     #[tokio::test]
     async fn test_in_memory_usage_store() {
@@ -502,5 +511,47 @@ mod tests {
         store.clear().await.unwrap();
         assert_eq!(store.get("wallet1").await.unwrap(), 0);
         assert_eq!(store.get("wallet2").await.unwrap(), 0);
+    }
+
+    // Run with: KORA_REDIS_URL="redis://127.0.0.1:6379" cargo test -p kora-lib test_redis -- --include-ignored
+    #[tokio::test]
+    #[ignore]
+    async fn test_redis_check_and_increment() {
+        let redis_url = env::var("KORA_REDIS_URL")
+            .expect("KORA_REDIS_URL must be set to run Redis integration tests");
+
+        let cfg = Config::from_url(redis_url);
+        let pool = cfg.create_pool(Some(Runtime::Tokio1)).unwrap();
+        let store = RedisUsageStore::new(pool);
+        store.clear().await.unwrap();
+
+        assert!(store.check_and_increment("key", 1, 2, None).await.unwrap());
+        assert!(store.check_and_increment("key", 1, 2, None).await.unwrap());
+
+        assert!(!store.check_and_increment("key", 1, 2, None).await.unwrap());
+        assert_eq!(store.get("key").await.unwrap(), 2);
+    }
+
+    // Run with: KORA_REDIS_URL="redis://127.0.0.1:6379" cargo test -p kora-lib test_redis -- --include-ignored
+    #[tokio::test]
+    #[ignore]
+    async fn test_redis_check_and_increment_many_all_or_nothing() {
+        let redis_url = env::var("KORA_REDIS_URL")
+            .expect("KORA_REDIS_URL must be set to run Redis integration tests");
+
+        let cfg = Config::from_url(redis_url);
+        let pool = cfg.create_pool(Some(Runtime::Tokio1)).unwrap();
+        let store = RedisUsageStore::new(pool);
+        store.clear().await.unwrap();
+
+        let entries = vec![("rkey1".to_string(), 1, 5, None), ("rkey2".to_string(), 1, 1, None)];
+
+        assert!(store.check_and_increment_many(&entries).await.unwrap());
+        assert_eq!(store.get("rkey1").await.unwrap(), 1);
+        assert_eq!(store.get("rkey2").await.unwrap(), 1);
+
+        assert!(!store.check_and_increment_many(&entries).await.unwrap());
+        assert_eq!(store.get("rkey1").await.unwrap(), 1);
+        assert_eq!(store.get("rkey2").await.unwrap(), 1);
     }
 }

--- a/crates/lib/src/usage_limit/usage_tracker.rs
+++ b/crates/lib/src/usage_limit/usage_tracker.rs
@@ -242,8 +242,7 @@ impl UsageTracker {
     }
 
     /// Check and record usage for a transaction.
-    /// Pre-checks all rules before incrementing; denied requests may still
-    /// consume quota from earlier rules under concurrent load.
+    /// Uses batch checking for all-or-nothing increments across multiple rules.
     async fn check_and_record(
         &self,
         ctx: &mut LimiterContext<'_>,
@@ -314,10 +313,13 @@ impl UsageTracker {
             pending_increments.push((key, increment_count, max, expiry, description));
         }
 
-        for (key, increment_count, max, expiry, description) in pending_increments {
-            if !self.store.check_and_increment(&key, increment_count, max, expiry).await? {
+        if !pending_increments.is_empty() {
+            let entries: Vec<_> =
+                pending_increments.iter().map(|(k, d, m, e, _)| (k.clone(), *d, *m, *e)).collect();
+
+            if !self.store.check_and_increment_many(&entries).await? {
                 return Ok(LimiterResult::Denied {
-                    reason: format!("User {} exceeded {} limit", ctx.user_id, description),
+                    reason: format!("User {} exceeded usage limit", ctx.user_id),
                 });
             }
         }
@@ -532,6 +534,14 @@ mod tests {
         ) -> Result<bool, KoraError> {
             tokio::task::yield_now().await;
             self.inner.check_and_increment(key, delta, max, expiry).await
+        }
+
+        async fn check_and_increment_many(
+            &self,
+            entries: &[(String, u64, u64, Option<u64>)],
+        ) -> Result<bool, KoraError> {
+            tokio::task::yield_now().await;
+            self.inner.check_and_increment_many(entries).await
         }
     }
 
@@ -1147,8 +1157,28 @@ mod tests {
 
         let lifetime_key = "kora:tx:multi-rule-concurrent-user";
         let lifetime_count = store.get(lifetime_key).await.unwrap();
-        // denied requests may have consumed quota from earlier rules
-        assert!(lifetime_count <= 10);
-        assert!(lifetime_count >= allowed_count as u32);
+        assert_eq!(lifetime_count, allowed_count as u32);
+    }
+
+    #[tokio::test]
+    async fn test_check_and_increment_many_all_or_nothing() {
+        let store = InMemoryUsageStore::new();
+
+        let entries = vec![("key1".to_string(), 1, 5, None), ("key2".to_string(), 1, 1, None)];
+
+        // First call should succeed
+        let result1 = store.check_and_increment_many(&entries).await.unwrap();
+        assert!(result1);
+
+        assert_eq!(store.get("key1").await.unwrap(), 1);
+        assert_eq!(store.get("key2").await.unwrap(), 1);
+
+        // Second call should fail because key2 would exceed its max of 1
+        let result2 = store.check_and_increment_many(&entries).await.unwrap();
+        assert!(!result2);
+
+        // All-or-nothing: key1 should not be incremented
+        assert_eq!(store.get("key1").await.unwrap(), 1);
+        assert_eq!(store.get("key2").await.unwrap(), 1);
     }
 }

--- a/crates/lib/src/usage_limit/usage_tracker.rs
+++ b/crates/lib/src/usage_limit/usage_tracker.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashSet, sync::Arc, time::SystemTime};
+use std::{cmp::min, collections::HashSet, sync::Arc, time::SystemTime};
 
 use super::{
     limiter::{LimiterContext, LimiterResult},
@@ -314,10 +314,37 @@ impl UsageTracker {
         }
 
         if !pending_increments.is_empty() {
+            let mut unique_pending = Vec::new();
+            for (key, delta, max, expiry, desc) in pending_increments {
+                if let Some(existing) = unique_pending.iter_mut().find(
+                    |(k, _, _, _, _): &&mut (String, u64, u64, Option<u64>, String)| *k == key,
+                ) {
+                    existing.1 += delta;
+                    existing.2 = min(existing.2, max);
+                } else {
+                    unique_pending.push((key, delta, max, expiry, desc));
+                }
+            }
+            let pending_increments = unique_pending;
+
             let entries: Vec<_> =
                 pending_increments.iter().map(|(k, d, m, e, _)| (k.clone(), *d, *m, *e)).collect();
 
             if !self.store.check_and_increment_many(&entries).await? {
+                for (key, delta, max, _expiry, description) in &pending_increments {
+                    let current = self.store.get(key).await?;
+                    if current as u64 + delta > *max {
+                        return Ok(LimiterResult::Denied {
+                            reason: format!(
+                                "User {} exceeded {} limit: {}/{}",
+                                ctx.user_id,
+                                description,
+                                current as u64 + delta,
+                                max
+                            ),
+                        });
+                    }
+                }
                 return Ok(LimiterResult::Denied {
                     reason: format!("User {} exceeded usage limit", ctx.user_id),
                 });


### PR DESCRIPTION
Sequential `check_and_increment` calls per rule left earlier rules incremented when a later rule denied denied requests could silently consume quota under concurrent load.

* Added `check_and_increment_many` to `UsageStore` trait with atomic Redis (Lua) and in-memory (single mutex) backends; default impl keeps external implementations from breaking
* `check_and_record` deduplicates entries by key and issues one batch call instead of a sequential loop
* Per-rule denial reason restored on the batch-denial path
* Added in-memory and Redis integration tests (`#[ignore]`) for both Lua scripts

Builds on #463.