### PR TITLE
fix: align fee estimation and config validation with runtime behavior

### DIFF
--- a/.claude/skills/kora-operator/references/configuration.md
+++ b/.claude/skills/kora-operator/references/configuration.md
@@ -106,6 +106,8 @@ window_seconds = 3600                    # 10 token transfers per hour
 
 Requires `user_id` parameter in signing requests when enabled with `free` pricing.
 
+> **Security:** `user_id` is trusted app-supplied input — Kora keys quota by it directly and does not verify it. Require authentication (API key or HMAC) before exposing usage-limited signing to untrusted callers; otherwise a caller can rotate `user_id` to reset its own quota. In paid pricing, requests that omit `user_id` are keyed to the payment source-account owner.
+
 ---
 
 ## Enabled Methods

--- a/crates/lib/src/config.rs
+++ b/crates/lib/src/config.rs
@@ -796,13 +796,58 @@ impl Default for AuthConfig {
 }
 
 impl AuthConfig {
+    pub(crate) const API_KEY_ENV: &'static str = "KORA_API_KEY";
+    pub(crate) const HMAC_SECRET_ENV: &'static str = "KORA_HMAC_SECRET";
+    pub(crate) const RECAPTCHA_SECRET_ENV: &'static str = "KORA_RECAPTCHA_SECRET";
+
     pub(crate) fn normalize_optional_secret(value: Option<String>) -> Option<String> {
         value.filter(|value| !value.is_empty())
     }
 
-    pub(crate) fn has_auth(&self) -> bool {
-        self.api_key.as_deref().is_some_and(|key| !key.is_empty())
-            || self.hmac_secret.as_deref().is_some_and(|key| !key.is_empty())
+    /// Resolve a secret env-first: a non-empty environment variable overrides the config value.
+    /// This is the same precedence the running server applies, so validation and runtime agree.
+    pub(crate) fn resolve_secret(env_var: &str, config_value: Option<&str>) -> Option<String> {
+        Self::normalize_optional_secret(std::env::var(env_var).ok())
+            .or_else(|| Self::normalize_optional_secret(config_value.map(str::to_string)))
+    }
+
+    pub(crate) fn resolved_api_key(&self) -> Option<String> {
+        Self::resolve_secret(Self::API_KEY_ENV, self.api_key.as_deref())
+    }
+
+    pub(crate) fn resolved_hmac_secret(&self) -> Option<String> {
+        Self::resolve_secret(Self::HMAC_SECRET_ENV, self.hmac_secret.as_deref())
+    }
+
+    pub(crate) fn resolved_recaptcha_secret(&self) -> Option<String> {
+        Self::resolve_secret(Self::RECAPTCHA_SECRET_ENV, self.recaptcha_secret.as_deref())
+    }
+
+    /// Whether API-key or HMAC auth is in effect after env-first resolution (what the server enforces).
+    pub(crate) fn has_resolved_auth(&self) -> bool {
+        self.resolved_api_key().is_some() || self.resolved_hmac_secret().is_some()
+    }
+
+    /// Auth fields where a non-empty environment variable overrides a *different* non-empty
+    /// kora.toml value. Returns `(env_var, config_field_label)`; never returns secret contents.
+    pub(crate) fn env_overridden_fields(&self) -> Vec<(&'static str, &'static str)> {
+        [
+            (Self::API_KEY_ENV, "[kora.auth].api_key", self.api_key.as_deref()),
+            (Self::HMAC_SECRET_ENV, "[kora.auth].hmac_secret", self.hmac_secret.as_deref()),
+            (
+                Self::RECAPTCHA_SECRET_ENV,
+                "[kora.auth].recaptcha_secret",
+                self.recaptcha_secret.as_deref(),
+            ),
+        ]
+        .into_iter()
+        .filter(|(env_var, _, config_value)| {
+            let env_value = Self::normalize_optional_secret(std::env::var(env_var).ok());
+            let config_value = Self::normalize_optional_secret(config_value.map(str::to_string));
+            matches!((env_value, config_value), (Some(env), Some(cfg)) if env != cfg)
+        })
+        .map(|(env_var, label, _)| (env_var, label))
+        .collect()
     }
 }
 

--- a/crates/lib/src/fee/fee.rs
+++ b/crates/lib/src/fee/fee.rs
@@ -11,7 +11,6 @@ use crate::{
     token::{
         spl_token_2022::Token2022Mint,
         token::{AtaCreationInstructionInfo, TokenType, TokenUtil, TransferHookValidationFlow},
-        TokenState,
     },
     transaction::{
         ParsedALTInstructionData, ParsedALTInstructionType, ParsedSPLInstructionData,
@@ -97,36 +96,6 @@ impl FeeConfigUtil {
 
     /// Helper function to check if a token transfer instruction is a payment to Kora
     /// Returns Some(token_account_data) if it's a payment, None otherwise
-    async fn get_payment_instruction_info(
-        config: &Config,
-        rpc_client: &RpcClient,
-        destination_address: &Pubkey,
-        payment_destination: &Pubkey,
-        skip_missing_accounts: bool,
-    ) -> Result<Option<Box<dyn TokenState + Send + Sync>>, KoraError> {
-        // Get destination account - handle missing accounts based on skip_missing_accounts
-        let destination_account =
-            match CacheUtil::get_account(config, rpc_client, destination_address, false).await {
-                Ok(account) => account,
-                Err(_) if skip_missing_accounts => {
-                    return Ok(None);
-                }
-                Err(e) => {
-                    return Err(e);
-                }
-            };
-
-        let token_program = TokenType::get_token_program_from_owner(&destination_account.owner)?;
-        let token_account = token_program.unpack_token_account(&destination_account.data)?;
-
-        // Check if this is a payment to Kora
-        if token_account.owner() == *payment_destination {
-            Ok(Some(token_account))
-        } else {
-            Ok(None)
-        }
-    }
-
     /// Analyze payment instructions in transaction
     /// Returns (has_payment, total_transfer_fees)
     async fn analyze_payment_instructions(
@@ -139,6 +108,7 @@ impl FeeConfigUtil {
         let mut has_payment = false;
         let mut total_transfer_fees = 0u64;
 
+        let all_instructions = resolved_transaction.all_instructions.clone();
         let parsed_spl_instructions = resolved_transaction.get_or_parse_spl_instructions()?;
 
         for instruction in parsed_spl_instructions
@@ -153,17 +123,30 @@ impl FeeConfigUtil {
                 ..
             } = instruction
             {
-                // Check if this is a payment to Kora
-                let payment_info = Self::get_payment_instruction_info(
-                    config,
-                    rpc_client,
-                    destination_address,
-                    &payment_destination,
-                    true, // Skip missing accounts
-                )
-                .await?;
+                // Resolve the destination owner ATA-aware: when the payment ATA is created in this
+                // same transaction or bundle it has no pre-state, so fall back to the ATA-creation
+                // instruction (the same helper payment validation uses) instead of treating the
+                // transfer as a non-payment.
+                let destination_owner =
+                    match CacheUtil::get_account(config, rpc_client, destination_address, true)
+                        .await
+                    {
+                        Ok(account) => {
+                            let token_program =
+                                TokenType::get_token_program_from_owner(&account.owner)?;
+                            Some(token_program.unpack_token_account(&account.data)?.owner())
+                        }
+                        Err(KoraError::AccountNotFound(_)) => {
+                            TokenUtil::find_ata_creation_for_destination(
+                                &all_instructions,
+                                destination_address,
+                            )
+                            .map(|(wallet_owner, _)| wallet_owner)
+                        }
+                        Err(e) => return Err(e),
+                    };
 
-                if payment_info.is_some() {
+                if destination_owner == Some(payment_destination) {
                     has_payment = true;
 
                     // Calculate Token2022 transfer fees if applicable
@@ -724,7 +707,9 @@ mod tests {
             config_mock::{mock_state::get_config, ConfigMockBuilder},
             rpc_mock::RpcMockBuilder,
         },
-        token::{interface::TokenInterface, spl_token::TokenProgram},
+        token::{
+            interface::TokenInterface, spl_token::TokenProgram, spl_token_2022::Token2022Program,
+        },
         transaction::TransactionUtil,
     };
     use solana_address_lookup_table_interface::{
@@ -1782,6 +1767,79 @@ mod tests {
 
         assert!(has_payment, "Should detect payment instruction");
         assert_eq!(transfer_fees, 0, "Should have no transfer fees for SPL token");
+    }
+
+    #[tokio::test]
+    async fn test_analyze_payment_instructions_recognizes_in_transaction_payment_ata() {
+        let _m = ConfigMockBuilder::new().build_and_setup();
+        let cache_ctx = CacheUtil::get_account_context();
+        cache_ctx.checkpoint();
+        let signer = setup_or_get_test_signer();
+        let mint = Pubkey::new_unique();
+        let sender = Keypair::new();
+        let token2022_id = spl_token_2022_interface::id();
+
+        let payment_ata =
+            spl_associated_token_account_interface::address::get_associated_token_address_with_program_id(
+                &signer,
+                &mint,
+                &token2022_id,
+            );
+        let sender_ata =
+            spl_associated_token_account_interface::address::get_associated_token_address_with_program_id(
+                &sender.pubkey(),
+                &mint,
+                &token2022_id,
+            );
+
+        let mint_account = crate::tests::account_mock::create_mock_token2022_mint_with_extensions(
+            6,
+            vec![ExtensionType::TransferFeeConfig],
+        );
+
+        // The payment ATA does not yet exist on-chain (created in this same transaction); the mint
+        // exists. The estimator must still recognize the payment.
+        cache_ctx.expect().returning(move |_, _, addr: &Pubkey, _| {
+            if *addr == payment_ata {
+                Err(KoraError::AccountNotFound(payment_ata.to_string()))
+            } else if *addr == mint {
+                Ok(mint_account.clone())
+            } else {
+                Err(KoraError::AccountNotFound(addr.to_string()))
+            }
+        });
+
+        let rpc_client = RpcMockBuilder::new().with_epoch_info_mock().build();
+
+        let ata_create_ix =
+            spl_associated_token_account_interface::instruction::create_associated_token_account_idempotent(
+                &sender.pubkey(),
+                &signer,
+                &mint,
+                &token2022_id,
+            );
+        let transfer_ix = Token2022Program::new()
+            .create_transfer_instruction(&sender_ata, &payment_ata, &sender.pubkey(), 1_000_000)
+            .unwrap();
+
+        let message = VersionedMessage::Legacy(Message::new(&[ata_create_ix, transfer_ix], None));
+        let mut resolved_transaction =
+            TransactionUtil::new_unsigned_versioned_transaction_resolved(message).unwrap();
+
+        let config = get_config().unwrap();
+        let (has_payment, _transfer_fees) = FeeConfigUtil::analyze_payment_instructions(
+            &config,
+            &mut resolved_transaction,
+            &rpc_client,
+            &signer,
+        )
+        .await
+        .unwrap();
+
+        assert!(
+            has_payment,
+            "A payment ATA created in the same transaction must be recognized as a payment"
+        );
     }
 
     #[tokio::test]

--- a/crates/lib/src/fee/fee.rs
+++ b/crates/lib/src/fee/fee.rs
@@ -9,7 +9,9 @@ use crate::{
     error::KoraError,
     fee::price::PriceModel,
     token::{
-        spl_token_2022::Token2022Mint,
+        interface::TokenInterface,
+        spl_token::TokenProgram,
+        spl_token_2022::{Token2022Mint, Token2022Program},
         token::{AtaCreationInstructionInfo, TokenType, TokenUtil, TransferHookValidationFlow},
     },
     transaction::{
@@ -121,28 +123,23 @@ impl FeeConfigUtil {
                 ..
             } = instruction
             {
-                // Resolve the destination owner ATA-aware: when the payment ATA is created in this
-                // same transaction or bundle it has no pre-state, so fall back to the ATA-creation
-                // instruction (the same helper payment validation uses) instead of treating the
-                // transfer as a non-payment.
-                let destination_owner =
-                    match CacheUtil::get_account(config, rpc_client, destination_address, true)
-                        .await
-                    {
-                        Ok(account) => {
-                            let token_program =
-                                TokenType::get_token_program_from_owner(&account.owner)?;
-                            Some(token_program.unpack_token_account(&account.data)?.owner())
-                        }
-                        Err(KoraError::AccountNotFound(_)) => {
-                            TokenUtil::find_ata_creation_for_destination(
-                                &all_instructions,
-                                destination_address,
-                            )
-                            .map(|(wallet_owner, _)| wallet_owner)
-                        }
-                        Err(e) => return Err(e),
-                    };
+                // Resolve the destination owner via the same helper payment validation uses, so an
+                // ATA created in this transaction (no pre-state) is recognized instead of treated
+                // as a non-payment.
+                let token_program: Box<dyn TokenInterface> = if *is_2022 {
+                    Box::new(Token2022Program::new())
+                } else {
+                    Box::new(TokenProgram::new())
+                };
+                let destination_owner = TokenUtil::resolve_token_account_owner_and_mint(
+                    config,
+                    rpc_client,
+                    token_program.as_ref(),
+                    destination_address,
+                    &all_instructions,
+                )
+                .await?
+                .map(|(owner, _, _)| owner);
 
                 if destination_owner == Some(payment_destination) {
                     has_payment = true;
@@ -1731,9 +1728,6 @@ mod tests {
         let mocked_account = create_mock_token_account(&signer, &mint);
         let mocked_rpc_client = create_mock_rpc_client_with_account(&mocked_account);
 
-        // Set up cache expectation for token account lookup
-        cache_ctx.expect().times(1).returning(move |_, _, _, _| Ok(mocked_account.clone()));
-
         let sender = Keypair::new();
 
         let sender_token_account = get_associated_token_address(&sender.pubkey(), &mint);
@@ -1882,9 +1876,6 @@ mod tests {
 
         let mocked_account = create_mock_token_account(&sender.pubkey(), &mint);
         let mocked_rpc_client = create_mock_rpc_client_with_account(&mocked_account);
-
-        // Set up cache expectation for token account lookup
-        cache_ctx.expect().times(1).returning(move |_, _, _, _| Ok(mocked_account.clone()));
 
         // Create token accounts
         let sender_token_account = get_associated_token_address(&sender.pubkey(), &mint);
@@ -2038,8 +2029,6 @@ mod tests {
 
         let mocked_account = create_mock_token_account(&signer, &mint);
         let mocked_rpc_client = create_mock_rpc_client_with_account(&mocked_account);
-
-        cache_ctx.expect().times(2).returning(move |_, _, _, _| Ok(mocked_account.clone()));
 
         let sender = Keypair::new();
         let sender_token_account = get_associated_token_address(&sender.pubkey(), &mint);

--- a/crates/lib/src/fee/fee.rs
+++ b/crates/lib/src/fee/fee.rs
@@ -94,8 +94,6 @@ impl FeeConfigUtil {
         Ok(transaction.signer_pubkeys().contains(fee_payer))
     }
 
-    /// Helper function to check if a token transfer instruction is a payment to Kora
-    /// Returns Some(token_account_data) if it's a payment, None otherwise
     /// Analyze payment instructions in transaction
     /// Returns (has_payment, total_transfer_fees)
     async fn analyze_payment_instructions(

--- a/crates/lib/src/rpc_server/server.rs
+++ b/crates/lib/src/rpc_server/server.rs
@@ -106,8 +106,7 @@ async fn wait_for_rpc_stop(rpc_handle: ServerHandle, port: u16) {
 
 // We'll always prioritize the environment variable over the config value
 fn get_value_by_priority(env_var: &str, config_value: Option<String>) -> Option<String> {
-    AuthConfig::normalize_optional_secret(std::env::var(env_var).ok())
-        .or_else(|| AuthConfig::normalize_optional_secret(config_value))
+    AuthConfig::resolve_secret(env_var, config_value.as_deref())
 }
 
 pub async fn run_rpc_server(rpc: KoraRpc, port: u16) -> Result<ServerHandles, anyhow::Error> {
@@ -144,15 +143,13 @@ pub async fn run_rpc_server(rpc: KoraRpc, port: u16) -> Result<ServerHandles, an
     // Build whitelist of allowed methods from enabled_methods config
     let allowed_methods = config.kora.enabled_methods.get_enabled_method_names();
 
-    let recaptcha_config =
-        get_value_by_priority("KORA_RECAPTCHA_SECRET", config.kora.auth.recaptcha_secret.clone())
-            .map(|secret| {
-                RecaptchaConfig::new(
-                    secret,
-                    config.kora.auth.recaptcha_score_threshold,
-                    config.kora.auth.protected_methods.clone(),
-                )
-            });
+    let recaptcha_config = config.kora.auth.resolved_recaptcha_secret().map(|secret| {
+        RecaptchaConfig::new(
+            secret,
+            config.kora.auth.recaptcha_score_threshold,
+            config.kora.auth.protected_methods.clone(),
+        )
+    });
 
     let middleware = tower::ServiceBuilder::new()
         // Add metrics handler first (before other layers) so it can intercept /metrics

--- a/crates/lib/src/token/token.rs
+++ b/crates/lib/src/token/token.rs
@@ -771,7 +771,7 @@ impl TokenUtil {
         Ok(())
     }
 
-    async fn resolve_token_account_owner_and_mint(
+    pub(crate) async fn resolve_token_account_owner_and_mint(
         config: &Config,
         rpc_client: &RpcClient,
         token_program: &dyn TokenInterface,

--- a/crates/lib/src/usage_limit/usage_tracker.rs
+++ b/crates/lib/src/usage_limit/usage_tracker.rs
@@ -284,6 +284,12 @@ impl UsageTracker {
 
         let mut pending_increments = Vec::with_capacity(self.rules.len());
 
+        // Refresh the timestamp just before touching the store. The value captured when the
+        // LimiterContext was created can be seconds stale after validation and RPC, which would
+        // push the window expiry into the past and let the store immediately expire the bucket,
+        // bypassing the limit.
+        ctx.timestamp = Self::current_timestamp();
+
         for (idx, rule) in self.rules.iter().enumerate() {
             let increment_count = rule_increments[idx];
             if increment_count == 0 {
@@ -594,6 +600,56 @@ mod tests {
         // Third transaction should fail (over limit)
         assert!(matches!(
             tracker.check_and_record(&mut ctx3).await.unwrap(),
+            LimiterResult::Denied { .. }
+        ));
+    }
+
+    fn create_windowed_test_tracker(max: u64, window_seconds: u64) -> UsageTracker {
+        let store = Arc::new(InMemoryUsageStore::new());
+        let config = UsageLimitConfig {
+            enabled: true,
+            cache_url: None,
+            fallback_if_unavailable: false,
+            rules: vec![UsageLimitRuleConfig::Transaction {
+                max,
+                window_seconds: Some(window_seconds),
+            }],
+        };
+        let rules = config.build_rules().unwrap();
+        UsageTracker::new(true, store, rules, HashSet::new(), false)
+    }
+
+    #[tokio::test]
+    async fn test_windowed_limit_not_bypassed_by_stale_timestamp() {
+        let window_seconds = 3600u64;
+        let tracker = create_windowed_test_tracker(1, window_seconds);
+        let user_id = "stale-window-user".to_string();
+
+        // A timestamp from two windows ago derives an already-past expiry; the tracker must
+        // refresh it at store time so the bucket stays live and the limit is still enforced.
+        let stale_timestamp = UsageTracker::current_timestamp().saturating_sub(window_seconds * 2);
+
+        let mut tx1 = create_mock_resolved_transaction();
+        let mut ctx1 = LimiterContext {
+            transaction: &mut tx1,
+            user_id: user_id.clone(),
+            kora_signer: None,
+            timestamp: stale_timestamp,
+        };
+        assert!(matches!(
+            tracker.check_and_record(&mut ctx1).await.unwrap(),
+            LimiterResult::Allowed
+        ));
+
+        let mut tx2 = create_mock_resolved_transaction();
+        let mut ctx2 = LimiterContext {
+            transaction: &mut tx2,
+            user_id: user_id.clone(),
+            kora_signer: None,
+            timestamp: stale_timestamp,
+        };
+        assert!(matches!(
+            tracker.check_and_record(&mut ctx2).await.unwrap(),
             LimiterResult::Denied { .. }
         ));
     }

--- a/crates/lib/src/validator/config_validator.rs
+++ b/crates/lib/src/validator/config_validator.rs
@@ -858,7 +858,7 @@ impl ConfigValidator {
                 }
 
                 // Warn about dangerous configurations with fixed pricing
-                let has_auth = config.kora.auth.has_auth();
+                let has_auth = config.kora.auth.has_resolved_auth();
                 if !has_auth {
                     warnings.push(
                         "⚠️  SECURITY: Fixed pricing with NO authentication enabled. \
@@ -888,7 +888,7 @@ impl ConfigValidator {
         };
 
         // General authentication warning
-        let has_auth = config.kora.auth.has_auth();
+        let has_auth = config.kora.auth.has_resolved_auth();
         if !has_auth {
             warnings.push(
                 "⚠️  SECURITY: No authentication configured (neither api_key nor hmac_secret). \
@@ -896,6 +896,16 @@ impl ConfigValidator {
                 Consider enabling api_key or hmac_secret in [kora.auth]."
                     .to_string(),
             );
+        }
+
+        // The running server resolves auth env-first, so a stale KORA_* environment variable
+        // silently overrides a rotated kora.toml secret and keeps the retired credential valid.
+        for (env_var, field) in config.kora.auth.env_overridden_fields() {
+            warnings.push(format!(
+                "⚠️  SECURITY: environment variable {env_var} overrides {field}. The environment \
+                 value takes precedence at runtime; if you rotated the secret in kora.toml, the \
+                 stale environment value is still in effect. Unset {env_var} or align it with the config."
+            ));
         }
 
         // Validate usage limit configuration
@@ -1220,6 +1230,93 @@ mod tests {
         assert_eq!(warnings.len(), 1);
         assert!(!warnings.iter().any(|w| w.contains("PermanentDelegate")));
         assert!(warnings.iter().any(|w| w.contains("No authentication configured")));
+    }
+
+    fn validation_config_with_auth() -> ValidationConfig {
+        ValidationConfig {
+            max_allowed_lamports: 1_000_000,
+            max_signatures: 10,
+            allowed_programs: ProgramsConfig::Allowlist(vec![
+                SYSTEM_PROGRAM_ID.to_string(),
+                SPL_TOKEN_PROGRAM_ID.to_string(),
+            ]),
+            allowed_tokens: vec!["4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU".to_string()],
+            allowed_spl_paid_tokens: SplTokenConfig::Allowlist(vec![
+                "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU".to_string(),
+            ]),
+            disallowed_accounts: vec![],
+            price_source: PriceSource::Jupiter,
+            fee_payer_policy: FeePayerPolicy::default(),
+            price: PriceConfig::default(),
+            token_2022: Token2022Config::default(),
+            allow_durable_transactions: false,
+            max_price_staleness_slots: 0,
+            require_one_of_programs: vec![],
+            cross_cluster_check: false,
+            cross_cluster_endpoints: vec![],
+        }
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_validate_warns_when_env_overrides_config_auth_secret() {
+        std::env::set_var("JUPITER_API_KEY", "test-api-key");
+        std::env::set_var(AuthConfig::API_KEY_ENV, "stale-env-key");
+        let config = Config {
+            validation: validation_config_with_auth(),
+            kora: KoraConfig {
+                auth: AuthConfig {
+                    api_key: Some("rotated-config-key".to_string()),
+                    ..Default::default()
+                },
+                ..KoraConfig::default()
+            },
+            metrics: MetricsConfig::default(),
+        };
+        let _ = update_config(config);
+
+        let rpc_client = RpcClient::new_with_commitment(
+            "http://localhost:8899".to_string(),
+            CommitmentConfig::confirmed(),
+        );
+        let result = ConfigValidator::validate_with_result(&rpc_client, true).await;
+        std::env::remove_var(AuthConfig::API_KEY_ENV);
+
+        let warnings = result.expect("validation should succeed with warnings");
+        assert!(
+            warnings
+                .iter()
+                .any(|w| w.contains("KORA_API_KEY") && w.contains("[kora.auth].api_key")),
+            "expected an env-override warning naming the field, got: {warnings:?}"
+        );
+        // Auth is in effect, so the no-auth warning must not appear.
+        assert!(!warnings.iter().any(|w| w.contains("No authentication configured")));
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_validate_no_false_no_auth_warning_when_env_provides_auth() {
+        std::env::set_var("JUPITER_API_KEY", "test-api-key");
+        std::env::set_var(AuthConfig::API_KEY_ENV, "env-only-key");
+        let config = Config {
+            validation: validation_config_with_auth(),
+            kora: KoraConfig::default(),
+            metrics: MetricsConfig::default(),
+        };
+        let _ = update_config(config);
+
+        let rpc_client = RpcClient::new_with_commitment(
+            "http://localhost:8899".to_string(),
+            CommitmentConfig::confirmed(),
+        );
+        let result = ConfigValidator::validate_with_result(&rpc_client, true).await;
+        std::env::remove_var(AuthConfig::API_KEY_ENV);
+
+        let warnings = result.expect("validation should succeed");
+        assert!(
+            !warnings.iter().any(|w| w.contains("No authentication configured")),
+            "env-provided auth must suppress the no-auth warning, got: {warnings:?}"
+        );
     }
 
     #[tokio::test]

--- a/crates/lib/src/validator/config_validator.rs
+++ b/crates/lib/src/validator/config_validator.rs
@@ -1281,6 +1281,7 @@ mod tests {
         );
         let result = ConfigValidator::validate_with_result(&rpc_client, true).await;
         std::env::remove_var(AuthConfig::API_KEY_ENV);
+        std::env::remove_var("JUPITER_API_KEY");
 
         let warnings = result.expect("validation should succeed with warnings");
         assert!(
@@ -1311,6 +1312,7 @@ mod tests {
         );
         let result = ConfigValidator::validate_with_result(&rpc_client, true).await;
         std::env::remove_var(AuthConfig::API_KEY_ENV);
+        std::env::remove_var("JUPITER_API_KEY");
 
         let warnings = result.expect("validation should succeed");
         assert!(


### PR DESCRIPTION
## Summary
- **Fee estimation**: recognize a payment whose destination ATA is created in the same transaction. The estimator only read pre-state accounts, so an in-transaction Token-2022 payment ATA read as no-payment — it skipped the transfer-fee surcharge and diverged from payment validation. Now falls back to `find_ata_creation_for_destination` on `AccountNotFound`, matching validation.
- **Config validation**: reflect env-overridden auth secrets. Runtime resolves auth env-first over `kora.toml`, but `config validate` only inspected the TOML, so it could report the config secret while a stale env var was active, or warn "no auth configured" while auth was live. Adds a shared `AuthConfig::resolve_secret` used by both server and validation, and warns when an env var overrides a differing `kora.toml` value (never logs secret contents). Env precedence unchanged.
- **Usage limits**: refresh the window timestamp at store time. The window bucket key/expiry were derived from a timestamp captured before validation+RPC, so under latency the bucket could be written already-expired and the windowed limit would not be enforced. Fix stamps the current time just before the store phase. (This also fixes the intermittent `Integration Tests (usage_limit)` flake on windowed-limit tests.)
- **Docs**: note that `user_id` is trusted app input for usage limits.

## Test Plan
- `cargo test -p kora-lib fee::` — 52 passed (incl. in-transaction payment ATA test)
- `cargo test -p kora-lib config_validator` — 66 passed (incl. env-override warning test)
- `cargo test -p kora-lib usage_limit` — 57 passed (incl. `test_windowed_limit_not_bypassed_by_stale_timestamp`)