### PR TITLE
fix(deps): bump crossbeam-epoch to 0.9.20 to resolve RUSTSEC-2026-0204

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1401,9 +1401,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
cargo-audit fails on main and every open PR since 2026-07-06: crossbeam-epoch 0.9.18 is flagged by [RUSTSEC-2026-0204](https://rustsec.org/advisories/RUSTSEC-2026-0204) (invalid pointer dereference in `fmt::Pointer` for `Atomic`/`Shared`). Patched in 0.9.20.

Reachability: runtime transitive dependency — solana-client / solana-perf / solana-streamer → rayon → crossbeam-deque → crossbeam-epoch. The vulnerable code is the `fmt::Pointer` impl for `Atomic`/`Shared`, which only executes if crossbeam internals are explicitly pointer-formatted with an invalid pointer; rayon and the solana crates never do this, and kora does not use crossbeam directly. Not attacker-reachable. LOW/NO RISK, fixed since a clean lockfile bump exists.

Lockfile-only change: `cargo update -p crossbeam-epoch --precise 0.9.20`. Verified locally: `cargo audit` reports 0 vulnerabilities (4 allowed warnings remain, unchanged).

Unblocks cargo-audit on dependabot PRs #594, #595, #596 (they need a rebase after this merges).