### PR TITLE
chore(kora-deploy): bump to 0.2.0 for crates.io publish

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3547,7 +3547,7 @@ dependencies = [
 
 [[package]]
 name = "kora-deploy"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ repository = "https://github.com/solana-foundation/kora"
 
 [workspace.dependencies]
 kora-lib = { path = "crates/lib", version = "2.2.0-beta.7" }
-kora-deploy = { path = "crates/kora-deploy", version = "0.1.0" }
+kora-deploy = { path = "crates/kora-deploy", version = "0.2.0" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 anyhow = "1.0.102"

--- a/crates/kora-deploy/Cargo.toml
+++ b/crates/kora-deploy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kora-deploy"
-version = "0.1.0"
+version = "0.2.0"
 edition = { workspace = true }
 license = { workspace = true }
 repository = { workspace = true }


### PR DESCRIPTION
## Summary
- Bump `kora-deploy` `0.1.0 → 0.2.0`. `0.1.0` (the deploy-only version) is already on the crates.io index, so the registry-gated upgrade support (#592) can't publish under it.
- Updates the workspace dependency pin and `Cargo.lock` to match.

## Why
The publish workflow failed with `crate kora-deploy@0.1.0 already exists on crates.io index`. This bump unblocks publishing the upgrade-capable client.

## Test Plan
- `cargo check -p kora-deploy -p devnet-deploy-paymaster` passes with the new version.
- After merge: re-run the `rust-publish` workflow with `publish-kora-deploy=true` to publish 0.2.0.