### PR TITLE
fix: startup and config hardening (auth flags, usage-limit rules, signer pool, transfer-hook warning)

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -150,9 +150,6 @@ async fn main() -> Result<(), KoraError> {
         Some(Commands::Rpc { rpc_command }) => {
             match rpc_command {
                 RpcCommands::Start { rpc_args } => {
-                    // Apply CLI auth flags before validation and startup so the auth resolver and
-                    // the no-auth warning reflect them; otherwise a flag-only launch would expose
-                    // signing methods unauthenticated.
                     rpc_args.auth_args.apply_to_env();
 
                     // Validate config and signers before starting server

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -150,6 +150,11 @@ async fn main() -> Result<(), KoraError> {
         Some(Commands::Rpc { rpc_command }) => {
             match rpc_command {
                 RpcCommands::Start { rpc_args } => {
+                    // Apply CLI auth flags before validation and startup so the auth resolver and
+                    // the no-auth warning reflect them; otherwise a flag-only launch would expose
+                    // signing methods unauthenticated.
+                    rpc_args.auth_args.apply_to_env();
+
                     // Validate config and signers before starting server
                     match ConfigValidator::validate_with_result_and_signers(
                         rpc_client.as_ref(),

--- a/crates/lib/src/rpc_server/args.rs
+++ b/crates/lib/src/rpc_server/args.rs
@@ -36,3 +36,54 @@ pub struct AuthArgs {
     #[arg(long, env = "KORA_HMAC_SECRET", help_heading = "Authentication")]
     pub hmac_secret: Option<String>,
 }
+
+impl AuthArgs {
+    /// Apply CLI auth flags to the environment the server's auth resolver reads. Without this a
+    /// flag-only launch (`--api-key`/`--hmac-secret` with nothing in env or `kora.toml`) would
+    /// build no auth middleware and expose signing methods unauthenticated.
+    pub fn apply_to_env(&self) {
+        if let Some(api_key) = &self.api_key {
+            std::env::set_var("KORA_API_KEY", api_key);
+        }
+        if let Some(hmac_secret) = &self.hmac_secret {
+            std::env::set_var("KORA_HMAC_SECRET", hmac_secret);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serial_test::serial;
+
+    #[test]
+    #[serial]
+    fn test_apply_to_env_sets_flags() {
+        std::env::remove_var("KORA_API_KEY");
+        std::env::remove_var("KORA_HMAC_SECRET");
+
+        AuthArgs {
+            api_key: Some("flag-api-key".to_string()),
+            hmac_secret: Some("flag-hmac-secret".to_string()),
+        }
+        .apply_to_env();
+
+        assert_eq!(std::env::var("KORA_API_KEY").unwrap(), "flag-api-key");
+        assert_eq!(std::env::var("KORA_HMAC_SECRET").unwrap(), "flag-hmac-secret");
+
+        std::env::remove_var("KORA_API_KEY");
+        std::env::remove_var("KORA_HMAC_SECRET");
+    }
+
+    #[test]
+    #[serial]
+    fn test_apply_to_env_leaves_unset_flags_untouched() {
+        std::env::remove_var("KORA_API_KEY");
+        std::env::remove_var("KORA_HMAC_SECRET");
+
+        AuthArgs { api_key: None, hmac_secret: None }.apply_to_env();
+
+        assert!(std::env::var("KORA_API_KEY").is_err());
+        assert!(std::env::var("KORA_HMAC_SECRET").is_err());
+    }
+}

--- a/crates/lib/src/rpc_server/args.rs
+++ b/crates/lib/src/rpc_server/args.rs
@@ -38,9 +38,7 @@ pub struct AuthArgs {
 }
 
 impl AuthArgs {
-    /// Apply CLI auth flags to the environment the server's auth resolver reads. Without this a
-    /// flag-only launch (`--api-key`/`--hmac-secret` with nothing in env or `kora.toml`) would
-    /// build no auth middleware and expose signing methods unauthenticated.
+    /// Maps CLI auth flags to the env vars the auth resolver reads; must run before validation.
     pub fn apply_to_env(&self) {
         if let Some(api_key) = &self.api_key {
             std::env::set_var("KORA_API_KEY", api_key);

--- a/crates/lib/src/signer/pool.rs
+++ b/crates/lib/src/signer/pool.rs
@@ -299,6 +299,16 @@ impl SignerPool {
             );
         }
 
+        let mut seen_pubkeys = std::collections::HashSet::new();
+        for signer in &signers {
+            let pubkey = signer.signer.pubkey();
+            if !seen_pubkeys.insert(pubkey) {
+                return Err(KoraError::ValidationError(format!(
+                    "Duplicate signer pubkey in pool: {pubkey}. Each signer backend must resolve to a unique pubkey so signer_key selection and health tracking stay bound to the chosen backend."
+                )));
+            }
+        }
+
         let total_weight: u32 = signers.iter().map(|s| s.weight).sum();
 
         if matches!(config.signer_pool.strategy, SelectionStrategy::Weighted) && total_weight == 0 {
@@ -578,7 +588,34 @@ mod tests {
     use solana_sdk::signature::Keypair;
 
     use super::*;
+    use crate::signer::config::{MemorySignerConfig, SignerPoolSettings, SignerTypeConfig};
     use std::collections::HashMap;
+
+    #[tokio::test]
+    async fn test_from_config_rejects_duplicate_signer_pubkeys() {
+        let keypair = Keypair::new();
+        std::env::set_var("KORA_TEST_DUP_PUBKEY_KEY", keypair.to_base58_string());
+
+        let memory = || SignerTypeConfig::Memory {
+            config: MemorySignerConfig { private_key_env: "KORA_TEST_DUP_PUBKEY_KEY".to_string() },
+        };
+        let config = SignerPoolConfig {
+            signer_pool: SignerPoolSettings { strategy: SelectionStrategy::RoundRobin },
+            signers: vec![
+                SignerConfig { name: "signer_a".to_string(), weight: Some(1), config: memory() },
+                SignerConfig { name: "signer_b".to_string(), weight: Some(1), config: memory() },
+            ],
+        };
+
+        let result = SignerPool::from_config(config).await;
+        std::env::remove_var("KORA_TEST_DUP_PUBKEY_KEY");
+
+        let err = match result {
+            Ok(_) => panic!("pool with duplicate signer pubkeys must be rejected"),
+            Err(e) => e,
+        };
+        assert!(err.to_string().contains("Duplicate signer pubkey"), "unexpected error: {err}");
+    }
 
     fn create_test_pool() -> SignerPool {
         // Create test signers using external signer library

--- a/crates/lib/src/signer/pool.rs
+++ b/crates/lib/src/signer/pool.rs
@@ -587,11 +587,14 @@ impl SignerPool {
 mod tests {
     use solana_sdk::signature::Keypair;
 
+    use serial_test::serial;
+
     use super::*;
     use crate::signer::config::{MemorySignerConfig, SignerPoolSettings, SignerTypeConfig};
     use std::collections::HashMap;
 
     #[tokio::test]
+    #[serial]
     async fn test_from_config_rejects_duplicate_signer_pubkeys() {
         let keypair = Keypair::new();
         std::env::set_var("KORA_TEST_DUP_PUBKEY_KEY", keypair.to_base58_string());

--- a/crates/lib/src/validator/config_validator.rs
+++ b/crates/lib/src/validator/config_validator.rs
@@ -484,6 +484,26 @@ impl ConfigValidator {
         }
     }
 
+    fn warn_mutable_transfer_hook_payment_risk(
+        validation: &crate::config::ValidationConfig,
+        warnings: &mut Vec<String>,
+    ) {
+        let allows_immediate_mutable_hook = !matches!(
+            validation.token_2022.transfer_hook_policy,
+            crate::config::TransferHookPolicy::DenyAll
+        );
+        if allows_immediate_mutable_hook && validation.is_payment_required() {
+            warnings.push(
+                "⚠️  SECURITY: transfer_hook_policy allows mutable Token-2022 transfer hooks on \
+                immediate signAndSend. A payment mint with a mutable transfer hook can refund \
+                Kora's payment after validation but before execution, leaving zero net payment. \
+                Use transfer_hook_policy = \"deny_all\", or only accept payment mints with \
+                immutable transfer hooks."
+                    .to_string(),
+            );
+        }
+    }
+
     pub async fn validate(_rpc_client: &RpcClient) -> Result<(), KoraError> {
         let config = &get_config()?;
 
@@ -818,6 +838,8 @@ impl ConfigValidator {
 
         // Validate fee payer policy - warn about enabled risky operations
         Self::validate_fee_payer_policy(&config.validation.fee_payer_policy, &mut warnings);
+
+        Self::warn_mutable_transfer_hook_payment_risk(&config.validation, &mut warnings);
 
         // Validate margin (error if negative)
         match &config.validation.price.model {
@@ -3080,6 +3102,39 @@ mod tests {
         let mut warnings = Vec::new();
         ConfigValidator::warn_unvalidated_programs(&allowed, &mut warnings);
         assert!(warnings.is_empty(), "Expected no warnings for known programs, got: {warnings:?}");
+    }
+
+    #[test]
+    fn test_warn_mutable_transfer_hook_payment_risk() {
+        use crate::{fee::price::PriceModel, tests::config_mock::ConfigMockBuilder};
+
+        let build = |policy: TransferHookPolicy, model: PriceModel| {
+            let mut config = ConfigMockBuilder::new().build();
+            config.validation.token_2022.transfer_hook_policy = policy;
+            config.validation.price.model = model;
+            config
+        };
+
+        // Paid pricing + policy that allows immediate-send mutable hooks -> warning.
+        let config = build(
+            TransferHookPolicy::DenyMutableForDelayedSigning,
+            PriceModel::Margin { margin: 0.0 },
+        );
+        let mut warnings = Vec::new();
+        ConfigValidator::warn_mutable_transfer_hook_payment_risk(&config.validation, &mut warnings);
+        assert!(warnings.iter().any(|w| w.contains("mutable Token-2022 transfer hooks")));
+
+        // DenyAll -> no warning.
+        let config = build(TransferHookPolicy::DenyAll, PriceModel::Margin { margin: 0.0 });
+        let mut warnings = Vec::new();
+        ConfigValidator::warn_mutable_transfer_hook_payment_risk(&config.validation, &mut warnings);
+        assert!(warnings.is_empty());
+
+        // Free pricing -> no warning even if the policy would allow mutable hooks.
+        let config = build(TransferHookPolicy::AllowAll, PriceModel::Free);
+        let mut warnings = Vec::new();
+        ConfigValidator::warn_mutable_transfer_hook_payment_risk(&config.validation, &mut warnings);
+        assert!(warnings.is_empty());
     }
 
     #[test]

--- a/crates/lib/src/validator/config_validator.rs
+++ b/crates/lib/src/validator/config_validator.rs
@@ -901,8 +901,6 @@ impl ConfigValidator {
         // Validate usage limit configuration
         let usage_config = &config.kora.usage_limit;
         if usage_config.enabled {
-            // enabled with no rules is a no-op at runtime (the limiter disables itself), so quotas
-            // silently disappear. Fail at startup instead of pretending limits are enforced.
             if usage_config.rules.is_empty() {
                 errors.push(
                     "usage_limit.enabled is true but no rules are configured; add at least one \

--- a/crates/lib/src/validator/config_validator.rs
+++ b/crates/lib/src/validator/config_validator.rs
@@ -2,7 +2,9 @@ use std::{collections::HashSet, path::Path, str::FromStr};
 
 use crate::{
     admin::token_util::find_missing_atas,
-    config::{FeePayerPolicy, SplTokenConfig, Token2022Config, TransferHookPolicy},
+    config::{
+        FeePayerPolicy, SplTokenConfig, Token2022Config, TransferHookPolicy, ValidationConfig,
+    },
     constant::{
         BPF_LOADER_UPGRADEABLE_PROGRAM_ID, LIGHTHOUSE_PROGRAM_ID, LOADER_V4_PROGRAM_ID,
         MAX_RECAPTCHA_SCORE, MIN_RECAPTCHA_SCORE, STAKE_PROGRAM_ID, VOTE_PROGRAM_ID,
@@ -485,13 +487,11 @@ impl ConfigValidator {
     }
 
     fn warn_mutable_transfer_hook_payment_risk(
-        validation: &crate::config::ValidationConfig,
+        validation: &ValidationConfig,
         warnings: &mut Vec<String>,
     ) {
-        let allows_immediate_mutable_hook = !matches!(
-            validation.token_2022.transfer_hook_policy,
-            crate::config::TransferHookPolicy::DenyAll
-        );
+        let allows_immediate_mutable_hook =
+            !matches!(validation.token_2022.transfer_hook_policy, TransferHookPolicy::DenyAll);
         if allows_immediate_mutable_hook && validation.is_payment_required() {
             warnings.push(
                 "⚠️  SECURITY: transfer_hook_policy allows mutable Token-2022 transfer hooks on \

--- a/crates/lib/src/validator/config_validator.rs
+++ b/crates/lib/src/validator/config_validator.rs
@@ -901,6 +901,16 @@ impl ConfigValidator {
         // Validate usage limit configuration
         let usage_config = &config.kora.usage_limit;
         if usage_config.enabled {
+            // enabled with no rules is a no-op at runtime (the limiter disables itself), so quotas
+            // silently disappear. Fail at startup instead of pretending limits are enforced.
+            if usage_config.rules.is_empty() {
+                errors.push(
+                    "usage_limit.enabled is true but no rules are configured; add at least one \
+                     [[kora.usage_limit.rules]] or set enabled = false"
+                        .to_string(),
+                );
+            }
+
             let (usage_errors, usage_warnings) = CacheValidator::validate(usage_config).await;
             errors.extend(usage_errors);
             warnings.extend(usage_warnings);
@@ -1212,6 +1222,106 @@ mod tests {
         assert_eq!(warnings.len(), 1);
         assert!(!warnings.iter().any(|w| w.contains("PermanentDelegate")));
         assert!(warnings.iter().any(|w| w.contains("No authentication configured")));
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_validate_rejects_usage_limit_enabled_without_rules() {
+        std::env::set_var("JUPITER_API_KEY", "test-api-key");
+        let config = Config {
+            validation: ValidationConfig {
+                max_allowed_lamports: 1_000_000,
+                max_signatures: 10,
+                allowed_programs: ProgramsConfig::Allowlist(vec![
+                    SYSTEM_PROGRAM_ID.to_string(),
+                    SPL_TOKEN_PROGRAM_ID.to_string(),
+                ]),
+                allowed_tokens: vec!["4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU".to_string()],
+                allowed_spl_paid_tokens: SplTokenConfig::Allowlist(vec![
+                    "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU".to_string(),
+                ]),
+                disallowed_accounts: vec![],
+                price_source: PriceSource::Jupiter,
+                fee_payer_policy: FeePayerPolicy::default(),
+                price: PriceConfig::default(),
+                token_2022: Token2022Config::default(),
+                allow_durable_transactions: false,
+                max_price_staleness_slots: 0,
+                require_one_of_programs: vec![],
+                cross_cluster_check: false,
+                cross_cluster_endpoints: vec![],
+            },
+            kora: KoraConfig {
+                usage_limit: UsageLimitConfig {
+                    enabled: true,
+                    cache_url: None,
+                    fallback_if_unavailable: true,
+                    rules: vec![],
+                },
+                ..KoraConfig::default()
+            },
+            metrics: MetricsConfig::default(),
+        };
+
+        let _ = update_config(config);
+
+        let rpc_client = RpcClient::new_with_commitment(
+            "http://localhost:8899".to_string(),
+            CommitmentConfig::confirmed(),
+        );
+        let result = ConfigValidator::validate_with_result(&rpc_client, true).await;
+        let errors = result.expect_err("enabled usage_limit with no rules must fail validation");
+        assert!(errors.iter().any(|e| e.contains("no rules are configured")));
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_validate_allows_usage_limit_disabled_without_rules() {
+        std::env::set_var("JUPITER_API_KEY", "test-api-key");
+        let config = Config {
+            validation: ValidationConfig {
+                max_allowed_lamports: 1_000_000,
+                max_signatures: 10,
+                allowed_programs: ProgramsConfig::Allowlist(vec![
+                    SYSTEM_PROGRAM_ID.to_string(),
+                    SPL_TOKEN_PROGRAM_ID.to_string(),
+                ]),
+                allowed_tokens: vec!["4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU".to_string()],
+                allowed_spl_paid_tokens: SplTokenConfig::Allowlist(vec![
+                    "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU".to_string(),
+                ]),
+                disallowed_accounts: vec![],
+                price_source: PriceSource::Jupiter,
+                fee_payer_policy: FeePayerPolicy::default(),
+                price: PriceConfig::default(),
+                token_2022: Token2022Config::default(),
+                allow_durable_transactions: false,
+                max_price_staleness_slots: 0,
+                require_one_of_programs: vec![],
+                cross_cluster_check: false,
+                cross_cluster_endpoints: vec![],
+            },
+            kora: KoraConfig {
+                usage_limit: UsageLimitConfig {
+                    enabled: false,
+                    cache_url: None,
+                    fallback_if_unavailable: true,
+                    rules: vec![],
+                },
+                ..KoraConfig::default()
+            },
+            metrics: MetricsConfig::default(),
+        };
+
+        let _ = update_config(config);
+
+        let rpc_client = RpcClient::new_with_commitment(
+            "http://localhost:8899".to_string(),
+            CommitmentConfig::confirmed(),
+        );
+        let result = ConfigValidator::validate_with_result(&rpc_client, true).await;
+        let warnings = result.expect("disabled usage_limit with no rules must pass validation");
+        assert!(!warnings.iter().any(|w| w.contains("no rules are configured")));
     }
 
     #[tokio::test]

--- a/sdks/ts/src/types/index.ts
+++ b/sdks/ts/src/types/index.ts
@@ -308,9 +308,7 @@ export interface Token2022Config {
  * - `free`: No additional fees charged
  */
 export type PriceModel =
-    | { amount: number; token: string; type: 'fixed' }
-    | { margin: number; type: 'margin' }
-    | { type: 'free' };
+    { amount: number; token: string; type: 'fixed' } | { margin: number; type: 'margin' } | { type: 'free' };
 
 export type PriceConfig = PriceModel;
 


### PR DESCRIPTION
## Summary
- Apply `rpc start --api-key`/`--hmac-secret` flags (previously parsed but ignored) by mapping them to `KORA_API_KEY`/`KORA_HMAC_SECRET` before validation.
- Fail startup when `usage_limit.enabled = true` with no rules — was a silent no-op.
- Reject duplicate resolved signer pubkeys at pool init — duplicates made by-pubkey reacquire ambiguous.
- Warn when a non-`deny_all` `transfer_hook_policy` is combined with paid pricing.
- Drive-by `style(sdk)`: format `types/index.ts` with pinned prettier (unblocked fmt hook).

## Test Plan
- `cargo test -p kora-lib config_validator` (64), `pool` (16), `apply_to_env` (2), `-p kora-cli` — all pass.

## Breaking Changes
- `usage_limit.enabled` with empty rules now fails startup validation. Add rules or disable.