### PR TITLE
ci: switch dependabot to biweekly patch-only updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,7 @@ multi-ecosystem-groups:
     schedule:
       interval: cron
       cronjob: "0 9 1,15 * *"
+      timezone: UTC
 
 updates:
   - package-ecosystem: cargo

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,50 +1,43 @@
 version: 2
+
+multi-ecosystem-groups:
+  all-deps:
+    schedule:
+      interval: cron
+      cronjob: "0 9 1,15 * *"
+
 updates:
   - package-ecosystem: cargo
     directory: "/"
-    schedule:
-      interval: weekly
+    multi-ecosystem-group: all-deps
+    patterns: ["*"]
     open-pull-requests-limit: 10
     cooldown:
       default-days: 7
-    ignore:
+    allow:
       - dependency-name: "*"
         update-types:
           - version-update:semver-patch
-    groups:
-      cargo-non-major:
-        applies-to: version-updates
-        update-types:
-          - minor
 
   - package-ecosystem: npm
     directory: "/sdks"
-    schedule:
-      interval: weekly
+    multi-ecosystem-group: all-deps
+    patterns: ["*"]
     open-pull-requests-limit: 10
     cooldown:
       default-days: 7
-    ignore:
+    allow:
       - dependency-name: "*"
         update-types:
           - version-update:semver-patch
-    groups:
-      npm-non-major:
-        applies-to: version-updates
-        update-types:
-          - minor
 
   - package-ecosystem: github-actions
     directory: "/"
-    schedule:
-      interval: weekly
+    multi-ecosystem-group: all-deps
+    patterns: ["*"]
     cooldown:
       default-days: 7
-    ignore:
+    allow:
       - dependency-name: "*"
         update-types:
           - version-update:semver-patch
-    groups:
-      actions:
-        patterns:
-          - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,13 +6,13 @@ multi-ecosystem-groups:
       interval: cron
       cronjob: "0 9 1,15 * *"
       timezone: UTC
+    open-pull-requests-limit: 10
 
 updates:
   - package-ecosystem: cargo
     directory: "/"
     multi-ecosystem-group: all-deps
     patterns: ["*"]
-    open-pull-requests-limit: 10
     cooldown:
       default-days: 7
     allow:
@@ -24,7 +24,6 @@ updates:
     directory: "/sdks"
     multi-ecosystem-group: all-deps
     patterns: ["*"]
-    open-pull-requests-limit: 10
     cooldown:
       default-days: 7
     allow:


### PR DESCRIPTION
## Summary
- Switch schedule from weekly to cron: 1st and 15th of the month, 09:00 UTC
- Restrict version updates to semver-patch via `allow` — majors and minors no longer open PRs
- Combine all ecosystems into a single PR via `multi-ecosystem-groups`
- Remove the `ignore` semver-patch rule, which also suppressed patch-level security PRs — security updates now always come through at any severity and bump level

## Test Plan
- YAML validated locally
- After merge: check Insights → Dependency graph → Dependabot for config parse errors
