### PR TITLE
fix(transaction): support mint-level setAuthority in CPI inner instruction reconstruction

### DIFF
--- a/crates/lib/src/transaction/instruction_util.rs
+++ b/crates/lib/src/transaction/instruction_util.rs
@@ -1590,7 +1590,16 @@ impl IxUtils {
                 })
             }
             PARSED_DATA_FIELD_SET_AUTHORITY => {
-                let account = Self::get_field_as_pubkey(info, PARSED_DATA_FIELD_ACCOUNT)?;
+                // The parser names the target field by authority level: `account` for
+                // AccountOwner/CloseAccount, `mint` for all mint-level authority types
+                // (MintTokens, FreezeAccount, and the Token-2022 extension authorities).
+                // See agave's parse_token.rs `TokenInstruction::SetAuthority` arm.
+                let target_field = if info.get(PARSED_DATA_FIELD_ACCOUNT).is_some() {
+                    PARSED_DATA_FIELD_ACCOUNT
+                } else {
+                    PARSED_DATA_FIELD_MINT
+                };
+                let account = Self::get_field_as_pubkey(info, target_field)?;
                 let current_authority =
                     Self::get_field_as_pubkey(info, PARSED_DATA_FIELD_AUTHORITY)?;
 
@@ -3803,6 +3812,37 @@ mod tests {
         Ok(parsed)
     }
 
+    fn create_parsed_spl_token_set_authority(
+        owned: &Pubkey,
+        authority_type: spl_token_interface::instruction::AuthorityType,
+        new_authority: &Pubkey,
+        authority: &Pubkey,
+    ) -> Result<solana_transaction_status_client_types::ParsedInstruction, Box<dyn std::error::Error>>
+    {
+        let solana_instruction = spl_token_interface::instruction::set_authority(
+            &spl_token_interface::ID,
+            owned,
+            Some(new_authority),
+            authority_type,
+            authority,
+            &[],
+        )?;
+
+        let message = Message::new(&[solana_instruction], None);
+        let compiled_instruction = &message.instructions[0];
+
+        let account_keys_for_parsing = AccountKeys::new(&message.account_keys, None);
+
+        let parsed = parse_instruction::parse(
+            &spl_token_interface::ID,
+            compiled_instruction,
+            &account_keys_for_parsing,
+            None,
+        )?;
+
+        Ok(parsed)
+    }
+
     fn create_parsed_spl_token_sync_native(
         account: &Pubkey,
     ) -> Result<solana_transaction_status_client_types::ParsedInstruction, Box<dyn std::error::Error>>
@@ -5656,6 +5696,67 @@ mod tests {
         assert_eq!(compiled.program_id_index, 0);
         assert_eq!(compiled.accounts, vec![1, 2, 3]); // account, destination, authority indices
         assert_eq!(compiled.data, instruction.data);
+    }
+
+    #[test]
+    fn test_reconstruct_spl_token_set_authority_on_token_account() {
+        let token_account = Pubkey::new_unique();
+        let new_authority = Pubkey::new_unique();
+        let authority = Pubkey::new_unique();
+        let token_program_id = spl_token_interface::ID;
+        let account_keys = vec![token_program_id, token_account, authority];
+
+        // AccountOwner is account-level, so the parser emits the target under `account`.
+        let solana_parsed = create_parsed_spl_token_set_authority(
+            &token_account,
+            spl_token_interface::instruction::AuthorityType::AccountOwner,
+            &new_authority,
+            &authority,
+        )
+        .expect("Failed to create parsed instruction");
+
+        let result = IxUtils::reconstruct_spl_token_instruction(
+            &solana_parsed,
+            &IxUtils::build_account_keys_hashmap(&account_keys),
+        );
+
+        assert!(
+            result.is_ok(),
+            "account-level setAuthority should reconstruct: {:?}",
+            result.err()
+        );
+        let compiled = result.unwrap();
+        assert_eq!(compiled.program_id_index, 0);
+        assert_eq!(compiled.accounts, vec![1, 2]); // target account, current authority indices
+    }
+
+    #[test]
+    fn test_reconstruct_spl_token_set_authority_on_mint() {
+        let mint = Pubkey::new_unique();
+        let new_authority = Pubkey::new_unique();
+        let authority = Pubkey::new_unique();
+        let token_program_id = spl_token_interface::ID;
+        let account_keys = vec![token_program_id, mint, authority];
+
+        // FreezeAccount is mint-level, so the parser emits the target under `mint`
+        // instead of `account` (agave parse_token.rs, TokenInstruction::SetAuthority).
+        let solana_parsed = create_parsed_spl_token_set_authority(
+            &mint,
+            spl_token_interface::instruction::AuthorityType::FreezeAccount,
+            &new_authority,
+            &authority,
+        )
+        .expect("Failed to create parsed instruction");
+
+        let result = IxUtils::reconstruct_spl_token_instruction(
+            &solana_parsed,
+            &IxUtils::build_account_keys_hashmap(&account_keys),
+        );
+
+        assert!(result.is_ok(), "mint-level setAuthority should reconstruct: {:?}", result.err());
+        let compiled = result.unwrap();
+        assert_eq!(compiled.program_id_index, 0);
+        assert_eq!(compiled.accounts, vec![1, 2]); // mint, current authority indices
     }
 
     #[test]


### PR DESCRIPTION
Fixes #587

## TL;DR

Kora cannot sponsor any transaction whose CPI inner instructions include a **mint-level** `setAuthority` — the signing request aborts with `-32092 Serialization error: Missing field 'account'`. The reconstruction code assumes the parsed-JSON target field is always named `account`, but agave names it `mint` for 15 of the 17 authority types. One-line fix + two regression tests that run through the real agave parser.

## Walkthrough: how we hit this

We deploy Token-2022 stablecoins with [`@solana/mosaic-sdk`](https://www.npmjs.com/package/@solana/mosaic-sdk) and sponsor the fee through Kora:

```ts
import {
  partiallySignTransactionMessageWithSigners,
  getBase64EncodedWireTransaction,
} from '@solana/kit';
import { createStablecoinInitTransaction } from '@solana/mosaic-sdk';

// One transaction: create mint, enable extensions (pausable, permanent
// delegate, confidential balances, metadata), set up sRFC-37 Token-ACL.
const tx = await createStablecoinInitTransaction(
  rpc,
  'Demo USD', 'DUSD', 6, metadataUri,
  custodySigner,        // mint authority — holds every power slot
  mintKeypair,
  koraFeePayer,         // fee payer = Kora's signer address
  'blocklist',
  undefined, undefined, undefined, undefined,
  true,                 // enableSrfc37 → Token-ACL setup instructions
  custodyAddress,       // freeze authority
);

// custody + mint keypair sign (Kora's fee-payer signature is still missing),
// then hand the wire-encoded transaction to Kora to co-sign and submit:
const signedTx = await partiallySignTransactionMessageWithSigners(tx);
const base64SignedTx = getBase64EncodedWireTransaction(signedTx);

await koraClient.signAndSendTransaction({ transaction: base64SignedTx });
```

The request is an ordinary JSON-RPC call — the transaction is an opaque base64 blob:

```json
{"jsonrpc":"2.0","id":1,"method":"signAndSendTransaction",
 "params":{"transaction":"AQAIDEnn3…"}}
```

Every response is:

```json
{"jsonrpc":"2.0","id":1,"error":{"code":-32092,
 "message":"Serialization error: Missing field 'account'"}}
```

The transaction is valid — it lands fine when self-submitted without Kora.

## Root cause

Before co-signing, Kora simulates the transaction to validate **CPI inner instructions** against the fee-payer policy (`fetch_inner_instructions` in `versioned_transaction.rs`). The RPC node returns those inner instructions only in `jsonParsed` form, and Kora reconstructs each one from that JSON.

The Token-ACL program in the deploy above CPIs a `SetAuthority` on the **mint** (freeze authority). The node serializes that inner instruction as:

```json
{"program":"spl-token","parsed":{
  "type":"setAuthority",
  "info":{"mint":"Fv3k…","authorityType":"freezeAccount",
          "newAuthority":"…","authority":"8dHE…"}}}
```

Note the target key is **`mint`**, not `account`. That's not variance — it's agave's documented-in-source naming rule ([`transaction-status/src/parse_token.rs`, `TokenInstruction::SetAuthority` arm](https://github.com/anza-xyz/agave/blob/master/transaction-status/src/parse_token.rs)):

```rust
// agave — the WRITER of the JSON. The key name depends on authority level:
let owned = match authority_type {
    AuthorityType::MintTokens
    | AuthorityType::FreezeAccount
    | AuthorityType::TransferFeeConfig
    | AuthorityType::WithheldWithdraw
    | AuthorityType::CloseMint
    | AuthorityType::InterestRate
    | AuthorityType::PermanentDelegate
    | AuthorityType::ConfidentialTransferMint
    | AuthorityType::TransferHookProgramId
    | AuthorityType::ConfidentialTransferFeeConfig
    | AuthorityType::MetadataPointer
    | AuthorityType::GroupPointer
    | AuthorityType::GroupMemberPointer
    | AuthorityType::ScaledUiAmount
    | AuthorityType::Pause
    | AuthorityType::PermissionedBurn => "mint",
    AuthorityType::AccountOwner | AuthorityType::CloseAccount => "account",
};
let mut value = json!({
    owned: account_keys[instruction.accounts[0] as usize].to_string(),
    "authorityType": …, "newAuthority": …,
});
```

Kora's reader assumes the bottom branch is the only one (`instruction_util.rs`):

```rust
// kora — the READER, before this PR:
PARSED_DATA_FIELD_SET_AUTHORITY => {
    let account = Self::get_field_as_pubkey(info, PARSED_DATA_FIELD_ACCOUNT)?;
    //            ^ errors with "Missing field 'account'" for every
    //              mint-level authority type — 15 of the 17 variants
```

Same positional `accounts[0]`, same pubkey — only the JSON key differs. The `?` propagates, so instead of the instruction being *validated*, the entire signing request dies.

## Fix

Read whichever key is present (allocation-free — no throwaway error on the mint path):

```rust
let target_field = if info.get(PARSED_DATA_FIELD_ACCOUNT).is_some() {
    PARSED_DATA_FIELD_ACCOUNT
} else {
    PARSED_DATA_FIELD_MINT
};
let account = Self::get_field_as_pubkey(info, target_field)?;
```

Behavior change: mint-level `setAuthority` CPIs go from *hard failure* to *normal fee-payer policy validation*. The reconstructed instruction still carries `[target, current_authority]`, so the policy questions ("is the fee payer's account targeted? is the fee payer the authority?") apply identically to both flavors — they're kind-agnostic. Agave emits exactly one of the two keys, never both, so the precedence cannot pick a wrong value.

## Tests

Both tests build a **real** `set_authority` instruction and serialize it through the **actual** `parse_instruction::parse` — no hand-mocked JSON, so they assert against agave's real behavior:

- `test_reconstruct_spl_token_set_authority_on_token_account` — `AuthorityType::AccountOwner` → parses with `"account"` → passes before and after this PR
- `test_reconstruct_spl_token_set_authority_on_mint` — `AuthorityType::FreezeAccount` → parses with `"mint"` → **fails on main**, passes with the fix

All 8 existing setAuthority-related tests in the crate still pass.

## Out of scope / possible follow-ups

- **Multisig authorities**: agave emits `"multisigAuthority"` + `"signers"` (not `"authority"`) when the current authority is a multisig — those still fail to reconstruct. Same bug class, separate change.
- Reconstruction remains deliberately minimal (`data = vec![6]`; `authority_type`/`new_authority` discarded) per the existing comment — this PR preserves that contract.


