### PR TITLE
fix(ci): bump builder to rust 1.89 (Solana deps require it)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # cargo-chef splits dependency compilation into a layer keyed only on the dependency manifest
 # (recipe.json), so app-source changes reuse the cached dep build instead of recompiling everything.
-FROM rust:1.88 AS chef
+FROM rust:1.89 AS chef
 RUN cargo install cargo-chef --locked
 WORKDIR /usr/src/app
 


### PR DESCRIPTION
## Problem
The edge image build on `main` fails:
```
error: rustc 1.88.0 is not supported by the following packages:
  solana-instruction-error@2.3.0 requires rustc 1.89.0
```
A transitive Solana dependency bumped its MSRV to 1.89, but the Dockerfile builder is pinned to `rust:1.88`. This breaks any image build (edge and release) regardless of cargo-chef — it just surfaced at the `cargo chef cook` step.

## Fix
Bump the builder base image `rust:1.88` → `rust:1.89`.

(Verified the failing run: https://github.com/solana-foundation/kora/actions/runs/27956770469 — fails at "Build and push" on the MSRV error.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)