### PR TITLE
fix: pin Docker builder to bookworm to match runtime glibc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 # cargo-chef splits dependency compilation into a layer keyed only on the dependency manifest
 # (recipe.json), so app-source changes reuse the cached dep build instead of recompiling everything.
-FROM rust:1.91 AS chef
+# Pin the builder distro to bookworm to match the runtime base below: the unsuffixed rust:1.91 image
+# now tracks Debian trixie (glibc 2.41), producing a binary that links GLIBC_2.38/2.39 — symbols the
+# debian:bookworm-slim runtime (glibc 2.36) lacks, so the container exits with a libc version error.
+FROM rust:1.91-bookworm AS chef
 RUN cargo install cargo-chef --locked
 WORKDIR /usr/src/app
 


### PR DESCRIPTION
## Problem
The edge image fails to start on Cloud Run:
```
kora: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.39' not found (required by kora)
kora: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.38' not found (required by kora)
Container called exit(1).
```

## Cause
The unsuffixed `rust:1.91` builder now tracks Debian **trixie** (glibc 2.41), so the binary links `GLIBC_2.38/2.39`. The runtime stage is `debian:bookworm-slim` (glibc **2.36**) — missing those symbols.

## Fix
Pin the builder to `rust:1.91-bookworm` so the binary links glibc 2.36, matching the bookworm runtime. Minimal, intent-preserving (keeps the existing runtime base).

🤖 Generated with [Claude Code](https://claude.com/claude-code)