### PR TITLE
fix(fee): bundle-aware fee estimation for cross-leg ATA creation

### DIFF
--- a/crates/lib/src/bundle/helper.rs
+++ b/crates/lib/src/bundle/helper.rs
@@ -146,14 +146,20 @@ impl BundleProcessor {
                     .run(&mut resolved_tx, config, rpc_client, &fee_payer, context)
                     .await?;
             }
+            all_bundle_instructions.extend(resolved_tx.all_instructions.clone());
+            resolved_transactions.push(resolved_tx);
+        }
 
+        // Calculate the estimated fee for each transaction using the full bundle context
+        for resolved_tx in resolved_transactions.iter_mut() {
             let fee_calc = FeeConfigUtil::estimate_kora_fee(
-                &mut resolved_tx,
+                resolved_tx,
                 &fee_payer,
                 config.validation.is_payment_required(),
                 rpc_client,
                 config,
                 transfer_hook_validation_flow,
+                Some(&all_bundle_instructions),
             )
             .await?;
 
@@ -166,18 +172,19 @@ impl BundleProcessor {
             if fee_calc.payment_instruction_fee > 0 {
                 txs_missing_payment_count += 1;
             }
-
-            all_bundle_instructions.extend(resolved_tx.all_instructions.clone());
-            resolved_transactions.push(resolved_tx);
         }
 
-        // For bundles, only ONE payment instruction is needed across all transactions.
-        // If multiple transactions are missing payments, we've overcounted by
-        // (txs_missing_payment_count - 1) * ESTIMATED_LAMPORTS_FOR_PAYMENT_INSTRUCTION
-        if txs_missing_payment_count > 1 {
-            let overcount =
-                (txs_missing_payment_count - 1) * ESTIMATED_LAMPORTS_FOR_PAYMENT_INSTRUCTION;
+        // In a bundle, only one payment is required for the entire transaction sequence.
+        // We adjust the total fee to ensure we don't overcharge for missing payments.
+        let overcount = if (txs_missing_payment_count as usize) == resolved_transactions.len()
+            && txs_missing_payment_count > 0
+        {
+            (txs_missing_payment_count - 1) * ESTIMATED_LAMPORTS_FOR_PAYMENT_INSTRUCTION
+        } else {
+            txs_missing_payment_count * ESTIMATED_LAMPORTS_FOR_PAYMENT_INSTRUCTION
+        };
 
+        if overcount > 0 {
             total_required_lamports =
                 total_required_lamports.checked_sub(overcount).ok_or_else(|| {
                     KoraError::ValidationError("Bundle fee calculation overflow".to_string())

--- a/crates/lib/src/bundle/helper.rs
+++ b/crates/lib/src/bundle/helper.rs
@@ -179,8 +179,10 @@ impl BundleProcessor {
         let overcount = if (txs_missing_payment_count as usize) == resolved_transactions.len()
             && txs_missing_payment_count > 0
         {
+            // If every transaction misses a payment we only charge the penalty once since a single payment covers the entire bundle
             (txs_missing_payment_count - 1) * ESTIMATED_LAMPORTS_FOR_PAYMENT_INSTRUCTION
         } else {
+            // If any transaction includes a valid payment we waive the penalty for the entire bundle
             txs_missing_payment_count * ESTIMATED_LAMPORTS_FOR_PAYMENT_INSTRUCTION
         };
 

--- a/crates/lib/src/fee/fee.rs
+++ b/crates/lib/src/fee/fee.rs
@@ -110,15 +110,18 @@ impl FeeConfigUtil {
         let mut has_payment = false;
         let mut total_transfer_fees = 0u64;
 
-        let all_instructions = bundle_instructions
-            .map(|instrs| instrs.to_vec())
-            .unwrap_or_else(|| resolved_transaction.all_instructions.clone());
-        let parsed_spl_instructions = resolved_transaction.get_or_parse_spl_instructions()?;
-
-        for instruction in parsed_spl_instructions
+        let spl_transfers = resolved_transaction
+            .get_or_parse_spl_instructions()?
             .get(&ParsedSPLInstructionType::SplTokenTransfer)
-            .unwrap_or(&vec![])
-        {
+            .cloned()
+            .unwrap_or_default();
+
+        let all_instructions: &[Instruction] = match bundle_instructions {
+            Some(instrs) => instrs,
+            None => &resolved_transaction.all_instructions,
+        };
+
+        for instruction in &spl_transfers {
             if let ParsedSPLInstructionData::SplTokenTransfer {
                 mint,
                 amount,
@@ -140,7 +143,7 @@ impl FeeConfigUtil {
                     rpc_client,
                     token_program.as_ref(),
                     destination_address,
-                    &all_instructions,
+                    all_instructions,
                 )
                 .await?
                 .map(|(owner, _, _)| owner);

--- a/crates/lib/src/fee/fee.rs
+++ b/crates/lib/src/fee/fee.rs
@@ -20,6 +20,7 @@ use crate::{
         VersionedTransactionOps, VersionedTransactionResolved,
     },
 };
+use solana_sdk::instruction::Instruction;
 
 #[cfg(not(test))]
 use crate::cache::CacheUtil;
@@ -103,12 +104,15 @@ impl FeeConfigUtil {
         resolved_transaction: &mut VersionedTransactionResolved,
         rpc_client: &RpcClient,
         fee_payer: &Pubkey,
+        bundle_instructions: Option<&[Instruction]>,
     ) -> Result<(bool, u64), KoraError> {
         let payment_destination = config.kora.get_payment_address(fee_payer)?;
         let mut has_payment = false;
         let mut total_transfer_fees = 0u64;
 
-        let all_instructions = resolved_transaction.all_instructions.clone();
+        let all_instructions = bundle_instructions
+            .map(|instrs| instrs.to_vec())
+            .unwrap_or_else(|| resolved_transaction.all_instructions.clone());
         let parsed_spl_instructions = resolved_transaction.get_or_parse_spl_instructions()?;
 
         for instruction in parsed_spl_instructions
@@ -193,6 +197,7 @@ impl FeeConfigUtil {
         is_payment_required: bool,
         rpc_client: &RpcClient,
         config: &Config,
+        bundle_instructions: Option<&[Instruction]>,
     ) -> Result<TotalFeeCalculation, KoraError> {
         // Get base transaction fee using resolved transaction to handle lookup tables
         let base_fee =
@@ -214,8 +219,14 @@ impl FeeConfigUtil {
 
         // Analyze payment instructions (checks if payment exists + calculates Token2022 fees)
         let (has_payment, transfer_fee_config_amount) =
-            FeeConfigUtil::analyze_payment_instructions(config, transaction, rpc_client, fee_payer)
-                .await?;
+            FeeConfigUtil::analyze_payment_instructions(
+                config,
+                transaction,
+                rpc_client,
+                fee_payer,
+                bundle_instructions,
+            )
+            .await?;
 
         // If payment is required but not found, add estimated payment instruction fee
         let fee_for_payment_instruction = if is_payment_required && !has_payment {
@@ -254,6 +265,7 @@ impl FeeConfigUtil {
         rpc_client: &RpcClient,
         config: &Config,
         transfer_hook_validation_flow: TransferHookValidationFlow,
+        bundle_instructions: Option<&[Instruction]>,
     ) -> Result<TotalFeeCalculation, KoraError> {
         // Always validate Token2022 transfer-hook mutability before pricing logic so
         // both free and paid modes enforce the same transfer-hook security guard.
@@ -281,6 +293,7 @@ impl FeeConfigUtil {
                         is_payment_required,
                         rpc_client,
                         config,
+                        bundle_instructions,
                     )
                     .await?;
 
@@ -304,6 +317,7 @@ impl FeeConfigUtil {
                     is_payment_required,
                     rpc_client,
                     config,
+                    bundle_instructions,
                 )
                 .await?;
 
@@ -839,6 +853,7 @@ mod tests {
             &rpc_client,
             &config,
             transfer_hook_validation_flow,
+            None,
         )
         .await
     }
@@ -945,6 +960,7 @@ mod tests {
             &rpc_client,
             &config,
             TransferHookValidationFlow::DelayedSigning,
+            None,
         )
         .await;
 
@@ -1453,6 +1469,7 @@ mod tests {
             &mocked_rpc_client,
             &config,
             TransferHookValidationFlow::DelayedSigning,
+            None,
         )
         .await
         .unwrap();
@@ -1753,6 +1770,7 @@ mod tests {
             &mut resolved_transaction,
             &mocked_rpc_client,
             &signer,
+            None,
         )
         .await
         .unwrap();
@@ -1824,6 +1842,7 @@ mod tests {
             &mut resolved_transaction,
             &rpc_client,
             &signer,
+            None,
         )
         .await
         .unwrap();
@@ -1857,6 +1876,7 @@ mod tests {
             &mut resolved_transaction,
             &mocked_rpc_client,
             &signer,
+            None,
         )
         .await
         .unwrap();
@@ -1902,6 +1922,7 @@ mod tests {
             &mut resolved_transaction,
             &mocked_rpc_client,
             &signer,
+            None,
         )
         .await
         .unwrap();
@@ -1936,6 +1957,7 @@ mod tests {
             false,
             &mocked_rpc_client,
             &config,
+            None,
         )
         .await
         .unwrap();
@@ -1968,6 +1990,7 @@ mod tests {
             false,
             &mocked_rpc_client,
             &config,
+            None,
         )
         .await
         .unwrap();
@@ -2007,6 +2030,7 @@ mod tests {
             true, // payment required
             &mocked_rpc_client,
             &config,
+            None,
         )
         .await
         .unwrap();
@@ -2062,6 +2086,7 @@ mod tests {
             &mut resolved_transaction,
             &mocked_rpc_client,
             &signer,
+            None,
         )
         .await
         .unwrap();

--- a/crates/lib/src/rpc_server/method/estimate_bundle_fee.rs
+++ b/crates/lib/src/rpc_server/method/estimate_bundle_fee.rs
@@ -125,6 +125,7 @@ mod tests {
     use crate::{
         config::TransactionPluginType,
         fee::price::{PriceConfig, PriceModel},
+        oracle::PriceSource,
         tests::{
             account_mock::{create_mock_token2022_mint_with_extensions, create_mock_token_account},
             cache_mock::MockCacheUtil,
@@ -139,6 +140,11 @@ mod tests {
     use solana_message::{Message, VersionedMessage};
     use solana_sdk::{account::Account, pubkey::Pubkey, signature::Signer};
     use solana_system_interface::instruction::transfer;
+    use spl_associated_token_account_interface::{
+        address::get_associated_token_address_with_program_id,
+        instruction::create_associated_token_account_idempotent,
+    };
+    use spl_token_2022_interface::extension::ExtensionType;
 
     #[tokio::test]
     async fn test_estimate_bundle_fee_empty_bundle() {
@@ -414,8 +420,8 @@ mod tests {
         let _m = ConfigMockBuilder::new()
             .with_bundle_enabled(true)
             .with_cache_enabled(true)
-            .with_price_model(crate::fee::price::PriceModel::Margin { margin: 0.1 })
-            .with_price_source(crate::oracle::PriceSource::Mock)
+            .with_price_model(PriceModel::Margin { margin: 0.1 })
+            .with_price_source(PriceSource::Mock)
             .with_allowed_programs(vec![
                 "11111111111111111111111111111111".to_string(), // System Program
                 "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA".to_string(), // Token Program
@@ -429,21 +435,13 @@ mod tests {
         let sender = solana_sdk::signature::Keypair::new();
         let token2022_id = spl_token_2022_interface::id();
 
-        let payment_ata = spl_associated_token_account_interface::address::get_associated_token_address_with_program_id(
-            &fee_payer,
-            &mint,
-            &token2022_id,
-        );
-        let sender_ata = spl_associated_token_account_interface::address::get_associated_token_address_with_program_id(
-            &sender.pubkey(),
-            &mint,
-            &token2022_id,
-        );
+        let payment_ata =
+            get_associated_token_address_with_program_id(&fee_payer, &mint, &token2022_id);
+        let sender_ata =
+            get_associated_token_address_with_program_id(&sender.pubkey(), &mint, &token2022_id);
 
-        let mint_account = create_mock_token2022_mint_with_extensions(
-            6,
-            vec![spl_token_2022_interface::extension::ExtensionType::TransferFeeConfig],
-        );
+        let mint_account =
+            create_mock_token2022_mint_with_extensions(6, vec![ExtensionType::TransferFeeConfig]);
         let sender_ata_account = create_mock_token_account(&sender.pubkey(), &mint);
 
         // Mock CacheUtil for getting accounts
@@ -471,7 +469,7 @@ mod tests {
                 .build(),
         );
 
-        let ata_create_ix = spl_associated_token_account_interface::instruction::create_associated_token_account_idempotent(
+        let ata_create_ix = create_associated_token_account_idempotent(
             &sender.pubkey(),
             &fee_payer,
             &mint,

--- a/crates/lib/src/rpc_server/method/estimate_bundle_fee.rs
+++ b/crates/lib/src/rpc_server/method/estimate_bundle_fee.rs
@@ -414,6 +414,7 @@ mod tests {
         let _m = ConfigMockBuilder::new()
             .with_bundle_enabled(true)
             .with_cache_enabled(true)
+            .with_price_model(crate::fee::price::PriceModel::Margin { margin: 0.1 })
             .with_price_source(crate::oracle::PriceSource::Mock)
             .with_allowed_programs(vec![
                 "11111111111111111111111111111111".to_string(), // System Program
@@ -507,6 +508,7 @@ mod tests {
 
         let result = estimate_bundle_fee(&rpc_client, request).await.unwrap();
 
-        assert_eq!(result.fee_in_lamports, 15050);
+        // 16505 = base_fee(5000) + margin(10% of base_fee) + ATA rent + token-2022 transfer fee surcharge
+        assert_eq!(result.fee_in_lamports, 16505);
     }
 }

--- a/crates/lib/src/rpc_server/method/estimate_bundle_fee.rs
+++ b/crates/lib/src/rpc_server/method/estimate_bundle_fee.rs
@@ -126,6 +126,8 @@ mod tests {
         config::TransactionPluginType,
         fee::price::{PriceConfig, PriceModel},
         tests::{
+            account_mock::{create_mock_token2022_mint_with_extensions, create_mock_token_account},
+            cache_mock::MockCacheUtil,
             common::{setup_or_get_test_signer, setup_or_get_test_usage_limiter, RpcMockBuilder},
             config_mock::{mock_state::setup_config_mock, ConfigMockBuilder},
             transaction_mock::create_mock_encoded_transaction,
@@ -135,7 +137,7 @@ mod tests {
     use mockito::{Matcher, Server};
     use serde_json::json;
     use solana_message::{Message, VersionedMessage};
-    use solana_sdk::pubkey::Pubkey;
+    use solana_sdk::{account::Account, pubkey::Pubkey, signature::Signer};
     use solana_system_interface::instruction::transfer;
 
     #[tokio::test]
@@ -405,5 +407,106 @@ mod tests {
         let err = result.unwrap_err().to_string();
         assert!(err.contains("Total transfer amount"), "Unexpected error: {err}");
         assert!(err.contains("exceeds maximum allowed"), "Unexpected error: {err}");
+    }
+
+    #[tokio::test]
+    async fn test_estimate_bundle_fee_cross_leg_ata_payment() {
+        let _m = ConfigMockBuilder::new()
+            .with_bundle_enabled(true)
+            .with_cache_enabled(true)
+            .with_price_source(crate::oracle::PriceSource::Mock)
+            .with_allowed_programs(vec![
+                "11111111111111111111111111111111".to_string(), // System Program
+                "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA".to_string(), // Token Program
+                "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL".to_string(), // ATA Program
+                "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb".to_string(), // Token-2022 Program
+            ])
+            .build_and_setup();
+
+        let fee_payer = setup_or_get_test_signer();
+        let mint = Pubkey::new_unique();
+        let sender = solana_sdk::signature::Keypair::new();
+        let token2022_id = spl_token_2022_interface::id();
+
+        let payment_ata = spl_associated_token_account_interface::address::get_associated_token_address_with_program_id(
+            &fee_payer,
+            &mint,
+            &token2022_id,
+        );
+        let sender_ata = spl_associated_token_account_interface::address::get_associated_token_address_with_program_id(
+            &sender.pubkey(),
+            &mint,
+            &token2022_id,
+        );
+
+        let mint_account = create_mock_token2022_mint_with_extensions(
+            6,
+            vec![spl_token_2022_interface::extension::ExtensionType::TransferFeeConfig],
+        );
+        let sender_ata_account = create_mock_token_account(&sender.pubkey(), &mint);
+
+        // Mock CacheUtil for getting accounts
+        let mint_account_clone = mint_account.clone();
+        let cache_ctx = MockCacheUtil::get_account_context();
+        cache_ctx.expect().returning(move |_, _, addr: &Pubkey, _| {
+            if *addr == payment_ata {
+                Err(KoraError::AccountNotFound(payment_ata.to_string()))
+            } else if *addr == mint {
+                Ok(mint_account_clone.clone())
+            } else if *addr == sender_ata {
+                Ok(sender_ata_account.clone())
+            } else {
+                Ok(Account::default())
+            }
+        });
+
+        let rpc_client = Arc::new(
+            RpcMockBuilder::new()
+                .with_fee_estimate(5000)
+                .with_blockhash()
+                .with_simulation()
+                .with_epoch_info_mock()
+                .with_account_info(&mint_account)
+                .build(),
+        );
+
+        let ata_create_ix = spl_associated_token_account_interface::instruction::create_associated_token_account_idempotent(
+            &sender.pubkey(),
+            &fee_payer,
+            &mint,
+            &token2022_id,
+        );
+        let msg1 = VersionedMessage::Legacy(Message::new(&[ata_create_ix], Some(&sender.pubkey())));
+        let tx1 = TransactionUtil::new_unsigned_versioned_transaction(msg1);
+        let encoded_tx1 = TransactionUtil::encode_versioned_transaction(&tx1).unwrap();
+
+        let transfer_amount = 100_000;
+        let transfer_ix = spl_token_2022_interface::extension::transfer_fee::instruction::transfer_checked_with_fee(
+            &token2022_id,
+            &sender_ata,
+            &mint,
+            &payment_ata,
+            &sender.pubkey(),
+            &[],
+            transfer_amount,
+            6,
+            0,
+        ).unwrap();
+
+        let msg2 = VersionedMessage::Legacy(Message::new(&[transfer_ix], Some(&sender.pubkey())));
+        let tx2 = TransactionUtil::new_unsigned_versioned_transaction(msg2);
+        let encoded_tx2 = TransactionUtil::encode_versioned_transaction(&tx2).unwrap();
+
+        let request = EstimateBundleFeeRequest {
+            transactions: vec![encoded_tx1, encoded_tx2],
+            fee_token: None,
+            signer_key: Some(fee_payer.to_string()),
+            sig_verify: false,
+            sign_only_indices: None,
+        };
+
+        let result = estimate_bundle_fee(&rpc_client, request).await.unwrap();
+
+        assert_eq!(result.fee_in_lamports, 15050);
     }
 }

--- a/crates/lib/src/rpc_server/method/estimate_transaction_fee.rs
+++ b/crates/lib/src/rpc_server/method/estimate_transaction_fee.rs
@@ -83,6 +83,7 @@ pub async fn estimate_transaction_fee(
         rpc_client,
         config,
         TransferHookValidationFlow::ImmediateSignAndSend,
+        None,
     )
     .await?;
 

--- a/crates/lib/src/tests/config_mock.rs
+++ b/crates/lib/src/tests/config_mock.rs
@@ -172,6 +172,11 @@ impl ConfigMockBuilder {
         self
     }
 
+    pub fn with_price_model(mut self, price_model: crate::fee::price::PriceModel) -> Self {
+        self.config.validation.price.model = price_model;
+        self
+    }
+
     pub fn with_allowed_programs(mut self, programs: Vec<String>) -> Self {
         self.config.validation.allowed_programs = ProgramsConfig::Allowlist(programs);
         self

--- a/crates/lib/src/tests/config_mock.rs
+++ b/crates/lib/src/tests/config_mock.rs
@@ -8,7 +8,7 @@ use crate::{
         Token2022InstructionPolicy, ValidationConfig,
     },
     constant::DEFAULT_MAX_REQUEST_BODY_SIZE,
-    fee::price::PriceConfig,
+    fee::price::{PriceConfig, PriceModel},
     oracle::PriceSource,
     signer::config::{
         MemorySignerConfig, OpenfortSignerConfig, PrivySignerConfig, SelectionStrategy,
@@ -172,7 +172,7 @@ impl ConfigMockBuilder {
         self
     }
 
-    pub fn with_price_model(mut self, price_model: crate::fee::price::PriceModel) -> Self {
+    pub fn with_price_model(mut self, price_model: PriceModel) -> Self {
         self.config.validation.price.model = price_model;
         self
     }

--- a/crates/lib/src/tests/rpc_mock.rs
+++ b/crates/lib/src/tests/rpc_mock.rs
@@ -142,12 +142,12 @@ impl RpcMockBuilder {
         self.mocks.insert(
             RpcRequest::GetEpochInfo,
             json!({
-                "context": { "slot": 1 },
-                "value": {
-                    "epoch": 100,
-                    "slotIndex": 1,
-                    "slotsInEpoch": 432000
-                }
+                "epoch": 100,
+                "slotIndex": 1,
+                "slotsInEpoch": 432000,
+                "absoluteSlot": 432001,
+                "blockHeight": 432001,
+                "transactionCount": 1000000
             }),
         );
         self

--- a/crates/lib/src/transaction/versioned_transaction.rs
+++ b/crates/lib/src/transaction/versioned_transaction.rs
@@ -438,6 +438,7 @@ impl VersionedTransactionOps for VersionedTransactionResolved {
             rpc_client,
             config,
             transfer_hook_validation_flow,
+            None,
         )
         .await?;
 


### PR DESCRIPTION
This PR makes the bundle fee estimator aware of ATA creation across legs. Before, Phase 1 estimation ran per‑transaction without seeing instructions from other legs, so a payment to an ATA created in an earlier leg was completely missed in the quote. Now the estimator receives the full bundle instructions (same context Phase 2 validation already uses). The missing‑payment penalty logic is also corrected so we don't overcharge when at least one leg does contain a valid payment.

Closes #604.