### PR TITLE
fix(ci): bump builder to rust 1.91 (AWS SDK deps require it)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # cargo-chef splits dependency compilation into a layer keyed only on the dependency manifest
 # (recipe.json), so app-source changes reuse the cached dep build instead of recompiling everything.
-FROM rust:1.89 AS chef
+FROM rust:1.91 AS chef
 RUN cargo install cargo-chef --locked
 WORKDIR /usr/src/app
 


### PR DESCRIPTION
Follow-up to #573. The 1.89 bump cleared the Solana deps, but the build still fails — AWS SDK deps (`aws-smithy-*`, `aws-types@1.3.12`) require rustc 1.91. Verified 1.91 is the highest MSRV across the whole tree, so this one bump unblocks the edge/release image build.

Failing run: https://github.com/solana-foundation/kora/actions/runs/27958920095

🤖 Generated with [Claude Code](https://claude.com/claude-code)