### PR TITLE
fix(ts-sdk): move kit integration to /kit subpath so the main entry bundles

### DIFF
--- a/sdks/ts/package.json
+++ b/sdks/ts/package.json
@@ -1,10 +1,20 @@
 {
   "name": "@solana/kora",
-  "version": "0.3.0-beta.1",
+  "version": "0.3.0-beta.2",
   "description": "TypeScript SDK for Kora RPC",
   "main": "dist/src/index.js",
   "type": "module",
   "types": "dist/src/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/src/index.d.ts",
+      "default": "./dist/src/index.js"
+    },
+    "./kit": {
+      "types": "./dist/src/kit/index.d.ts",
+      "default": "./dist/src/kit/index.js"
+    }
+  },
   "scripts": {
     "build": "tsc",
     "test": "jest",

--- a/sdks/ts/src/index.ts
+++ b/sdks/ts/src/index.ts
@@ -1,5 +1,4 @@
 export * from './error.js';
 export * from './types/index.js';
 export { KoraClient } from './client.js';
-export { createKitKoraClient, kora, type KoraKitClient } from './kit/index.js';
 export { koraPlugin, type KoraApi } from './plugin.js';

--- a/sdks/ts/test/integration.test.ts
+++ b/sdks/ts/test/integration.test.ts
@@ -28,7 +28,8 @@ import {
     tokenProgram,
 } from '@solana-program/token';
 
-import { KoraClient, kora } from '../src/index.js';
+import { kora } from '../src/kit/index.js';
+import { KoraClient } from '../src/index.js';
 import { runAuthenticationTests } from './auth-setup.js';
 import setupTestSuite from './setup.js';
 


### PR DESCRIPTION
Closes #580.

## Problem
`import { KoraClient } from "@solana/kora"` (0.3.0-beta.x) breaks bundlers — esbuild fails with `Could not resolve "@solana/kit-plugin-payer"` (and `-signer`). The main barrel (`src/index.ts`) re-exports `createKitKoraClient`/`kora`/`KoraKitClient` from `./kit`, and `./kit/index.ts` imports the `@solana/kit-plugin-*` peers — so **every** `@solana/kora` import drags those peers into the graph, even for consumers that only use `KoraClient`. (`package.json` also had no `exports` map.)

This broke the SDP API's Docker/esbuild build when adopting 0.3.0-beta for the typed `user_id`.

## Fix
- Drop the kit re-export from the main barrel (`src/index.ts`); `KoraClient`, `koraPlugin`, and types stay (all bundle-clean — `client.ts`/`plugin.ts` only use `@solana/kit`).
- Add a proper `exports` map: `.` → core client, **`./kit`** → the kit integration. Consumers who want the kit client import `@solana/kora/kit` (and provide the kit-plugin peers).
- Bump `0.3.0-beta.1` → `0.3.0-beta.2`.

## Verify
- `tsc` build clean; `dist/src/index.js` now has **0** references to `./kit`; `dist/src/kit/index.js` still emitted for the subpath.
- Unit tests green: **85 passed** (`unit` + `kit-client` + `plugin`). `kit-client.test.ts` already imported from `../src/kit`; updated the one main-barrel `kora` import in `integration.test.ts` → `../src/kit`.

## ⚠️ Breaking (beta only)
`createKitKoraClient` / `kora` / `KoraKitClient` move from `@solana/kora` → **`@solana/kora/kit`**.
