### PR TITLE
feat(pricing): add FixedStable price model for multi-stablecoin fixed fees

### DIFF
--- a/crates/lib/src/config.rs
+++ b/crates/lib/src/config.rs
@@ -818,6 +818,27 @@ impl Config {
             ))
         })?;
 
+        // Validate FixedStable price model configuration
+        if let PriceModel::FixedStable { amount, tokens, .. } = &config.validation.price.model {
+            if tokens.is_empty() {
+                return Err(KoraError::ConfigError(
+                    "FixedStable price model requires at least one token in 'tokens'".to_string(),
+                ));
+            }
+            if *amount == 0 {
+                return Err(KoraError::ConfigError(
+                    "FixedStable price model 'amount' must be greater than zero".to_string(),
+                ));
+            }
+            for token in tokens {
+                Pubkey::from_str(token).map_err(|_| {
+                    KoraError::ConfigError(format!(
+                        "FixedStable price model contains invalid token mint address: '{token}'"
+                    ))
+                })?;
+            }
+        }
+
         Ok(config)
     }
 }
@@ -1018,6 +1039,99 @@ mod tests {
                 assert!(!strict);
             }
             _ => panic!("Expected FixedStable price model"),
+        }
+    }
+
+    #[test]
+    fn test_fixed_stable_empty_tokens_rejected() {
+        let result = crate::tests::toml_mock::create_invalid_config(
+            r#"
+[validation]
+max_allowed_lamports = 1000000000
+max_signatures = 10
+allowed_programs = ["program1"]
+allowed_tokens = ["token1"]
+allowed_spl_paid_tokens = ["token2"]
+disallowed_accounts = []
+price_source = "Mock"
+
+[validation.price]
+type = "fixed_stable"
+amount = 100000
+tokens = []
+strict = false
+
+[kora]
+rate_limit = 100
+"#,
+        );
+        assert!(result.is_err());
+        if let Err(KoraError::ConfigError(msg)) = result {
+            assert!(msg.contains("requires at least one token"), "Unexpected error: {msg}");
+        } else {
+            panic!("Expected ConfigError");
+        }
+    }
+
+    #[test]
+    fn test_fixed_stable_zero_amount_rejected() {
+        let result = crate::tests::toml_mock::create_invalid_config(
+            r#"
+[validation]
+max_allowed_lamports = 1000000000
+max_signatures = 10
+allowed_programs = ["program1"]
+allowed_tokens = ["token1"]
+allowed_spl_paid_tokens = ["token2"]
+disallowed_accounts = []
+price_source = "Mock"
+
+[validation.price]
+type = "fixed_stable"
+amount = 0
+tokens = ["4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU"]
+strict = false
+
+[kora]
+rate_limit = 100
+"#,
+        );
+        assert!(result.is_err());
+        if let Err(KoraError::ConfigError(msg)) = result {
+            assert!(msg.contains("amount"), "Unexpected error: {msg}");
+        } else {
+            panic!("Expected ConfigError");
+        }
+    }
+
+    #[test]
+    fn test_fixed_stable_invalid_mint_rejected() {
+        let result = crate::tests::toml_mock::create_invalid_config(
+            r#"
+[validation]
+max_allowed_lamports = 1000000000
+max_signatures = 10
+allowed_programs = ["program1"]
+allowed_tokens = ["token1"]
+allowed_spl_paid_tokens = ["token2"]
+disallowed_accounts = []
+price_source = "Mock"
+
+[validation.price]
+type = "fixed_stable"
+amount = 100000
+tokens = ["not-a-valid-pubkey"]
+strict = false
+
+[kora]
+rate_limit = 100
+"#,
+        );
+        assert!(result.is_err());
+        if let Err(KoraError::ConfigError(msg)) = result {
+            assert!(msg.contains("invalid token mint address"), "Unexpected error: {msg}");
+        } else {
+            panic!("Expected ConfigError");
         }
     }
 

--- a/crates/lib/src/config.rs
+++ b/crates/lib/src/config.rs
@@ -1003,6 +1003,25 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_fixed_stable_price_config() {
+        let usdc = "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU";
+        let usdt = "Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB";
+        let config = ConfigBuilder::new()
+            .with_fixed_stable_price(100_000, &[usdc, usdt])
+            .build_config()
+            .unwrap();
+
+        match &config.validation.price.model {
+            PriceModel::FixedStable { amount, tokens, strict } => {
+                assert_eq!(*amount, 100_000);
+                assert_eq!(tokens, &[usdc, usdt]);
+                assert!(!strict);
+            }
+            _ => panic!("Expected FixedStable price model"),
+        }
+    }
+
+    #[test]
     fn test_parse_missing_price_config() {
         let config = ConfigBuilder::new().build_config().unwrap();
 

--- a/crates/lib/src/fee/fee.rs
+++ b/crates/lib/src/fee/fee.rs
@@ -318,6 +318,35 @@ impl FeeConfigUtil {
                     Ok(TotalFeeCalculation::new_fixed(fixed_fee_lamports))
                 }
             }
+            PriceModel::FixedStable { strict, .. } => {
+                let fixed_fee_lamports = config
+                    .validation
+                    .price
+                    .get_required_lamports_with_fixed_stable(rpc_client, config)
+                    .await?;
+
+                if *strict {
+                    let fee_calculation = Self::estimate_transaction_fee(
+                        transaction,
+                        fee_payer,
+                        is_payment_required,
+                        rpc_client,
+                        config,
+                    )
+                    .await?;
+
+                    Ok(TotalFeeCalculation::new(
+                        fixed_fee_lamports,
+                        fee_calculation.base_fee,
+                        fee_calculation.kora_signature_fee,
+                        fee_calculation.fee_payer_outflow,
+                        fee_calculation.payment_instruction_fee,
+                        fee_calculation.transfer_fee_amount,
+                    ))
+                } else {
+                    Ok(TotalFeeCalculation::new_fixed(fixed_fee_lamports))
+                }
+            }
             PriceModel::Margin { .. } => {
                 // Get the raw transaction
                 let fee_calculation = Self::estimate_transaction_fee(
@@ -347,7 +376,9 @@ impl FeeConfigUtil {
         }
     }
 
-    /// Calculate the fee in a specific token if provided
+    /// Calculate the fee in a specific token if provided.
+    /// For `FixedStable` pricing, returns the configured fixed amount directly
+    /// for any token in the stable group, bypassing the oracle conversion.
     pub async fn calculate_fee_in_token(
         fee_in_lamports: u64,
         fee_token: Option<&str>,
@@ -365,6 +396,13 @@ impl FeeConfigUtil {
                 return Err(KoraError::InvalidRequest(format!(
                     "Token {fee_token} is not supported"
                 )));
+            }
+
+            // For FixedStable pricing, return the fixed amount directly for tokens in the group.
+            if let Some(fixed_amount) =
+                config.validation.price.get_fixed_stable_fee_for_token(fee_token)
+            {
+                return Ok(Some(fixed_amount));
             }
 
             let fee_value_in_token = TokenUtil::calculate_lamports_value_in_token(

--- a/crates/lib/src/fee/fee.rs
+++ b/crates/lib/src/fee/fee.rs
@@ -295,28 +295,16 @@ impl FeeConfigUtil {
                     .price
                     .get_required_lamports_with_fixed(rpc_client, config)
                     .await?;
-
-                if *strict {
-                    let fee_calculation = Self::estimate_transaction_fee(
-                        transaction,
-                        fee_payer,
-                        is_payment_required,
-                        rpc_client,
-                        config,
-                    )
-                    .await?;
-
-                    Ok(TotalFeeCalculation::new(
-                        fixed_fee_lamports,
-                        fee_calculation.base_fee,
-                        fee_calculation.kora_signature_fee,
-                        fee_calculation.fee_payer_outflow,
-                        fee_calculation.payment_instruction_fee,
-                        fee_calculation.transfer_fee_amount,
-                    ))
-                } else {
-                    Ok(TotalFeeCalculation::new_fixed(fixed_fee_lamports))
-                }
+                Self::finalize_fixed_price_fee(
+                    fixed_fee_lamports,
+                    *strict,
+                    transaction,
+                    fee_payer,
+                    is_payment_required,
+                    rpc_client,
+                    config,
+                )
+                .await
             }
             PriceModel::FixedStable { strict, .. } => {
                 let fixed_fee_lamports = config
@@ -324,28 +312,16 @@ impl FeeConfigUtil {
                     .price
                     .get_required_lamports_with_fixed_stable(rpc_client, config)
                     .await?;
-
-                if *strict {
-                    let fee_calculation = Self::estimate_transaction_fee(
-                        transaction,
-                        fee_payer,
-                        is_payment_required,
-                        rpc_client,
-                        config,
-                    )
-                    .await?;
-
-                    Ok(TotalFeeCalculation::new(
-                        fixed_fee_lamports,
-                        fee_calculation.base_fee,
-                        fee_calculation.kora_signature_fee,
-                        fee_calculation.fee_payer_outflow,
-                        fee_calculation.payment_instruction_fee,
-                        fee_calculation.transfer_fee_amount,
-                    ))
-                } else {
-                    Ok(TotalFeeCalculation::new_fixed(fixed_fee_lamports))
-                }
+                Self::finalize_fixed_price_fee(
+                    fixed_fee_lamports,
+                    *strict,
+                    transaction,
+                    fee_payer,
+                    is_payment_required,
+                    rpc_client,
+                    config,
+                )
+                .await
             }
             PriceModel::Margin { .. } => {
                 // Get the raw transaction
@@ -376,9 +352,42 @@ impl FeeConfigUtil {
         }
     }
 
-    /// Calculate the fee in a specific token if provided.
-    /// For `FixedStable` pricing, returns the configured fixed amount directly
-    /// for any token in the stable group, bypassing the oracle conversion.
+    /// Wrap a fixed lamport fee in a `TotalFeeCalculation`. In strict mode the real
+    /// transaction cost is also computed so strict-pricing validation can reject
+    /// transactions whose true cost exceeds the fixed price.
+    async fn finalize_fixed_price_fee(
+        fixed_fee_lamports: u64,
+        strict: bool,
+        transaction: &mut VersionedTransactionResolved,
+        fee_payer: &Pubkey,
+        is_payment_required: bool,
+        rpc_client: &RpcClient,
+        config: &Config,
+    ) -> Result<TotalFeeCalculation, KoraError> {
+        if !strict {
+            return Ok(TotalFeeCalculation::new_fixed(fixed_fee_lamports));
+        }
+
+        let fee_calculation = Self::estimate_transaction_fee(
+            transaction,
+            fee_payer,
+            is_payment_required,
+            rpc_client,
+            config,
+        )
+        .await?;
+
+        Ok(TotalFeeCalculation::new(
+            fixed_fee_lamports,
+            fee_calculation.base_fee,
+            fee_calculation.kora_signature_fee,
+            fee_calculation.fee_payer_outflow,
+            fee_calculation.payment_instruction_fee,
+            fee_calculation.transfer_fee_amount,
+        ))
+    }
+
+    /// Calculate the fee in a specific token if provided
     pub async fn calculate_fee_in_token(
         fee_in_lamports: u64,
         fee_token: Option<&str>,
@@ -396,13 +405,6 @@ impl FeeConfigUtil {
                 return Err(KoraError::InvalidRequest(format!(
                     "Token {fee_token} is not supported"
                 )));
-            }
-
-            // For FixedStable pricing, return the fixed amount directly for tokens in the group.
-            if let Some(fixed_amount) =
-                config.validation.price.get_fixed_stable_fee_for_token(fee_token)
-            {
-                return Ok(Some(fixed_amount));
             }
 
             let fee_value_in_token = TokenUtil::calculate_lamports_value_in_token(

--- a/crates/lib/src/fee/price.rs
+++ b/crates/lib/src/fee/price.rs
@@ -10,10 +10,15 @@ use std::str::FromStr;
 use utoipa::ToSchema;
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
-#[serde(tag = "type", rename_all = "lowercase")]
+#[serde(tag = "type", rename_all = "snake_case")]
 pub enum PriceModel {
     Margin { margin: f64 },
     Fixed { amount: u64, token: String, strict: bool },
+    /// Charge a fixed amount in any of the listed stablecoin mints.
+    /// All tokens in the group are treated as equivalent (same amount, no per-token oracle call).
+    /// The `amount` is in base units and applies identically to every token in `tokens`.
+    /// Use this when you accept USDC, USDT, PYUSD, etc. at the same flat fee.
+    FixedStable { amount: u64, tokens: Vec<String>, strict: bool },
     Free,
 }
 
@@ -55,6 +60,47 @@ impl PriceConfig {
         Err(KoraError::ConfigError(
             "Price model is not 'Fixed': cannot compute fixed fee".to_string(),
         ))
+    }
+
+    pub async fn get_required_lamports_with_fixed_stable(
+        &self,
+        rpc_client: &RpcClient,
+        config: &Config,
+    ) -> Result<u64, KoraError> {
+        if let PriceModel::FixedStable { amount, tokens, .. } = &self.model {
+            let reference_token = tokens.first().ok_or_else(|| {
+                KoraError::ConfigError(
+                    "FixedStable price model requires at least one token".to_string(),
+                )
+            })?;
+            return TokenUtil::calculate_token_value_in_lamports(
+                *amount,
+                &Pubkey::from_str(reference_token).map_err(|e| {
+                    log::error!("Invalid Pubkey for fixed stable price {e}");
+                    KoraError::ConfigError(
+                        "Invalid token address in fee config: failed to parse as Solana pubkey"
+                            .to_string(),
+                    )
+                })?,
+                rpc_client,
+                config,
+            )
+            .await;
+        }
+
+        Err(KoraError::ConfigError(
+            "Price model is not 'FixedStable': cannot compute fixed stable fee".to_string(),
+        ))
+    }
+
+    /// Returns the fixed stable fee amount if the given token is in the stable group, or None otherwise.
+    pub fn get_fixed_stable_fee_for_token(&self, fee_token: &str) -> Option<u64> {
+        if let PriceModel::FixedStable { amount, tokens, .. } = &self.model {
+            if tokens.iter().any(|t| t == fee_token) {
+                return Some(*amount);
+            }
+        }
+        None
     }
 
     pub async fn get_required_lamports_with_margin(
@@ -228,5 +274,91 @@ mod tests {
             PriceModel::Margin { margin } => assert_eq!(margin, 0.0),
             _ => panic!("Default should be Margin with 0.0 margin"),
         }
+    }
+
+    #[tokio::test]
+    async fn test_fixed_stable_model_get_required_lamports_uses_first_token() {
+        let _m = ConfigMockBuilder::new().build_and_setup();
+        let config = get_config().unwrap();
+        let rpc_client = create_mock_rpc_client_with_mint(6);
+
+        let usdc_mint = "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU";
+        let other_stable = "HZ1JovNiVvGrGNiiYvEozEVgZ58xaU3RKwX8eACQBCt3"; // some other stable mint
+        let price_config = PriceConfig {
+            model: PriceModel::FixedStable {
+                amount: 1_000_000, // 1 USDC
+                tokens: vec![usdc_mint.to_string(), other_stable.to_string()],
+                strict: false,
+            },
+        };
+
+        let result = price_config
+            .get_required_lamports_with_fixed_stable(&rpc_client, &config)
+            .await
+            .unwrap();
+
+        // First token (USDC) is used as reference: 1 USDC * 0.0075 SOL/USDC * 1e9 = 7,500,000 lamports
+        assert_eq!(result, 7_500_000);
+    }
+
+    #[tokio::test]
+    async fn test_fixed_stable_model_empty_tokens_returns_error() {
+        let _m = ConfigMockBuilder::new().build_and_setup();
+        let config = get_config().unwrap();
+        let rpc_client = create_mock_rpc_client_with_mint(6);
+
+        let price_config = PriceConfig {
+            model: PriceModel::FixedStable {
+                amount: 1_000_000,
+                tokens: vec![],
+                strict: false,
+            },
+        };
+
+        let result =
+            price_config.get_required_lamports_with_fixed_stable(&rpc_client, &config).await;
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("at least one token"), "Expected 'at least one token' in error: {err}");
+    }
+
+    #[test]
+    fn test_get_fixed_stable_fee_for_token_in_group() {
+        let usdc_mint = "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU";
+        let usdt_mint = "Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB";
+        let price_config = PriceConfig {
+            model: PriceModel::FixedStable {
+                amount: 100_000,
+                tokens: vec![usdc_mint.to_string(), usdt_mint.to_string()],
+                strict: false,
+            },
+        };
+
+        assert_eq!(price_config.get_fixed_stable_fee_for_token(usdc_mint), Some(100_000));
+        assert_eq!(price_config.get_fixed_stable_fee_for_token(usdt_mint), Some(100_000));
+    }
+
+    #[test]
+    fn test_get_fixed_stable_fee_for_token_not_in_group() {
+        let usdc_mint = "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU";
+        let other_mint = "HZ1JovNiVvGrGNiiYvEozEVgZ58xaU3RKwX8eACQBCt3";
+        let price_config = PriceConfig {
+            model: PriceModel::FixedStable {
+                amount: 100_000,
+                tokens: vec![usdc_mint.to_string()],
+                strict: false,
+            },
+        };
+
+        assert_eq!(price_config.get_fixed_stable_fee_for_token(other_mint), None);
+    }
+
+    #[test]
+    fn test_get_fixed_stable_fee_for_token_wrong_model() {
+        let usdc_mint = "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU";
+        let price_config = PriceConfig {
+            model: PriceModel::Margin { margin: 0.1 },
+        };
+        assert_eq!(price_config.get_fixed_stable_fee_for_token(usdc_mint), None);
     }
 }

--- a/crates/lib/src/fee/price.rs
+++ b/crates/lib/src/fee/price.rs
@@ -20,10 +20,10 @@ pub enum PriceModel {
         token: String,
         strict: bool,
     },
-    /// Charge a fixed amount in any of the listed stablecoin mints.
-    /// All tokens in the group are treated as equivalent (same amount, no per-token oracle call).
-    /// The `amount` is in base units and applies identically to every token in `tokens`.
-    /// Use this when you accept USDC, USDT, PYUSD, etc. at the same flat fee.
+    /// Charge a fixed fee payable in any of the listed stablecoin mints.
+    /// `amount` is in base units of the first listed mint, which anchors the fee; a payer
+    /// using any other listed mint is charged the equivalent value at current oracle prices.
+    /// Use this when you accept several stablecoins (USDC, USDT, PYUSD, …) for one fee.
     FixedStable {
         amount: u64,
         tokens: Vec<String>,
@@ -45,26 +45,28 @@ pub struct PriceConfig {
 }
 
 impl PriceConfig {
+    async fn token_amount_to_lamports(
+        amount: u64,
+        token: &str,
+        rpc_client: &RpcClient,
+        config: &Config,
+    ) -> Result<u64, KoraError> {
+        let mint = Pubkey::from_str(token).map_err(|e| {
+            log::error!("Invalid Pubkey for price {e}");
+            KoraError::ConfigError(
+                "Invalid token address in fee config: failed to parse as Solana pubkey".to_string(),
+            )
+        })?;
+        TokenUtil::calculate_token_value_in_lamports(amount, &mint, rpc_client, config).await
+    }
+
     pub async fn get_required_lamports_with_fixed(
         &self,
         rpc_client: &RpcClient,
         config: &Config,
     ) -> Result<u64, KoraError> {
         if let PriceModel::Fixed { amount, token, .. } = &self.model {
-            return TokenUtil::calculate_token_value_in_lamports(
-                *amount,
-                &Pubkey::from_str(token).map_err(|e| {
-                    log::error!("Invalid Pubkey for price {e}");
-
-                    KoraError::ConfigError(
-                        "Invalid token address in fee config: failed to parse as Solana pubkey"
-                            .to_string(),
-                    )
-                })?,
-                rpc_client,
-                config,
-            )
-            .await;
+            return Self::token_amount_to_lamports(*amount, token, rpc_client, config).await;
         }
 
         Err(KoraError::ConfigError(
@@ -72,65 +74,28 @@ impl PriceConfig {
         ))
     }
 
+    /// Lamport equivalent of the fixed fee, anchored to the first listed mint.
+    /// This is the reference value used for `max_allowed_lamports` and strict-pricing
+    /// enforcement; the actual token a payer uses is converted at oracle rates in
+    /// [`FeeConfigUtil::calculate_fee_in_token`].
     pub async fn get_required_lamports_with_fixed_stable(
         &self,
         rpc_client: &RpcClient,
         config: &Config,
     ) -> Result<u64, KoraError> {
         if let PriceModel::FixedStable { amount, tokens, .. } = &self.model {
-            if tokens.is_empty() {
-                return Err(KoraError::ConfigError(
+            let reference_token = tokens.first().ok_or_else(|| {
+                KoraError::ConfigError(
                     "FixedStable price model requires at least one token".to_string(),
-                ));
-            }
-
-            let mut last_err = KoraError::ConfigError(
-                "FixedStable price model requires at least one token".to_string(),
-            );
-
-            for token in tokens {
-                let mint = match Pubkey::from_str(token) {
-                    Ok(pk) => pk,
-                    Err(e) => {
-                        log::warn!("Skipping invalid Pubkey in FixedStable tokens: {e}");
-                        last_err = KoraError::ConfigError(
-                            "Invalid token address in fee config: failed to parse as Solana pubkey"
-                                .to_string(),
-                        );
-                        continue;
-                    }
-                };
-                match TokenUtil::calculate_token_value_in_lamports(
-                    *amount, &mint, rpc_client, config,
                 )
-                .await
-                {
-                    Ok(lamports) => return Ok(lamports),
-                    Err(e) => {
-                        log::warn!(
-                            "Oracle lookup failed for FixedStable reference token {token}: {e}; trying next"
-                        );
-                        last_err = e;
-                    }
-                }
-            }
-
-            return Err(last_err);
+            })?;
+            return Self::token_amount_to_lamports(*amount, reference_token, rpc_client, config)
+                .await;
         }
 
         Err(KoraError::ConfigError(
             "Price model is not 'FixedStable': cannot compute fixed stable fee".to_string(),
         ))
-    }
-
-    /// Returns the fixed stable fee amount if the given token is in the stable group, or None otherwise.
-    pub fn get_fixed_stable_fee_for_token(&self, fee_token: &str) -> Option<u64> {
-        if let PriceModel::FixedStable { amount, tokens, .. } = &self.model {
-            if tokens.iter().any(|t| t == fee_token) {
-                return Some(*amount);
-            }
-        }
-        None
     }
 
     pub async fn get_required_lamports_with_margin(
@@ -349,43 +314,5 @@ mod tests {
             err.contains("at least one token"),
             "Expected 'at least one token' in error: {err}"
         );
-    }
-
-    #[test]
-    fn test_get_fixed_stable_fee_for_token_in_group() {
-        let usdc_mint = "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU";
-        let usdt_mint = "Es9vMFrzaCERmJfrF4H2FYD4KCoNkY11McCe8BenwNYB";
-        let price_config = PriceConfig {
-            model: PriceModel::FixedStable {
-                amount: 100_000,
-                tokens: vec![usdc_mint.to_string(), usdt_mint.to_string()],
-                strict: false,
-            },
-        };
-
-        assert_eq!(price_config.get_fixed_stable_fee_for_token(usdc_mint), Some(100_000));
-        assert_eq!(price_config.get_fixed_stable_fee_for_token(usdt_mint), Some(100_000));
-    }
-
-    #[test]
-    fn test_get_fixed_stable_fee_for_token_not_in_group() {
-        let usdc_mint = "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU";
-        let other_mint = "HZ1JovNiVvGrGNiiYvEozEVgZ58xaU3RKwX8eACQBCt3";
-        let price_config = PriceConfig {
-            model: PriceModel::FixedStable {
-                amount: 100_000,
-                tokens: vec![usdc_mint.to_string()],
-                strict: false,
-            },
-        };
-
-        assert_eq!(price_config.get_fixed_stable_fee_for_token(other_mint), None);
-    }
-
-    #[test]
-    fn test_get_fixed_stable_fee_for_token_wrong_model() {
-        let usdc_mint = "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU";
-        let price_config = PriceConfig { model: PriceModel::Margin { margin: 0.1 } };
-        assert_eq!(price_config.get_fixed_stable_fee_for_token(usdc_mint), None);
     }
 }

--- a/crates/lib/src/fee/price.rs
+++ b/crates/lib/src/fee/price.rs
@@ -12,13 +12,23 @@ use utoipa::ToSchema;
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum PriceModel {
-    Margin { margin: f64 },
-    Fixed { amount: u64, token: String, strict: bool },
+    Margin {
+        margin: f64,
+    },
+    Fixed {
+        amount: u64,
+        token: String,
+        strict: bool,
+    },
     /// Charge a fixed amount in any of the listed stablecoin mints.
     /// All tokens in the group are treated as equivalent (same amount, no per-token oracle call).
     /// The `amount` is in base units and applies identically to every token in `tokens`.
     /// Use this when you accept USDC, USDT, PYUSD, etc. at the same flat fee.
-    FixedStable { amount: u64, tokens: Vec<String>, strict: bool },
+    FixedStable {
+        amount: u64,
+        tokens: Vec<String>,
+        strict: bool,
+    },
     Free,
 }
 
@@ -68,24 +78,44 @@ impl PriceConfig {
         config: &Config,
     ) -> Result<u64, KoraError> {
         if let PriceModel::FixedStable { amount, tokens, .. } = &self.model {
-            let reference_token = tokens.first().ok_or_else(|| {
-                KoraError::ConfigError(
+            if tokens.is_empty() {
+                return Err(KoraError::ConfigError(
                     "FixedStable price model requires at least one token".to_string(),
+                ));
+            }
+
+            let mut last_err = KoraError::ConfigError(
+                "FixedStable price model requires at least one token".to_string(),
+            );
+
+            for token in tokens {
+                let mint = match Pubkey::from_str(token) {
+                    Ok(pk) => pk,
+                    Err(e) => {
+                        log::warn!("Skipping invalid Pubkey in FixedStable tokens: {e}");
+                        last_err = KoraError::ConfigError(
+                            "Invalid token address in fee config: failed to parse as Solana pubkey"
+                                .to_string(),
+                        );
+                        continue;
+                    }
+                };
+                match TokenUtil::calculate_token_value_in_lamports(
+                    *amount, &mint, rpc_client, config,
                 )
-            })?;
-            return TokenUtil::calculate_token_value_in_lamports(
-                *amount,
-                &Pubkey::from_str(reference_token).map_err(|e| {
-                    log::error!("Invalid Pubkey for fixed stable price {e}");
-                    KoraError::ConfigError(
-                        "Invalid token address in fee config: failed to parse as Solana pubkey"
-                            .to_string(),
-                    )
-                })?,
-                rpc_client,
-                config,
-            )
-            .await;
+                .await
+                {
+                    Ok(lamports) => return Ok(lamports),
+                    Err(e) => {
+                        log::warn!(
+                            "Oracle lookup failed for FixedStable reference token {token}: {e}; trying next"
+                        );
+                        last_err = e;
+                    }
+                }
+            }
+
+            return Err(last_err);
         }
 
         Err(KoraError::ConfigError(
@@ -308,18 +338,17 @@ mod tests {
         let rpc_client = create_mock_rpc_client_with_mint(6);
 
         let price_config = PriceConfig {
-            model: PriceModel::FixedStable {
-                amount: 1_000_000,
-                tokens: vec![],
-                strict: false,
-            },
+            model: PriceModel::FixedStable { amount: 1_000_000, tokens: vec![], strict: false },
         };
 
         let result =
             price_config.get_required_lamports_with_fixed_stable(&rpc_client, &config).await;
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
-        assert!(err.contains("at least one token"), "Expected 'at least one token' in error: {err}");
+        assert!(
+            err.contains("at least one token"),
+            "Expected 'at least one token' in error: {err}"
+        );
     }
 
     #[test]
@@ -356,9 +385,7 @@ mod tests {
     #[test]
     fn test_get_fixed_stable_fee_for_token_wrong_model() {
         let usdc_mint = "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU";
-        let price_config = PriceConfig {
-            model: PriceModel::Margin { margin: 0.1 },
-        };
+        let price_config = PriceConfig { model: PriceModel::Margin { margin: 0.1 } };
         assert_eq!(price_config.get_fixed_stable_fee_for_token(usdc_mint), None);
     }
 }

--- a/crates/lib/src/plugin/plugin_gas_swap.rs
+++ b/crates/lib/src/plugin/plugin_gas_swap.rs
@@ -145,7 +145,10 @@ impl TransactionPlugin for GasSwapPlugin {
         }
 
         let mut warnings = Vec::new();
-        if matches!(config.validation.price.model, PriceModel::Fixed { .. }) {
+        if matches!(
+            config.validation.price.model,
+            PriceModel::Fixed { .. } | PriceModel::FixedStable { .. }
+        ) {
             warnings.push(
                 "GasSwap plugin with Fixed pricing: ensure the fixed token fee is worth at least \
                  max_allowed_lamports in SOL to avoid a drain condition."

--- a/crates/lib/src/rpc_server/openapi/spec/combined_api.json
+++ b/crates/lib/src/rpc_server/openapi/spec/combined_api.json
@@ -1902,14 +1902,14 @@
                 "type": "integer",
                 "format": "int64",
                 "minimum": 0,
-                "description": "Fixed fee in token base units, applied identically to every token in the stable group."
+                "description": "Fixed fee in base units of the first listed mint, which anchors the fee. Payers using any other listed mint are charged the equivalent value at current oracle prices."
               },
               "tokens": {
                 "type": "array",
                 "items": {
                   "type": "string"
                 },
-                "description": "Stablecoin mint addresses accepted at this fixed price. All tokens are treated as equivalent."
+                "description": "Stablecoin mint addresses accepted for this fixed fee. The first mint anchors the price; others are converted at oracle rates."
               },
               "strict": {
                 "type": "boolean"

--- a/crates/lib/src/rpc_server/openapi/spec/combined_api.json
+++ b/crates/lib/src/rpc_server/openapi/spec/combined_api.json
@@ -1892,6 +1892,39 @@
           {
             "type": "object",
             "required": [
+              "amount",
+              "tokens",
+              "strict",
+              "type"
+            ],
+            "properties": {
+              "amount": {
+                "type": "integer",
+                "format": "int64",
+                "minimum": 0,
+                "description": "Fixed fee in token base units, applied identically to every token in the stable group."
+              },
+              "tokens": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Stablecoin mint addresses accepted at this fixed price. All tokens are treated as equivalent."
+              },
+              "strict": {
+                "type": "boolean"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "fixed_stable"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "required": [
               "type"
             ],
             "properties": {

--- a/crates/lib/src/tests/toml_mock.rs
+++ b/crates/lib/src/tests/toml_mock.rs
@@ -124,6 +124,14 @@ impl ConfigBuilder {
         self
     }
 
+    pub fn with_fixed_stable_price(mut self, amount: u64, tokens: &[&str]) -> Self {
+        let tokens_list = tokens.iter().map(|t| format!("\"{t}\"")).collect::<Vec<_>>().join(", ");
+        self.validation.price_config = Some(format!(
+            "[validation.price]\ntype = \"fixed_stable\"\namount = {amount}\ntokens = [{tokens_list}]\nstrict = false\n"
+        ));
+        self
+    }
+
     pub fn with_free_price(mut self) -> Self {
         self.validation.price_config = Some("[validation.price]\ntype = \"free\"\n".to_string());
         self

--- a/crates/lib/src/validator/config_validator.rs
+++ b/crates/lib/src/validator/config_validator.rs
@@ -855,7 +855,18 @@ impl ConfigValidator {
                     );
                 }
             }
-            PriceModel::FixedStable { tokens, strict, .. } => {
+            PriceModel::FixedStable { amount, tokens, strict } => {
+                if tokens.is_empty() {
+                    errors.push(
+                        "FixedStable price model requires at least one token in 'tokens'"
+                            .to_string(),
+                    );
+                }
+                if *amount == 0 {
+                    errors.push(
+                        "FixedStable price model 'amount' must be greater than zero".to_string(),
+                    );
+                }
                 for token in tokens {
                     if Pubkey::from_str(token).is_err() {
                         errors
@@ -1874,6 +1885,107 @@ mod tests {
 
         assert!(errors.iter().any(|e| e
             .contains("Token address for fixed_stable price is not in allowed spl paid tokens")));
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_validate_with_result_fixed_stable_price_zero_amount_errors() {
+        let config = Config {
+            validation: ValidationConfig {
+                max_allowed_lamports: 1_000_000,
+                max_signatures: 10,
+                allowed_programs: ProgramsConfig::Allowlist(vec![SYSTEM_PROGRAM_ID.to_string()]),
+                allowed_tokens: vec!["4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU".to_string()],
+                allowed_spl_paid_tokens: SplTokenConfig::Allowlist(vec![
+                    "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU".to_string(),
+                ]),
+                disallowed_accounts: vec![],
+                price_source: PriceSource::Jupiter,
+                fee_payer_policy: FeePayerPolicy::default(),
+                price: PriceConfig {
+                    model: PriceModel::FixedStable {
+                        amount: 0, // Should error
+                        tokens: vec![
+                            "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU".to_string(), // allowed
+                        ],
+                        strict: false,
+                    },
+                },
+                token_2022: Token2022Config::default(),
+                allow_durable_transactions: false,
+                max_price_staleness_slots: 0,
+                require_one_of_programs: vec![],
+                cross_cluster_check: false,
+                cross_cluster_endpoints: vec![],
+            },
+            metrics: MetricsConfig::default(),
+            kora: KoraConfig::default(),
+        };
+
+        let _ = update_config(config);
+
+        let rpc_client = RpcClient::new_with_commitment(
+            "http://localhost:8899".to_string(),
+            CommitmentConfig::confirmed(),
+        );
+        let result = ConfigValidator::validate_with_result(&rpc_client, true).await;
+        assert!(result.is_err());
+        let errors = result.unwrap_err();
+
+        assert!(errors
+            .iter()
+            .any(|e| e.contains("FixedStable price model 'amount' must be greater than zero")));
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_validate_with_result_fixed_stable_price_empty_tokens_errors() {
+        let config = Config {
+            validation: ValidationConfig {
+                max_allowed_lamports: 1_000_000,
+                max_signatures: 10,
+                allowed_programs: ProgramsConfig::Allowlist(vec![SYSTEM_PROGRAM_ID.to_string()]),
+                allowed_tokens: vec!["4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU".to_string()],
+                allowed_spl_paid_tokens: SplTokenConfig::Allowlist(vec![
+                    "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU".to_string(),
+                ]),
+                disallowed_accounts: vec![],
+                price_source: PriceSource::Jupiter,
+                fee_payer_policy: FeePayerPolicy::default(),
+                price: PriceConfig {
+                    model: PriceModel::FixedStable {
+                        amount: 1000,
+                        tokens: vec![], // Should error
+                        strict: false,
+                    },
+                },
+                token_2022: Token2022Config::default(),
+                allow_durable_transactions: false,
+                max_price_staleness_slots: 0,
+                require_one_of_programs: vec![],
+                cross_cluster_check: false,
+                cross_cluster_endpoints: vec![],
+            },
+            metrics: MetricsConfig::default(),
+            kora: KoraConfig::default(),
+        };
+
+        let _ = update_config(config);
+
+        let rpc_client = RpcClient::new_with_commitment(
+            "http://localhost:8899".to_string(),
+            CommitmentConfig::confirmed(),
+        );
+        let result = ConfigValidator::validate_with_result(&rpc_client, true).await;
+        assert!(result.is_err());
+        let errors = result.unwrap_err();
+
+        assert!(
+            errors
+                .iter()
+                .any(|e| e
+                    .contains("FixedStable price model requires at least one token in 'tokens'"))
+        );
     }
 
     #[tokio::test]

--- a/crates/lib/src/validator/config_validator.rs
+++ b/crates/lib/src/validator/config_validator.rs
@@ -855,6 +855,36 @@ impl ConfigValidator {
                     );
                 }
             }
+            PriceModel::FixedStable { tokens, strict, .. } => {
+                for token in tokens {
+                    if Pubkey::from_str(token).is_err() {
+                        errors
+                            .push(format!("Invalid token address for fixed_stable price: {token}"));
+                    } else if !config.validation.supports_token(token) {
+                        errors.push(format!(
+                            "Token address for fixed_stable price is not in allowed spl paid tokens: {token}"
+                        ));
+                    }
+                }
+
+                let has_auth = config.kora.auth.has_auth();
+                if !has_auth {
+                    warnings.push(
+                        "⚠️  SECURITY: FixedStable pricing with NO authentication enabled. \
+                        Without authentication, anyone can spam transactions at your expense. \
+                        Consider enabling api_key or hmac_secret in [kora.auth]."
+                            .to_string(),
+                    );
+                }
+
+                if *strict {
+                    warnings.push(
+                        "Strict pricing mode enabled. \
+                        Transactions where fee payer outflow exceeds the fixed price will be rejected."
+                            .to_string(),
+                    );
+                }
+            }
             PriceModel::Margin { margin } => {
                 if *margin < 0.0 {
                     errors.push("Margin cannot be negative".to_string());
@@ -1794,6 +1824,56 @@ mod tests {
                 .any(|e| e
                     .contains("Token address for fixed price is not in allowed spl paid tokens"))
         );
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_validate_with_result_fixed_stable_price_not_in_allowed_tokens() {
+        let config = Config {
+            validation: ValidationConfig {
+                max_allowed_lamports: 1_000_000,
+                max_signatures: 10,
+                allowed_programs: ProgramsConfig::Allowlist(vec![SYSTEM_PROGRAM_ID.to_string()]),
+                allowed_tokens: vec!["4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU".to_string()],
+                allowed_spl_paid_tokens: SplTokenConfig::Allowlist(vec![
+                    "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU".to_string(),
+                ]),
+                disallowed_accounts: vec![],
+                price_source: PriceSource::Jupiter,
+                fee_payer_policy: FeePayerPolicy::default(),
+                price: PriceConfig {
+                    model: PriceModel::FixedStable {
+                        amount: 1000,
+                        tokens: vec![
+                            "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU".to_string(), // allowed
+                            "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v".to_string(), // valid but not allowed
+                        ],
+                        strict: false,
+                    },
+                },
+                token_2022: Token2022Config::default(),
+                allow_durable_transactions: false,
+                max_price_staleness_slots: 0,
+                require_one_of_programs: vec![],
+                cross_cluster_check: false,
+                cross_cluster_endpoints: vec![],
+            },
+            metrics: MetricsConfig::default(),
+            kora: KoraConfig::default(),
+        };
+
+        let _ = update_config(config);
+
+        let rpc_client = RpcClient::new_with_commitment(
+            "http://localhost:8899".to_string(),
+            CommitmentConfig::confirmed(),
+        );
+        let result = ConfigValidator::validate_with_result(&rpc_client, true).await;
+        assert!(result.is_err());
+        let errors = result.unwrap_err();
+
+        assert!(errors.iter().any(|e| e
+            .contains("Token address for fixed_stable price is not in allowed spl paid tokens")));
     }
 
     #[tokio::test]

--- a/crates/lib/src/validator/transaction_validator.rs
+++ b/crates/lib/src/validator/transaction_validator.rs
@@ -927,7 +927,11 @@ impl TransactionValidator {
         config: &Config,
         fee_calculation: &TotalFeeCalculation,
     ) -> Result<(), KoraError> {
-        if !matches!(&config.validation.price.model, PriceModel::Fixed { strict: true, .. }) {
+        let is_strict = matches!(
+            &config.validation.price.model,
+            PriceModel::Fixed { strict: true, .. } | PriceModel::FixedStable { strict: true, .. }
+        );
+        if !is_strict {
             return Ok(());
         }
 
@@ -3668,6 +3672,58 @@ mod tests {
         } else {
             panic!("Expected ValidationError");
         }
+    }
+
+    #[test]
+    #[serial]
+    fn test_strict_pricing_fixed_stable_enforced() {
+        use crate::{
+            fee::price::PriceModel, state::update_config, tests::config_mock::ConfigMockBuilder,
+        };
+
+        let mut config = ConfigMockBuilder::new().build();
+        config.validation.price.model = PriceModel::FixedStable {
+            amount: 5000,
+            tokens: vec!["EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v".to_string()],
+            strict: true,
+        };
+        let _ = update_config(config);
+
+        // Fixed price = 5000, but total = 3000 + 2000 + 5000 = 10000 > 5000
+        let fee_calc = TotalFeeCalculation::new(5000, 3000, 2000, 5000, 0, 0);
+
+        let config = get_config().unwrap();
+        let result = TransactionValidator::validate_strict_pricing_with_fee(config, &fee_calc);
+
+        assert!(result.is_err(), "FixedStable strict=true must reject when total exceeds fixed");
+        if let Err(KoraError::ValidationError(msg)) = result {
+            assert!(msg.contains("Strict pricing violation"));
+        } else {
+            panic!("Expected ValidationError");
+        }
+    }
+
+    #[test]
+    #[serial]
+    fn test_strict_pricing_fixed_stable_not_strict_passes() {
+        use crate::{
+            fee::price::PriceModel, state::update_config, tests::config_mock::ConfigMockBuilder,
+        };
+
+        let mut config = ConfigMockBuilder::new().build();
+        config.validation.price.model = PriceModel::FixedStable {
+            amount: 5000,
+            tokens: vec!["EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v".to_string()],
+            strict: false,
+        };
+        let _ = update_config(config);
+
+        let fee_calc = TotalFeeCalculation::new(5000, 10000, 0, 0, 0, 0);
+
+        let config = get_config().unwrap();
+        let result = TransactionValidator::validate_strict_pricing_with_fee(config, &fee_calc);
+
+        assert!(result.is_ok(), "FixedStable strict=false must not enforce cap");
     }
 
     #[tokio::test]

--- a/crates/lib/src/validator/transaction_validator.rs
+++ b/crates/lib/src/validator/transaction_validator.rs
@@ -3726,6 +3726,33 @@ mod tests {
         assert!(result.is_ok(), "FixedStable strict=false must not enforce cap");
     }
 
+    #[test]
+    #[serial]
+    fn test_strict_pricing_fixed_stable_passes_within_cap() {
+        use crate::{
+            fee::price::PriceModel, state::update_config, tests::config_mock::ConfigMockBuilder,
+        };
+
+        let mut config = ConfigMockBuilder::new().build();
+        config.validation.price.model = PriceModel::FixedStable {
+            amount: 10000,
+            tokens: vec!["EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v".to_string()],
+            strict: true,
+        };
+        let _ = update_config(config);
+
+        // Fixed price = 10000, total = 3000 + 2000 = 5000 <= 10000
+        let fee_calc = TotalFeeCalculation::new(10000, 3000, 2000, 0, 0, 0);
+
+        let config = get_config().unwrap();
+        let result = TransactionValidator::validate_strict_pricing_with_fee(config, &fee_calc);
+
+        assert!(
+            result.is_ok(),
+            "FixedStable strict=true must pass when total is within the fixed price"
+        );
+    }
+
     #[tokio::test]
     #[serial]
     async fn test_durable_transaction_rejected_by_default() {

--- a/kora.toml
+++ b/kora.toml
@@ -132,8 +132,16 @@ allow_deactivate = false        # Allow fee payer to be authority in ALT Deactiv
 allow_close = false             # Allow fee payer to be authority in ALT CloseLookupTable
 
 [validation.price]
-type = "margin" # free / margin / fixed
+type = "margin" # free / margin / fixed / fixed_stable
 margin = 0.1  # 10% margin (0.1 = 10%, 1.0 = 100%)
+
+# fixed_stable: one fee payable in any of several stablecoins. `amount` is in base units of the
+# first listed mint (which anchors the fee); other mints are accepted at the equivalent oracle value.
+# [validation.price]
+# type = "fixed_stable"
+# amount = 100000              # 0.10 of a 6-decimal stablecoin
+# tokens = ["<usdc-mint>", "<usdt-mint>"]  # must also appear in allowed_spl_paid_tokens
+# strict = false              # true rejects transactions whose real cost exceeds the fixed fee
 
 [validation.token_2022]
 transfer_hook_policy = "deny_mutable_for_delayed_signing"

--- a/sdks/ts/docs/README.md
+++ b/sdks/ts/docs/README.md
@@ -698,6 +698,12 @@ type PriceModel =
   type: "fixed";
 }
   | {
+  amount: number;
+  tokens: string[];
+  strict: boolean;
+  type: "fixed_stable";
+}
+  | {
   type: "free";
 };
 ```

--- a/sdks/ts/src/types/index.ts
+++ b/sdks/ts/src/types/index.ts
@@ -305,10 +305,12 @@ export interface Token2022Config {
  * @remarks
  * - `margin`: Adds a percentage margin to base fees
  * - `fixed`: Charges a fixed amount in a specific token
+ * - `fixed_stable`: Charges a fixed fee payable in any of the listed mints, anchored to the first
  * - `free`: No additional fees charged
  */
 export type PriceModel =
     | { amount: number; token: string; type: 'fixed' }
+    | { amount: number; tokens: string[]; strict: boolean; type: 'fixed_stable' }
     | { margin: number; type: 'margin' }
     | { type: 'free' };
 


### PR DESCRIPTION
Operators can now specify a single fixed fee that applies to any of a
list of stablecoin mints, treating them as equivalent (e.g. charge
0.10 regardless of whether the user pays in USDC, USDT, PYUSD, etc.).

- Add `PriceModel::FixedStable { amount, tokens, strict }` variant
- Fee quoting returns `amount` directly for any token in the group,
  bypassing per-token oracle calls
- Lamport equivalent still uses the first listed token as reference
  (one oracle call for validation/max_allowed_lamports enforcement)
- Add `get_required_lamports_with_fixed_stable` and
  `get_fixed_stable_fee_for_token` to PriceConfig
- Handle FixedStable in estimate_kora_fee and calculate_fee_in_token
- Update OpenAPI spec with fixed_stable variant
- Add TOML builder helper and full unit test coverage
