### PR TITLE
feat(validation): support CreateAccountAllowPrefund instruction

### DIFF
--- a/.github/actions/setup-solana/action.yml
+++ b/.github/actions/setup-solana/action.yml
@@ -13,22 +13,20 @@ runs:
       uses: actions/cache@v4
       with:
         path: ~/.local/share/solana
-        key: solana-cli-stable-${{ runner.os }}-${{ steps.week.outputs.week }}
+        key: solana-cli-v4.0.3-${{ runner.os }}-${{ steps.week.outputs.week }}
         restore-keys: |
-          solana-cli-stable-${{ runner.os }}-
+          solana-cli-v4.0.3-${{ runner.os }}-
 
     - name: Install Solana CLI
       shell: bash
       run: |
-        # Check if already installed
-        if command -v solana &> /dev/null; then
+        if command -v solana &> /dev/null && solana --version | grep -q ' 4\.'; then
           echo "Solana CLI already installed"
           solana --version
           exit 0
         fi
-        
-        # Install Solana CLI (stable version)
-        sh -c "$(curl -sSfL https://release.anza.xyz/stable/install)"
+
+        sh -c "$(curl -sSfL https://release.anza.xyz/v4.0.3/install)"
         echo "$HOME/.local/share/solana/install/active_release/bin" >> $GITHUB_PATH
         export PATH="$HOME/.local/share/solana/install/active_release/bin:$PATH"
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -436,7 +436,7 @@ disallowed_accounts = []  # Blocked account addresses
 [validation.fee_payer_policy.system]
 allow_transfer = false           # System Transfer/TransferWithSeed
 allow_assign = false             # System Assign/AssignWithSeed
-allow_create_account = false     # System CreateAccount/CreateAccountWithSeed
+allow_create_account = false     # System CreateAccount/CreateAccountWithSeed/CreateAccountAllowPrefund
 allow_allocate = false           # System Allocate/AllocateWithSeed
 
 [validation.fee_payer_policy.system.nonce]
@@ -516,7 +516,7 @@ The fee payer policy is configured via nested sections in `kora.toml`:
 **System Program (8 controls)**:
 1. **Transfer** - Transfer and TransferWithSeed instructions (fee payer as sender)
 2. **Assign** - Assign and AssignWithSeed instructions (fee payer as authority)
-3. **CreateAccount** - CreateAccount and CreateAccountWithSeed instructions (fee payer as funding source)
+3. **CreateAccount** - CreateAccount, CreateAccountWithSeed, and CreateAccountAllowPrefund instructions (fee payer as funding source or as the account being created)
 4. **Allocate** - Allocate and AllocateWithSeed instructions (fee payer as account owner)
 5. **Nonce Initialize** - InitializeNonceAccount instruction (fee payer set as authority)
 6. **Nonce Advance** - AdvanceNonceAccount instruction (fee payer as authority)

--- a/crates/lib/src/config.rs
+++ b/crates/lib/src/config.rs
@@ -258,7 +258,8 @@ pub struct SystemInstructionPolicy {
     pub allow_transfer: bool,
     /// Allow fee payer to be the authority in System Assign/AssignWithSeed instructions
     pub allow_assign: bool,
-    /// Allow fee payer to be the payer in System CreateAccount/CreateAccountWithSeed instructions
+    /// Allow fee payer to be the funder, or the account being created, in System
+    /// CreateAccount/CreateAccountWithSeed/CreateAccountAllowPrefund instructions
     pub allow_create_account: bool,
     /// Allow fee payer to be the account in System Allocate/AllocateWithSeed instructions
     pub allow_allocate: bool,

--- a/crates/lib/src/constant.rs
+++ b/crates/lib/src/constant.rs
@@ -67,6 +67,15 @@ pub mod instruction_indexes {
         pub const NEW_ACCOUNT_INDEX: usize = 1;
     }
 
+    // CreateAccountAllowPrefund orders accounts [new, funding] and omits the funding
+    // account entirely when lamports == 0 — the reverse of system_create_account.
+    pub mod system_create_account_allow_prefund {
+        pub const MIN_REQUIRED_NUMBER_OF_ACCOUNTS: usize = 1;
+        pub const REQUIRED_NUMBER_OF_ACCOUNTS_WITH_FUNDING: usize = 2;
+        pub const NEW_ACCOUNT_INDEX: usize = 0;
+        pub const FUNDING_INDEX: usize = 1;
+    }
+
     pub mod system_transfer {
         pub const REQUIRED_NUMBER_OF_ACCOUNTS: usize = 2;
         pub const SENDER_INDEX: usize = 0;

--- a/crates/lib/src/constant.rs
+++ b/crates/lib/src/constant.rs
@@ -67,8 +67,7 @@ pub mod instruction_indexes {
         pub const NEW_ACCOUNT_INDEX: usize = 1;
     }
 
-    // CreateAccountAllowPrefund orders accounts [new, funding] and omits the funding
-    // account entirely when lamports == 0 — the reverse of system_create_account.
+    // Reverse of system_create_account: [new, funding], funding omitted when lamports == 0.
     pub mod system_create_account_allow_prefund {
         pub const MIN_REQUIRED_NUMBER_OF_ACCOUNTS: usize = 1;
         pub const REQUIRED_NUMBER_OF_ACCOUNTS_WITH_FUNDING: usize = 2;

--- a/crates/lib/src/constant.rs
+++ b/crates/lib/src/constant.rs
@@ -69,6 +69,8 @@ pub mod instruction_indexes {
 
     // Reverse of system_create_account: [new, funding], funding omitted when lamports == 0.
     pub mod system_create_account_allow_prefund {
+        // bincode variant tag; absent from solana-system-interface 2.0.0.
+        pub const DISCRIMINATOR: u32 = 13;
         pub const MIN_REQUIRED_NUMBER_OF_ACCOUNTS: usize = 1;
         pub const REQUIRED_NUMBER_OF_ACCOUNTS_WITH_FUNDING: usize = 2;
         pub const NEW_ACCOUNT_INDEX: usize = 0;

--- a/crates/lib/src/transaction/instruction_util.rs
+++ b/crates/lib/src/transaction/instruction_util.rs
@@ -2009,12 +2009,12 @@ impl IxUtils {
         Ok(parsed_instructions)
     }
 
-    // Absent from system-interface 2.0.0; decode tag 13 (tag, lamports, space, owner) by hand.
+    // Absent from system-interface 2.0.0; decode (tag, lamports, space, owner) by hand.
     fn parse_create_account_allow_prefund(data: &[u8]) -> Option<(u64, Pubkey)> {
-        const CREATE_ACCOUNT_ALLOW_PREFUND_TAG: u32 = 13;
         let (tag, lamports, _space, owner) =
             bincode::deserialize::<(u32, u64, u64, Pubkey)>(data).ok()?;
-        (tag == CREATE_ACCOUNT_ALLOW_PREFUND_TAG).then_some((lamports, owner))
+        (tag == instruction_indexes::system_create_account_allow_prefund::DISCRIMINATOR)
+            .then_some((lamports, owner))
     }
 
     pub fn parse_alt_instructions(
@@ -3430,7 +3430,10 @@ impl IxUtils {
 mod tests {
 
     use super::*;
-    use crate::transaction::versioned_transaction::VersionedTransactionResolved;
+    use crate::{
+        constant::instruction_indexes::system_create_account_allow_prefund::DISCRIMINATOR,
+        transaction::versioned_transaction::VersionedTransactionResolved,
+    };
     use solana_sdk::{
         instruction::{AccountMeta, Instruction},
         message::{AccountKeys, Message, VersionedMessage},
@@ -4359,7 +4362,7 @@ mod tests {
         Instruction {
             program_id: SYSTEM_PROGRAM_ID,
             accounts,
-            data: bincode::serialize(&(13u32, lamports, space, *owner)).unwrap(),
+            data: bincode::serialize(&(DISCRIMINATOR, lamports, space, *owner)).unwrap(),
         }
     }
 

--- a/crates/lib/src/transaction/instruction_util.rs
+++ b/crates/lib/src/transaction/instruction_util.rs
@@ -3430,9 +3430,12 @@ impl IxUtils {
 mod tests {
 
     use super::*;
+    use crate::transaction::versioned_transaction::VersionedTransactionResolved;
     use solana_sdk::{
         instruction::{AccountMeta, Instruction},
-        message::{AccountKeys, Message},
+        message::{AccountKeys, Message, VersionedMessage},
+        signature::{Keypair, Signer},
+        transaction::VersionedTransaction,
     };
     use solana_system_interface::{
         instruction::SystemInstruction, program::ID as SYSTEM_PROGRAM_ID,
@@ -4362,13 +4365,6 @@ mod tests {
 
     #[test]
     fn test_parse_system_instructions_create_account_allow_prefund() {
-        use crate::transaction::versioned_transaction::VersionedTransactionResolved;
-        use solana_message::{Message, VersionedMessage};
-        use solana_sdk::{
-            signature::{Keypair, Signer},
-            transaction::VersionedTransaction,
-        };
-
         let funder = Keypair::new();
         let new_account = Keypair::new();
         let owner = Pubkey::new_unique();
@@ -4415,13 +4411,6 @@ mod tests {
 
     #[test]
     fn test_parse_system_instructions_create_account_allow_prefund_no_funding() {
-        use crate::transaction::versioned_transaction::VersionedTransactionResolved;
-        use solana_message::{Message, VersionedMessage};
-        use solana_sdk::{
-            signature::{Keypair, Signer},
-            transaction::VersionedTransaction,
-        };
-
         // lamports == 0 omits the funding account; the new account is the only signer and
         // is recorded as the payer so policy and outflow accounting treat it consistently.
         let new_account = Keypair::new();

--- a/crates/lib/src/transaction/instruction_util.rs
+++ b/crates/lib/src/transaction/instruction_util.rs
@@ -1976,11 +1976,47 @@ impl IxUtils {
                     Ok(SystemInstruction::UpgradeNonceAccount) => {
                         // Skip parsing
                     }
-                    _ => {}
+                    _ => {
+                        if let Some((lamports, owner)) =
+                            Self::parse_create_account_allow_prefund(&instruction.data)
+                        {
+                            let min_accounts = if lamports > 0 {
+                                instruction_indexes::system_create_account_allow_prefund::REQUIRED_NUMBER_OF_ACCOUNTS_WITH_FUNDING
+                            } else {
+                                instruction_indexes::system_create_account_allow_prefund::MIN_REQUIRED_NUMBER_OF_ACCOUNTS
+                            };
+                            validate_number_accounts!(instruction, min_accounts);
+                            let new_account = instruction.accounts[instruction_indexes::system_create_account_allow_prefund::NEW_ACCOUNT_INDEX].pubkey;
+                            let payer = if lamports > 0 {
+                                instruction.accounts[instruction_indexes::system_create_account_allow_prefund::FUNDING_INDEX].pubkey
+                            } else {
+                                new_account
+                            };
+                            parsed_instructions
+                                .entry(ParsedSystemInstructionType::SystemCreateAccount)
+                                .or_default()
+                                .push(ParsedSystemInstructionData::SystemCreateAccount {
+                                    lamports,
+                                    payer,
+                                    new_account,
+                                    owner,
+                                });
+                        }
+                    }
                 }
             }
         }
         Ok(parsed_instructions)
+    }
+
+    // CreateAccountAllowPrefund is absent from solana-system-interface 2.0.0, so it fails the
+    // SystemInstruction match above. Decode its bincode wire layout directly: variant tag,
+    // lamports, space, owner. Returns lamports and owner; space is not needed downstream.
+    fn parse_create_account_allow_prefund(data: &[u8]) -> Option<(u64, Pubkey)> {
+        const CREATE_ACCOUNT_ALLOW_PREFUND_TAG: u32 = 13;
+        let (tag, lamports, _space, owner) =
+            bincode::deserialize::<(u32, u64, u64, Pubkey)>(data).ok()?;
+        (tag == CREATE_ACCOUNT_ALLOW_PREFUND_TAG).then_some((lamports, owner))
     }
 
     pub fn parse_alt_instructions(
@@ -4289,6 +4325,144 @@ mod tests {
                 assert_eq!(*parsed_payer, payer.pubkey());
                 assert_eq!(*parsed_new_account, new_account);
                 assert_eq!(*parsed_owner, owner);
+            }
+            _ => panic!("Expected SystemCreateAccount variant"),
+        }
+    }
+
+    #[test]
+    fn test_create_account_allow_prefund_bincode_tag() {
+        use solana_system_interface::instruction::SystemInstruction;
+
+        // CreateAccountAllowPrefund (tag 13) is absent from solana-system-interface 2.0.0.
+        // It is declared immediately after UpgradeNonceAccount, and bincode encodes the
+        // variant index as a u32 LE tag — so confirming UpgradeNonceAccount == 12 anchors
+        // the tag 13 the manual decoder relies on. This breaks loudly if upstream reorders.
+        let upgrade = bincode::serialize(&SystemInstruction::UpgradeNonceAccount).unwrap();
+        assert_eq!(&upgrade[0..4], &12u32.to_le_bytes());
+    }
+
+    fn build_create_account_allow_prefund_ix(
+        new_account: &Pubkey,
+        funder: &Pubkey,
+        lamports: u64,
+        space: u64,
+        owner: &Pubkey,
+    ) -> solana_sdk::instruction::Instruction {
+        use solana_sdk::instruction::{AccountMeta, Instruction};
+        use solana_system_interface::program::ID as SYSTEM_PROGRAM_ID;
+
+        let mut accounts = vec![AccountMeta::new(*new_account, true)];
+        if lamports > 0 {
+            accounts.push(AccountMeta::new(*funder, true));
+        }
+        Instruction {
+            program_id: SYSTEM_PROGRAM_ID,
+            accounts,
+            data: bincode::serialize(&(13u32, lamports, space, *owner)).unwrap(),
+        }
+    }
+
+    #[test]
+    fn test_parse_system_instructions_create_account_allow_prefund() {
+        use crate::transaction::versioned_transaction::VersionedTransactionResolved;
+        use solana_message::{Message, VersionedMessage};
+        use solana_sdk::{
+            signature::{Keypair, Signer},
+            transaction::VersionedTransaction,
+        };
+
+        let funder = Keypair::new();
+        let new_account = Keypair::new();
+        let owner = Pubkey::new_unique();
+        let lamports = 2_000_000u64;
+
+        let instruction = build_create_account_allow_prefund_ix(
+            &new_account.pubkey(),
+            &funder.pubkey(),
+            lamports,
+            165,
+            &owner,
+        );
+
+        let message =
+            VersionedMessage::Legacy(Message::new(&[instruction], Some(&funder.pubkey())));
+        let tx = VersionedTransaction::try_new(message, &[&funder, &new_account]).unwrap();
+
+        let resolved_tx = VersionedTransactionResolved::from_kora_built_transaction(&tx)
+            .expect("Failed to create resolved transaction");
+
+        let parsed_instructions = IxUtils::parse_system_instructions(&resolved_tx)
+            .expect("Failed to parse system instructions");
+
+        let creates = parsed_instructions
+            .get(&ParsedSystemInstructionType::SystemCreateAccount)
+            .expect("Expected SystemCreateAccount instructions");
+
+        assert_eq!(creates.len(), 1);
+        match &creates[0] {
+            ParsedSystemInstructionData::SystemCreateAccount {
+                lamports: parsed_lamports,
+                payer: parsed_payer,
+                new_account: parsed_new_account,
+                owner: parsed_owner,
+            } => {
+                assert_eq!(*parsed_lamports, lamports);
+                assert_eq!(*parsed_payer, funder.pubkey());
+                assert_eq!(*parsed_new_account, new_account.pubkey());
+                assert_eq!(*parsed_owner, owner);
+            }
+            _ => panic!("Expected SystemCreateAccount variant"),
+        }
+    }
+
+    #[test]
+    fn test_parse_system_instructions_create_account_allow_prefund_no_funding() {
+        use crate::transaction::versioned_transaction::VersionedTransactionResolved;
+        use solana_message::{Message, VersionedMessage};
+        use solana_sdk::{
+            signature::{Keypair, Signer},
+            transaction::VersionedTransaction,
+        };
+
+        // lamports == 0 omits the funding account; the new account is the only signer and
+        // is recorded as the payer so policy and outflow accounting treat it consistently.
+        let new_account = Keypair::new();
+        let owner = Pubkey::new_unique();
+
+        let instruction = build_create_account_allow_prefund_ix(
+            &new_account.pubkey(),
+            &new_account.pubkey(),
+            0,
+            165,
+            &owner,
+        );
+
+        let message =
+            VersionedMessage::Legacy(Message::new(&[instruction], Some(&new_account.pubkey())));
+        let tx = VersionedTransaction::try_new(message, &[&new_account]).unwrap();
+
+        let resolved_tx = VersionedTransactionResolved::from_kora_built_transaction(&tx)
+            .expect("Failed to create resolved transaction");
+
+        let parsed_instructions = IxUtils::parse_system_instructions(&resolved_tx)
+            .expect("Failed to parse system instructions");
+
+        let creates = parsed_instructions
+            .get(&ParsedSystemInstructionType::SystemCreateAccount)
+            .expect("Expected SystemCreateAccount instructions");
+
+        assert_eq!(creates.len(), 1);
+        match &creates[0] {
+            ParsedSystemInstructionData::SystemCreateAccount {
+                lamports: parsed_lamports,
+                payer: parsed_payer,
+                new_account: parsed_new_account,
+                ..
+            } => {
+                assert_eq!(*parsed_lamports, 0);
+                assert_eq!(*parsed_payer, new_account.pubkey());
+                assert_eq!(*parsed_new_account, new_account.pubkey());
             }
             _ => panic!("Expected SystemCreateAccount variant"),
         }

--- a/crates/lib/src/transaction/instruction_util.rs
+++ b/crates/lib/src/transaction/instruction_util.rs
@@ -3432,7 +3432,13 @@ impl IxUtils {
 mod tests {
 
     use super::*;
-    use solana_sdk::message::{AccountKeys, Message};
+    use solana_sdk::{
+        instruction::{AccountMeta, Instruction},
+        message::{AccountKeys, Message},
+    };
+    use solana_system_interface::{
+        instruction::SystemInstruction, program::ID as SYSTEM_PROGRAM_ID,
+    };
     use solana_transaction_status::parse_instruction;
 
     fn create_parsed_system_transfer(
@@ -4332,8 +4338,6 @@ mod tests {
 
     #[test]
     fn test_create_account_allow_prefund_bincode_tag() {
-        use solana_system_interface::instruction::SystemInstruction;
-
         // CreateAccountAllowPrefund (tag 13) is absent from solana-system-interface 2.0.0.
         // It is declared immediately after UpgradeNonceAccount, and bincode encodes the
         // variant index as a u32 LE tag — so confirming UpgradeNonceAccount == 12 anchors
@@ -4348,10 +4352,7 @@ mod tests {
         lamports: u64,
         space: u64,
         owner: &Pubkey,
-    ) -> solana_sdk::instruction::Instruction {
-        use solana_sdk::instruction::{AccountMeta, Instruction};
-        use solana_system_interface::program::ID as SYSTEM_PROGRAM_ID;
-
+    ) -> Instruction {
         let mut accounts = vec![AccountMeta::new(*new_account, true)];
         if lamports > 0 {
             accounts.push(AccountMeta::new(*funder, true));

--- a/crates/lib/src/transaction/instruction_util.rs
+++ b/crates/lib/src/transaction/instruction_util.rs
@@ -2009,9 +2009,7 @@ impl IxUtils {
         Ok(parsed_instructions)
     }
 
-    // CreateAccountAllowPrefund is absent from solana-system-interface 2.0.0, so it fails the
-    // SystemInstruction match above. Decode its bincode wire layout directly: variant tag,
-    // lamports, space, owner. Returns lamports and owner; space is not needed downstream.
+    // Absent from system-interface 2.0.0; decode tag 13 (tag, lamports, space, owner) by hand.
     fn parse_create_account_allow_prefund(data: &[u8]) -> Option<(u64, Pubkey)> {
         const CREATE_ACCOUNT_ALLOW_PREFUND_TAG: u32 = 13;
         let (tag, lamports, _space, owner) =
@@ -4338,10 +4336,8 @@ mod tests {
 
     #[test]
     fn test_create_account_allow_prefund_bincode_tag() {
-        // CreateAccountAllowPrefund (tag 13) is absent from solana-system-interface 2.0.0.
-        // It is declared immediately after UpgradeNonceAccount, and bincode encodes the
-        // variant index as a u32 LE tag — so confirming UpgradeNonceAccount == 12 anchors
-        // the tag 13 the manual decoder relies on. This breaks loudly if upstream reorders.
+        // Anchors the hand-coded tag 13: prefund follows UpgradeNonceAccount, so tag 12 here
+        // proves it. Fails loud if upstream reorders the enum.
         let upgrade = bincode::serialize(&SystemInstruction::UpgradeNonceAccount).unwrap();
         assert_eq!(&upgrade[0..4], &12u32.to_le_bytes());
     }

--- a/crates/lib/src/validator/transaction_validator.rs
+++ b/crates/lib/src/validator/transaction_validator.rs
@@ -317,36 +317,24 @@ impl TransactionValidator {
         });
 
         // CreateAccountAllowPrefund can target a prefunded account, so the fee payer can be the
-        // account being created (and bricked by the allocate+assign) without being the funder
-        // that validate_system! checks above. Gate that vector under the same policy.
-        for instruction in system_instructions
-            .get(&ParsedSystemInstructionType::SystemCreateAccount)
-            .unwrap_or(&vec![])
-        {
-            if let ParsedSystemInstructionData::SystemCreateAccount { new_account, owner, .. } =
-                instruction
-            {
-                if *new_account == self.fee_payer_pubkey {
-                    if !self.fee_payer_policy.system.allow_create_account {
-                        return Err(KoraError::InvalidTransaction(
-                            "Fee payer cannot be used for 'System Create Account'".to_string(),
-                        ));
-                    }
-                    if !self.allow_all_programs && !self.allowed_programs.contains(owner) {
-                        return Err(KoraError::InvalidTransaction(format!(
-                            "CreateAccount owner program {} is not in the allowed programs list",
-                            owner
-                        )));
-                    }
-                    if self.disallowed_accounts.contains(owner) {
-                        return Err(KoraError::InvalidTransaction(format!(
-                            "CreateAccount owner program {} is in the disallowed accounts list",
-                            owner
-                        )));
-                    }
-                }
+        // account being created (and bricked by the allocate+assign) rather than the funder the
+        // check above keys on. Re-run the same gate keyed on new_account to cover that vector.
+        validate_system!(self, system_instructions, SystemCreateAccount,
+        ParsedSystemInstructionData::SystemCreateAccount { new_account, owner, .. } => new_account,
+        self.fee_payer_policy.system.allow_create_account, "System Create Account", {
+            if !self.allow_all_programs && !self.allowed_programs.contains(owner) {
+                return Err(KoraError::InvalidTransaction(format!(
+                    "CreateAccount owner program {} is not in the allowed programs list",
+                    owner
+                )));
             }
-        }
+            if self.disallowed_accounts.contains(owner) {
+                return Err(KoraError::InvalidTransaction(format!(
+                    "CreateAccount owner program {} is in the disallowed accounts list",
+                    owner
+                )));
+            }
+        });
 
         validate_system!(self, system_instructions, SystemInitializeNonceAccount,
             ParsedSystemInstructionData::SystemInitializeNonceAccount { nonce_authority, .. } => nonce_authority,

--- a/crates/lib/src/validator/transaction_validator.rs
+++ b/crates/lib/src/validator/transaction_validator.rs
@@ -316,6 +316,26 @@ impl TransactionValidator {
             }
         });
 
+        // CreateAccountAllowPrefund can target a prefunded account, so the fee payer can be the
+        // account being created (and bricked by the allocate+assign) without being the funder
+        // that validate_system! checks above. Gate that vector under the same policy.
+        for instruction in system_instructions
+            .get(&ParsedSystemInstructionType::SystemCreateAccount)
+            .unwrap_or(&vec![])
+        {
+            if let ParsedSystemInstructionData::SystemCreateAccount { new_account, .. } =
+                instruction
+            {
+                if *new_account == self.fee_payer_pubkey
+                    && !self.fee_payer_policy.system.allow_create_account
+                {
+                    return Err(KoraError::InvalidTransaction(
+                        "Fee payer cannot be used for 'System Create Account'".to_string(),
+                    ));
+                }
+            }
+        }
+
         validate_system!(self, system_instructions, SystemInitializeNonceAccount,
             ParsedSystemInstructionData::SystemInitializeNonceAccount { nonce_authority, .. } => nonce_authority,
             self.fee_payer_policy.system.nonce.allow_initialize, "System Initialize Nonce Account");
@@ -2984,6 +3004,61 @@ mod tests {
             .validate_transaction(config, &mut transaction, &rpc_client)
             .await
             .is_err());
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_fee_payer_policy_create_account_allow_prefund() {
+        use solana_sdk::instruction::{AccountMeta, Instruction};
+
+        let fee_payer = Pubkey::new_unique();
+        let other = Pubkey::new_unique();
+        let owner = SYSTEM_PROGRAM_ID;
+
+        let build_ix = |new_account: Pubkey, funder: Pubkey, lamports: u64| -> Instruction {
+            let mut accounts = vec![AccountMeta::new(new_account, true)];
+            if lamports > 0 {
+                accounts.push(AccountMeta::new(funder, true));
+            }
+            Instruction {
+                program_id: SYSTEM_PROGRAM_ID,
+                accounts,
+                data: bincode::serialize(&(13u32, lamports, 100u64, owner)).unwrap(),
+            }
+        };
+
+        // (label, instruction, allow_create_account, expect_ok)
+        let cases = [
+            // Fee payer is the funder — caught by the reused create-account gate.
+            ("funder vector, disallowed", build_ix(other, fee_payer, 1000), false, false),
+            ("funder vector, allowed", build_ix(other, fee_payer, 1000), true, true),
+            // Fee payer is the prefunded account being created — the brick vector.
+            ("brick vector, disallowed", build_ix(fee_payer, other, 1000), false, false),
+            ("brick vector, allowed", build_ix(fee_payer, other, 1000), true, true),
+            // lamports == 0 omits the funder; fee payer as new account must still be gated.
+            (
+                "brick vector no funding, disallowed",
+                build_ix(fee_payer, fee_payer, 0),
+                false,
+                false,
+            ),
+        ];
+
+        for (label, instruction, allow, expect_ok) in cases {
+            let rpc_client = RpcMockBuilder::new().build();
+            let mut policy = FeePayerPolicy::default();
+            policy.system.allow_create_account = allow;
+            setup_config_with_policy(policy);
+
+            let config = get_config().unwrap();
+            let validator = TransactionValidator::new(config, fee_payer).unwrap();
+            let message = VersionedMessage::Legacy(Message::new(&[instruction], Some(&fee_payer)));
+            let mut transaction =
+                TransactionUtil::new_unsigned_versioned_transaction_resolved(message).unwrap();
+            let result =
+                validator.validate_transaction(config, &mut transaction, &rpc_client).await;
+            assert_eq!(result.is_ok(), expect_ok, "case failed: {}", label);
+        }
     }
 
     #[tokio::test]

--- a/crates/lib/src/validator/transaction_validator.rs
+++ b/crates/lib/src/validator/transaction_validator.rs
@@ -267,6 +267,20 @@ impl TransactionValidator {
         Ok(())
     }
 
+    fn validate_create_account_owner(&self, owner: &Pubkey) -> Result<(), KoraError> {
+        if !self.allow_all_programs && !self.allowed_programs.contains(owner) {
+            return Err(KoraError::InvalidTransaction(format!(
+                "CreateAccount owner program {owner} is not in the allowed programs list"
+            )));
+        }
+        if self.disallowed_accounts.contains(owner) {
+            return Err(KoraError::InvalidTransaction(format!(
+                "CreateAccount owner program {owner} is in the disallowed accounts list"
+            )));
+        }
+        Ok(())
+    }
+
     fn validate_fee_payer_usage(
         &self,
         config: &Config,
@@ -302,18 +316,7 @@ impl TransactionValidator {
         validate_system!(self, system_instructions, SystemCreateAccount,
         ParsedSystemInstructionData::SystemCreateAccount { payer, owner, .. } => payer,
         self.fee_payer_policy.system.allow_create_account, "System Create Account", {
-            if !self.allow_all_programs && !self.allowed_programs.contains(owner) {
-                return Err(KoraError::InvalidTransaction(format!(
-                    "CreateAccount owner program {} is not in the allowed programs list",
-                    owner
-                )));
-            }
-            if self.disallowed_accounts.contains(owner) {
-                return Err(KoraError::InvalidTransaction(format!(
-                    "CreateAccount owner program {} is in the disallowed accounts list",
-                    owner
-                )));
-            }
+            self.validate_create_account_owner(owner)?;
         });
 
         // Prefund lets the fee payer be the account created (bricked), not just the funder above.
@@ -321,18 +324,7 @@ impl TransactionValidator {
         validate_system!(self, system_instructions, SystemCreateAccount,
         ParsedSystemInstructionData::SystemCreateAccount { new_account, owner, .. } => new_account,
         self.fee_payer_policy.system.allow_create_account, "System Create Account", {
-            if !self.allow_all_programs && !self.allowed_programs.contains(owner) {
-                return Err(KoraError::InvalidTransaction(format!(
-                    "CreateAccount owner program {} is not in the allowed programs list",
-                    owner
-                )));
-            }
-            if self.disallowed_accounts.contains(owner) {
-                return Err(KoraError::InvalidTransaction(format!(
-                    "CreateAccount owner program {} is in the disallowed accounts list",
-                    owner
-                )));
-            }
+            self.validate_create_account_owner(owner)?;
         });
 
         validate_system!(self, system_instructions, SystemInitializeNonceAccount,

--- a/crates/lib/src/validator/transaction_validator.rs
+++ b/crates/lib/src/validator/transaction_validator.rs
@@ -966,6 +966,7 @@ mod tests {
     use serial_test::serial;
 
     use super::*;
+    use crate::constant::instruction_indexes::system_create_account_allow_prefund::DISCRIMINATOR;
     use solana_address_lookup_table_interface::{
         instruction as alt_instruction, program::ID as ADDRESS_LOOKUP_TABLE_PROGRAM_ID,
     };
@@ -3014,7 +3015,7 @@ mod tests {
                 Instruction {
                     program_id: SYSTEM_PROGRAM_ID,
                     accounts,
-                    data: bincode::serialize(&(13u32, lamports, 100u64, owner)).unwrap(),
+                    data: bincode::serialize(&(DISCRIMINATOR, lamports, 100u64, owner)).unwrap(),
                 }
             };
 
@@ -3094,7 +3095,7 @@ mod tests {
         transaction.all_instructions.push(Instruction {
             program_id: SYSTEM_PROGRAM_ID,
             accounts: vec![AccountMeta::new(new_account, true), AccountMeta::new(fee_payer, true)],
-            data: bincode::serialize(&(13u32, 1_000u64, 0u64, SYSTEM_PROGRAM_ID)).unwrap(),
+            data: bincode::serialize(&(DISCRIMINATOR, 1_000u64, 0u64, SYSTEM_PROGRAM_ID)).unwrap(),
         });
 
         let err = validator

--- a/crates/lib/src/validator/transaction_validator.rs
+++ b/crates/lib/src/validator/transaction_validator.rs
@@ -3079,6 +3079,44 @@ mod tests {
 
     #[tokio::test]
     #[serial]
+    async fn test_fee_payer_policy_create_account_allow_prefund_via_cpi() {
+        // A CreateAccountAllowPrefund surfaced as a CPI inner instruction (appended to
+        // all_instructions, absent from the outer message) must still hit the policy gate.
+        let fee_payer = Pubkey::new_unique();
+        let new_account = Pubkey::new_unique();
+
+        let rpc_client = RpcMockBuilder::new().build();
+        let mut policy = FeePayerPolicy::default();
+        policy.system.allow_create_account = false;
+        setup_config_with_policy(policy);
+        let config = get_config().unwrap();
+        let validator = TransactionValidator::new(config, fee_payer).unwrap();
+
+        // Outer message: a transfer not involving the fee payer — policy-neutral, keeps the tx valid.
+        let outer = transfer(&new_account, &Pubkey::new_unique(), 1);
+        let message = VersionedMessage::Legacy(Message::new(&[outer], Some(&fee_payer)));
+        let mut transaction =
+            TransactionUtil::new_unsigned_versioned_transaction_resolved(message).unwrap();
+
+        // Fee payer funds the prefund create as a CPI inner instruction.
+        transaction.all_instructions.push(Instruction {
+            program_id: SYSTEM_PROGRAM_ID,
+            accounts: vec![AccountMeta::new(new_account, true), AccountMeta::new(fee_payer, true)],
+            data: bincode::serialize(&(13u32, 1_000u64, 0u64, SYSTEM_PROGRAM_ID)).unwrap(),
+        });
+
+        let err = validator
+            .validate_transaction(config, &mut transaction, &rpc_client)
+            .await
+            .expect_err("CPI prefund with fee payer as funder must be rejected");
+        assert!(
+            err.to_string().contains("Fee payer cannot be used for 'System Create Account'"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[tokio::test]
+    #[serial]
     async fn test_fee_payer_policy_create_account_rejects_disallowed_owner() {
         use solana_system_interface::instruction::create_account;
 

--- a/crates/lib/src/validator/transaction_validator.rs
+++ b/crates/lib/src/validator/transaction_validator.rs
@@ -316,9 +316,8 @@ impl TransactionValidator {
             }
         });
 
-        // CreateAccountAllowPrefund can target a prefunded account, so the fee payer can be the
-        // account being created (and bricked by the allocate+assign) rather than the funder the
-        // check above keys on. Re-run the same gate keyed on new_account to cover that vector.
+        // Prefund lets the fee payer be the account created (bricked), not just the funder above.
+        // Re-run the same gate keyed on new_account.
         validate_system!(self, system_instructions, SystemCreateAccount,
         ParsedSystemInstructionData::SystemCreateAccount { new_account, owner, .. } => new_account,
         self.fee_payer_policy.system.allow_create_account, "System Create Account", {

--- a/crates/lib/src/validator/transaction_validator.rs
+++ b/crates/lib/src/validator/transaction_validator.rs
@@ -981,7 +981,7 @@ mod tests {
     use solana_compute_budget_interface::ComputeBudgetInstruction;
     use solana_message::{Message, VersionedMessage};
     use solana_sdk::{
-        instruction::Instruction,
+        instruction::{AccountMeta, Instruction},
         signature::{Keypair, Signer},
     };
     use solana_system_interface::{
@@ -3009,8 +3009,6 @@ mod tests {
     #[tokio::test]
     #[serial]
     async fn test_fee_payer_policy_create_account_allow_prefund() {
-        use solana_sdk::instruction::{AccountMeta, Instruction};
-
         let fee_payer = Pubkey::new_unique();
         let other = Pubkey::new_unique();
         let allowed_owner = SYSTEM_PROGRAM_ID;

--- a/crates/lib/src/validator/transaction_validator.rs
+++ b/crates/lib/src/validator/transaction_validator.rs
@@ -323,15 +323,27 @@ impl TransactionValidator {
             .get(&ParsedSystemInstructionType::SystemCreateAccount)
             .unwrap_or(&vec![])
         {
-            if let ParsedSystemInstructionData::SystemCreateAccount { new_account, .. } =
+            if let ParsedSystemInstructionData::SystemCreateAccount { new_account, owner, .. } =
                 instruction
             {
-                if *new_account == self.fee_payer_pubkey
-                    && !self.fee_payer_policy.system.allow_create_account
-                {
-                    return Err(KoraError::InvalidTransaction(
-                        "Fee payer cannot be used for 'System Create Account'".to_string(),
-                    ));
+                if *new_account == self.fee_payer_pubkey {
+                    if !self.fee_payer_policy.system.allow_create_account {
+                        return Err(KoraError::InvalidTransaction(
+                            "Fee payer cannot be used for 'System Create Account'".to_string(),
+                        ));
+                    }
+                    if !self.allow_all_programs && !self.allowed_programs.contains(owner) {
+                        return Err(KoraError::InvalidTransaction(format!(
+                            "CreateAccount owner program {} is not in the allowed programs list",
+                            owner
+                        )));
+                    }
+                    if self.disallowed_accounts.contains(owner) {
+                        return Err(KoraError::InvalidTransaction(format!(
+                            "CreateAccount owner program {} is in the disallowed accounts list",
+                            owner
+                        )));
+                    }
                 }
             }
         }
@@ -3013,33 +3025,52 @@ mod tests {
 
         let fee_payer = Pubkey::new_unique();
         let other = Pubkey::new_unique();
-        let owner = SYSTEM_PROGRAM_ID;
+        let allowed_owner = SYSTEM_PROGRAM_ID;
+        let disallowed_owner = Pubkey::new_unique();
 
-        let build_ix = |new_account: Pubkey, funder: Pubkey, lamports: u64| -> Instruction {
-            let mut accounts = vec![AccountMeta::new(new_account, true)];
-            if lamports > 0 {
-                accounts.push(AccountMeta::new(funder, true));
-            }
-            Instruction {
-                program_id: SYSTEM_PROGRAM_ID,
-                accounts,
-                data: bincode::serialize(&(13u32, lamports, 100u64, owner)).unwrap(),
-            }
-        };
+        let build_ix =
+            |new_account: Pubkey, funder: Pubkey, lamports: u64, owner: Pubkey| -> Instruction {
+                let mut accounts = vec![AccountMeta::new(new_account, true)];
+                if lamports > 0 {
+                    accounts.push(AccountMeta::new(funder, true));
+                }
+                Instruction {
+                    program_id: SYSTEM_PROGRAM_ID,
+                    accounts,
+                    data: bincode::serialize(&(13u32, lamports, 100u64, owner)).unwrap(),
+                }
+            };
 
         // (label, instruction, allow_create_account, expect_ok)
         let cases = [
             // Fee payer is the funder — caught by the reused create-account gate.
-            ("funder vector, disallowed", build_ix(other, fee_payer, 1000), false, false),
-            ("funder vector, allowed", build_ix(other, fee_payer, 1000), true, true),
+            (
+                "funder vector, disallowed",
+                build_ix(other, fee_payer, 1000, allowed_owner),
+                false,
+                false,
+            ),
+            ("funder vector, allowed", build_ix(other, fee_payer, 1000, allowed_owner), true, true),
             // Fee payer is the prefunded account being created — the brick vector.
-            ("brick vector, disallowed", build_ix(fee_payer, other, 1000), false, false),
-            ("brick vector, allowed", build_ix(fee_payer, other, 1000), true, true),
+            (
+                "brick vector, disallowed",
+                build_ix(fee_payer, other, 1000, allowed_owner),
+                false,
+                false,
+            ),
+            ("brick vector, allowed", build_ix(fee_payer, other, 1000, allowed_owner), true, true),
             // lamports == 0 omits the funder; fee payer as new account must still be gated.
             (
                 "brick vector no funding, disallowed",
-                build_ix(fee_payer, fee_payer, 0),
+                build_ix(fee_payer, fee_payer, 0, allowed_owner),
                 false,
+                false,
+            ),
+            // Even when allowed, the brick path must still enforce the owner allowlist.
+            (
+                "brick vector, owner not allowlisted",
+                build_ix(fee_payer, other, 1000, disallowed_owner),
+                true,
                 false,
             ),
         ];

--- a/tests/fee_payer_policy/fee_payer_policy_violations.rs
+++ b/tests/fee_payer_policy/fee_payer_policy_violations.rs
@@ -1,10 +1,17 @@
 use crate::common::{assertions::RpcErrorAssertions, *};
 use jsonrpsee::rpc_params;
 use solana_sdk::{
-    program_pack::Pack, pubkey::Pubkey, signature::Keypair, signer::Signer,
+    instruction::{AccountMeta, Instruction},
+    program_pack::Pack,
+    pubkey::Pubkey,
+    signature::Keypair,
+    signer::Signer,
     transaction::Transaction,
 };
-use solana_system_interface::instruction::{create_account, transfer};
+use solana_system_interface::{
+    instruction::{create_account, transfer},
+    program::ID as SYSTEM_PROGRAM_ID,
+};
 use spl_associated_token_account_interface::address::{
     get_associated_token_address, get_associated_token_address_with_program_id,
 };
@@ -1372,5 +1379,92 @@ async fn test_reallocate_multisig_bypass() {
             );
         }
         Ok(_) => panic!("Expected error for reallocate multisig bypass policy violation"),
+    }
+}
+
+fn build_create_account_allow_prefund_ix(
+    new_account: &Pubkey,
+    funder: &Pubkey,
+    lamports: u64,
+    space: u64,
+    owner: &Pubkey,
+) -> Instruction {
+    let mut accounts = vec![AccountMeta::new(*new_account, true)];
+    if lamports > 0 {
+        accounts.push(AccountMeta::new(*funder, true));
+    }
+    Instruction {
+        program_id: SYSTEM_PROGRAM_ID,
+        accounts,
+        data: bincode::serialize(&(13u32, lamports, space, *owner)).unwrap(),
+    }
+}
+
+#[tokio::test]
+async fn test_create_account_allow_prefund_funder_policy_violation() {
+    let ctx = TestContext::new().await.expect("Failed to create test context");
+
+    let fee_payer_pubkey = FeePayerTestHelper::get_fee_payer_pubkey();
+    let new_account = Pubkey::new_unique();
+    let owner = Pubkey::new_unique();
+
+    let prefund_ix = build_create_account_allow_prefund_ix(
+        &new_account,
+        &fee_payer_pubkey,
+        1_000_000,
+        0,
+        &owner,
+    );
+
+    let malicious_tx = ctx
+        .transaction_builder()
+        .with_fee_payer(fee_payer_pubkey)
+        .with_instruction(prefund_ix)
+        .build()
+        .await
+        .expect("Failed to create transaction with create_account_allow_prefund");
+
+    let result =
+        ctx.rpc_call::<serde_json::Value, _>("signTransaction", rpc_params![malicious_tx]).await;
+
+    match result {
+        Err(error) => {
+            error.assert_contains_message("Fee payer cannot be used for 'System Create Account'");
+        }
+        Ok(_) => panic!("Expected error for create_account_allow_prefund funder policy violation"),
+    }
+}
+
+#[tokio::test]
+async fn test_create_account_allow_prefund_brick_vector_policy_violation() {
+    let ctx = TestContext::new().await.expect("Failed to create test context");
+
+    let fee_payer_pubkey = FeePayerTestHelper::get_fee_payer_pubkey();
+    let owner = Pubkey::new_unique();
+
+    // Fee payer is the account being created (allocate+assign brick), not the funder. lamports=0
+    // omits the funding account so simulation can succeed against the prefunded fee payer, letting
+    // the policy gate be the layer that rejects it.
+    let prefund_ix =
+        build_create_account_allow_prefund_ix(&fee_payer_pubkey, &fee_payer_pubkey, 0, 0, &owner);
+
+    let malicious_tx = ctx
+        .transaction_builder()
+        .with_fee_payer(fee_payer_pubkey)
+        .with_instruction(prefund_ix)
+        .build()
+        .await
+        .expect("Failed to create transaction with create_account_allow_prefund");
+
+    let result =
+        ctx.rpc_call::<serde_json::Value, _>("signTransaction", rpc_params![malicious_tx]).await;
+
+    match result {
+        Err(error) => {
+            error.assert_contains_message("Fee payer cannot be used for 'System Create Account'");
+        }
+        Ok(_) => {
+            panic!("Expected error for create_account_allow_prefund brick-vector policy violation")
+        }
     }
 }

--- a/tests/fee_payer_policy/fee_payer_policy_violations.rs
+++ b/tests/fee_payer_policy/fee_payer_policy_violations.rs
@@ -1,17 +1,10 @@
 use crate::common::{assertions::RpcErrorAssertions, *};
 use jsonrpsee::rpc_params;
 use solana_sdk::{
-    instruction::{AccountMeta, Instruction},
-    program_pack::Pack,
-    pubkey::Pubkey,
-    signature::Keypair,
-    signer::Signer,
+    program_pack::Pack, pubkey::Pubkey, signature::Keypair, signer::Signer,
     transaction::Transaction,
 };
-use solana_system_interface::{
-    instruction::{create_account, transfer},
-    program::ID as SYSTEM_PROGRAM_ID,
-};
+use solana_system_interface::instruction::{create_account, transfer};
 use spl_associated_token_account_interface::address::{
     get_associated_token_address, get_associated_token_address_with_program_id,
 };
@@ -1382,24 +1375,6 @@ async fn test_reallocate_multisig_bypass() {
     }
 }
 
-fn build_create_account_allow_prefund_ix(
-    new_account: &Pubkey,
-    funder: &Pubkey,
-    lamports: u64,
-    space: u64,
-    owner: &Pubkey,
-) -> Instruction {
-    let mut accounts = vec![AccountMeta::new(*new_account, true)];
-    if lamports > 0 {
-        accounts.push(AccountMeta::new(*funder, true));
-    }
-    Instruction {
-        program_id: SYSTEM_PROGRAM_ID,
-        accounts,
-        data: bincode::serialize(&(13u32, lamports, space, *owner)).unwrap(),
-    }
-}
-
 #[tokio::test]
 async fn test_create_account_allow_prefund_funder_policy_violation() {
     let ctx = TestContext::new().await.expect("Failed to create test context");
@@ -1408,18 +1383,10 @@ async fn test_create_account_allow_prefund_funder_policy_violation() {
     let new_account = Pubkey::new_unique();
     let owner = Pubkey::new_unique();
 
-    let prefund_ix = build_create_account_allow_prefund_ix(
-        &new_account,
-        &fee_payer_pubkey,
-        1_000_000,
-        0,
-        &owner,
-    );
-
     let malicious_tx = ctx
         .transaction_builder()
         .with_fee_payer(fee_payer_pubkey)
-        .with_instruction(prefund_ix)
+        .with_create_account_allow_prefund(&new_account, &fee_payer_pubkey, 1_000_000, 0, &owner)
         .build()
         .await
         .expect("Failed to create transaction with create_account_allow_prefund");
@@ -1445,13 +1412,10 @@ async fn test_create_account_allow_prefund_brick_vector_policy_violation() {
     // Fee payer is the account being created (allocate+assign brick), not the funder. lamports=0
     // omits the funding account so simulation can succeed against the prefunded fee payer, letting
     // the policy gate be the layer that rejects it.
-    let prefund_ix =
-        build_create_account_allow_prefund_ix(&fee_payer_pubkey, &fee_payer_pubkey, 0, 0, &owner);
-
     let malicious_tx = ctx
         .transaction_builder()
         .with_fee_payer(fee_payer_pubkey)
-        .with_instruction(prefund_ix)
+        .with_create_account_allow_prefund(&fee_payer_pubkey, &fee_payer_pubkey, 0, 0, &owner)
         .build()
         .await
         .expect("Failed to create transaction with create_account_allow_prefund");

--- a/tests/fee_payer_policy/fee_payer_policy_violations.rs
+++ b/tests/fee_payer_policy/fee_payer_policy_violations.rs
@@ -1409,9 +1409,8 @@ async fn test_create_account_allow_prefund_brick_vector_policy_violation() {
     let fee_payer_pubkey = FeePayerTestHelper::get_fee_payer_pubkey();
     let owner = Pubkey::new_unique();
 
-    // Fee payer is the account being created (allocate+assign brick), not the funder. lamports=0
-    // omits the funding account so simulation can succeed against the prefunded fee payer, letting
-    // the policy gate be the layer that rejects it.
+    // Fee payer is the account created (brick), not the funder. lamports=0 lets simulation pass
+    // so the policy gate is what rejects it.
     let malicious_tx = ctx
         .transaction_builder()
         .with_fee_payer(fee_payer_pubkey)

--- a/tests/src/common/transaction.rs
+++ b/tests/src/common/transaction.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 use base64::{engine::general_purpose::STANDARD, Engine as _};
 use kora_lib::{
+    constant::instruction_indexes::system_create_account_allow_prefund::DISCRIMINATOR,
     token::{spl_token::TokenProgram, spl_token_2022::Token2022Program, TokenInterface},
     transaction::TransactionUtil,
 };
@@ -149,7 +150,7 @@ impl TransactionBuilder {
         self.instructions.push(Instruction {
             program_id: SYSTEM_PROGRAM_ID,
             accounts,
-            data: bincode::serialize(&(13u32, lamports, space, *owner)).unwrap(),
+            data: bincode::serialize(&(DISCRIMINATOR, lamports, space, *owner)).unwrap(),
         });
         self
     }

--- a/tests/src/common/transaction.rs
+++ b/tests/src/common/transaction.rs
@@ -13,13 +13,16 @@ use solana_message::{
 };
 use solana_program_pack::Pack;
 use solana_sdk::{
-    instruction::Instruction,
+    instruction::{AccountMeta, Instruction},
     pubkey::Pubkey,
     signature::{Keypair, Signature},
     signer::Signer,
     transaction::VersionedTransaction,
 };
-use solana_system_interface::instruction::{create_account, transfer};
+use solana_system_interface::{
+    instruction::{create_account, transfer},
+    program::ID as SYSTEM_PROGRAM_ID,
+};
 use spl_associated_token_account_interface::address::{
     get_associated_token_address, get_associated_token_address_with_program_id,
 };
@@ -126,6 +129,29 @@ impl TransactionBuilder {
     pub fn with_system_allocate(mut self, account: &Pubkey, space: u64) -> Self {
         let instruction = solana_system_interface::instruction::allocate(account, space);
         self.instructions.push(instruction);
+        self
+    }
+
+    /// Add a CreateAccountAllowPrefund (SIMD-0312) instruction. Encoded by hand because
+    /// solana-system-interface 2.0.0 has no constructor for variant tag 13; the funding
+    /// account is omitted when lamports == 0.
+    pub fn with_create_account_allow_prefund(
+        mut self,
+        new_account: &Pubkey,
+        funder: &Pubkey,
+        lamports: u64,
+        space: u64,
+        owner: &Pubkey,
+    ) -> Self {
+        let mut accounts = vec![AccountMeta::new(*new_account, true)];
+        if lamports > 0 {
+            accounts.push(AccountMeta::new(*funder, true));
+        }
+        self.instructions.push(Instruction {
+            program_id: SYSTEM_PROGRAM_ID,
+            accounts,
+            data: bincode::serialize(&(13u32, lamports, space, *owner)).unwrap(),
+        });
         self
     }
 

--- a/tests/src/common/transaction.rs
+++ b/tests/src/common/transaction.rs
@@ -132,9 +132,8 @@ impl TransactionBuilder {
         self
     }
 
-    /// Add a CreateAccountAllowPrefund (SIMD-0312) instruction. Encoded by hand because
-    /// solana-system-interface 2.0.0 has no constructor for variant tag 13; the funding
-    /// account is omitted when lamports == 0.
+    /// Add a CreateAccountAllowPrefund instruction (tag 13, hand-encoded — no constructor in
+    /// system-interface 2.0.0; funding account omitted when lamports == 0).
     pub fn with_create_account_allow_prefund(
         mut self,
         new_account: &Pubkey,


### PR DESCRIPTION
## Summary
- The System program's `CreateAccountAllowPrefund` was absent from `solana-system-interface 2.0.0`, so it fell through the instruction parser's catch-all and silently bypassed the fee-payer policy and outflow accounting. The parser now decodes its bincode wire layout directly (variant tag 13) and maps it onto the existing `SystemCreateAccount` parsed type, so validation and fee logic apply unchanged.
- Added `system_create_account_allow_prefund` index module — its account order is the reverse of `CreateAccount` (`[new, funder]`) and the funder is omitted when `lamports == 0`.
- Because a prefunded target can already hold lamports, the fee payer can be the account being created (and bricked by allocate+assign) without being the funder the existing gate checks. That vector is now rejected under the same `allow_create_account` policy.
- A stack bump to the upstream enum was evaluated and rejected: `system-interface 3.x` requires `solana-address 2.x` / `pubkey 4.x`, but `solana-loader-v4-interface` has no pubkey-4 release, so no consistent stable dependency set exists yet.

## Test Plan
- `cargo test -p kora-lib --lib` — 829 pass, incl. 5 new tests.
- Tag anchor test serializes the real `UpgradeNonceAccount` (= 12) to prove the appended `CreateAccountAllowPrefund` tag is 13; fails loudly if upstream reorders the enum.
- Parse tests cover the 2-account (funder) and 1-account (`lamports == 0`) forms.
- Validator tests cover the funder vector, the brick vector, and the no-funding brick vector across both policy states.