### PR TITLE
feat!: reject unknown keys in kora.toml via deny_unknown_fields

### DIFF
--- a/crates/lib/src/bundle/jito/config.rs
+++ b/crates/lib/src/bundle/jito/config.rs
@@ -5,6 +5,7 @@ use crate::bundle::jito::constant::JITO_DEFAULT_BLOCK_ENGINE_URL;
 
 /// Jito-specific configuration
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[serde(deny_unknown_fields)]
 pub struct JitoConfig {
     /// Jito block engine URL for sendBundle / getBundleStatuses
     #[serde(default = "default_jito_block_engine_url")]

--- a/crates/lib/src/config.rs
+++ b/crates/lib/src/config.rs
@@ -28,6 +28,7 @@ use crate::{
 pub use crate::usage_limit::{UsageLimitConfig, UsageLimitRuleConfig};
 
 #[derive(Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct Config {
     pub validation: ValidationConfig,
     pub kora: KoraConfig,
@@ -36,7 +37,7 @@ pub struct Config {
 }
 
 #[derive(Clone, Serialize, Deserialize, ToSchema)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct MetricsConfig {
     pub enabled: bool,
     pub endpoint: String,
@@ -58,6 +59,7 @@ impl Default for MetricsConfig {
 }
 
 #[derive(Clone, Serialize, Deserialize, ToSchema)]
+#[serde(deny_unknown_fields)]
 pub struct FeePayerBalanceMetricsConfig {
     pub enabled: bool,
     pub expiry_seconds: u64,
@@ -184,6 +186,7 @@ impl ProgramsConfig {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[serde(deny_unknown_fields)]
 pub struct ValidationConfig {
     pub max_allowed_lamports: u64,
     pub max_signatures: u64,
@@ -241,7 +244,7 @@ impl ValidationConfig {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema, Default)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct FeePayerPolicy {
     pub system: SystemInstructionPolicy,
     pub spl_token: SplTokenInstructionPolicy,
@@ -252,7 +255,7 @@ pub struct FeePayerPolicy {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema, Default)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct SystemInstructionPolicy {
     /// Allow fee payer to be the sender in System Transfer/TransferWithSeed instructions
     pub allow_transfer: bool,
@@ -268,6 +271,7 @@ pub struct SystemInstructionPolicy {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema, Default)]
+#[serde(deny_unknown_fields)]
 pub struct NonceInstructionPolicy {
     /// Allow fee payer to be set as the nonce authority in InitializeNonceAccount instructions
     pub allow_initialize: bool,
@@ -281,6 +285,7 @@ pub struct NonceInstructionPolicy {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema, Default)]
+#[serde(deny_unknown_fields)]
 pub struct SplTokenInstructionPolicy {
     /// Allow fee payer to be the owner in SPL Token Transfer/TransferChecked instructions
     pub allow_transfer: bool,
@@ -315,7 +320,7 @@ pub struct SplTokenInstructionPolicy {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema, Default)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct Token2022InstructionPolicy {
     /// Allow fee payer to be the owner in Token2022 Transfer/TransferChecked instructions
     pub allow_transfer: bool,
@@ -356,7 +361,7 @@ pub struct Token2022InstructionPolicy {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema, Default)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct AltInstructionPolicy {
     /// Allow fee payer to be authority/payer in ALT CreateLookupTable instructions
     pub allow_create: bool,
@@ -371,7 +376,7 @@ pub struct AltInstructionPolicy {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema, Default)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct BpfLoaderUpgradeableInstructionPolicy {
     /// Allow fee payer to be the buffer authority in InitializeBuffer instructions
     pub allow_initialize_buffer: bool,
@@ -400,7 +405,7 @@ pub struct BpfLoaderUpgradeableInstructionPolicy {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema, Default)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct LoaderV4InstructionPolicy {
     /// Allow fee payer to be the authority in Write instructions
     pub allow_write: bool,
@@ -419,7 +424,7 @@ pub struct LoaderV4InstructionPolicy {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema, Default)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct Token2022Config {
     pub blocked_mint_extensions: Vec<String>,
     pub blocked_account_extensions: Vec<String>,
@@ -520,7 +525,7 @@ impl Token2022Config {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct EnabledMethods {
     pub liveness: bool,
     pub estimate_transaction_fee: bool,
@@ -650,6 +655,7 @@ impl Default for EnabledMethods {
 }
 
 #[derive(Clone, Serialize, Deserialize, ToSchema)]
+#[serde(deny_unknown_fields)]
 pub struct CacheConfig {
     /// Redis URL for caching (e.g., "redis://localhost:6379")
     pub url: Option<String>,
@@ -692,14 +698,14 @@ pub enum TransactionPluginType {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema, Default)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct PluginsConfig {
     /// List of enabled transaction plugins, executed for sign/signAndSend flows
     pub enabled: Vec<TransactionPluginType>,
 }
 
 #[derive(Clone, Serialize, Deserialize, ToSchema)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct KoraConfig {
     pub rate_limit: u64,
     pub max_request_body_size: usize,
@@ -746,7 +752,7 @@ impl Default for KoraConfig {
 
 /// Configuration for bundle support (wraps provider-specific configs)
 #[derive(Debug, Clone, Default, Serialize, Deserialize, ToSchema)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct BundleConfig {
     /// Enable bundle support
     pub enabled: bool,
@@ -756,7 +762,7 @@ pub struct BundleConfig {
 
 /// Configuration for Lighthouse assertions to protect fee payer balance
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct LighthouseConfig {
     /// Enable Lighthouse assertions for fee payer protection
     pub enabled: bool,
@@ -772,7 +778,7 @@ impl Default for LighthouseConfig {
 }
 
 #[derive(Clone, Serialize, Deserialize, ToSchema)]
-#[serde(default)]
+#[serde(default, deny_unknown_fields)]
 pub struct AuthConfig {
     pub api_key: Option<String>,
     pub hmac_secret: Option<String>,
@@ -1372,5 +1378,80 @@ allow_create = true
         scoped_redis_env(None, || {
             assert_eq!(cfg.resolved_url(), None);
         });
+    }
+
+    fn assert_unknown_field_error(result: Result<Config, KoraError>, field: &str) {
+        match result {
+            Err(KoraError::InternalServerError(msg)) => {
+                assert!(
+                    msg.contains("Failed to parse config file"),
+                    "expected parse failure wrapper, got: {msg}"
+                );
+                assert!(
+                    msg.contains("unknown field") && msg.contains(field),
+                    "expected unknown field `{field}` in error, got: {msg}"
+                );
+            }
+            Err(e) => panic!("expected InternalServerError for unknown field `{field}`, got: {e}"),
+            Ok(_) => panic!("expected error for unknown field `{field}`, but config loaded"),
+        }
+    }
+
+    #[test]
+    fn test_deny_unknown_fields_misspelled_fee_payer_policy_key() {
+        let result = ConfigBuilder::new()
+            .with_custom_section(
+                "[validation.fee_payer_policy.system]\nalow_transfer = false\n",
+            )
+            .build_config();
+        assert_unknown_field_error(result, "alow_transfer");
+    }
+
+    #[test]
+    fn test_deny_unknown_fields_key_under_wrong_table() {
+        // allow_burn belongs under spl_token / token_2022, not system
+        let result = ConfigBuilder::new()
+            .with_custom_section(
+                "[validation.fee_payer_policy.system]\nallow_burn = false\n",
+            )
+            .build_config();
+        assert_unknown_field_error(result, "allow_burn");
+    }
+
+    #[test]
+    fn test_deny_unknown_fields_unknown_top_level_table() {
+        let result = ConfigBuilder::new()
+            .with_custom_section("[unknown_section]\nfoo = 1\n")
+            .build_config();
+        assert_unknown_field_error(result, "unknown_section");
+    }
+
+    #[test]
+    fn test_deny_unknown_fields_unknown_kora_key() {
+        let result = ConfigBuilder::new()
+            .with_custom_section("typo_key = 1\n")
+            .build_config();
+        // typo_key is appended after [kora], so it lands in KoraConfig
+        assert_unknown_field_error(result, "typo_key");
+    }
+
+    #[test]
+    fn test_deny_unknown_fields_unknown_price_key() {
+        let result = ConfigBuilder::new()
+            .with_custom_section(
+                "[validation.price]\ntype = \"margin\"\nmargin = 0.1\nunknown_price_field = 1\n",
+            )
+            .build_config();
+        assert_unknown_field_error(result, "unknown_price_field");
+    }
+
+    #[test]
+    fn test_deny_unknown_fields_unknown_usage_limit_rule_key() {
+        let result = ConfigBuilder::new()
+            .with_custom_section(
+                "[kora.usage_limit]\nenabled = true\nfallback_if_unavailable = true\n\n[[kora.usage_limit.rules]]\ntype = \"transaction\"\nmax = 10\nunknown_rule_field = true\n",
+            )
+            .build_config();
+        assert_unknown_field_error(result, "unknown_rule_field");
     }
 }

--- a/crates/lib/src/config.rs
+++ b/crates/lib/src/config.rs
@@ -1380,6 +1380,9 @@ allow_create = true
         });
     }
 
+    /// Asserts load failed with `InternalServerError` and that the offending key name appears
+    /// in the message. Does not assert on serde/toml phrasing (e.g. "unknown field"), which
+    /// can change across crate versions — only that parse failed and the key is named.
     fn assert_unknown_field_error(result: Result<Config, KoraError>, field: &str) {
         match result {
             Err(KoraError::InternalServerError(msg)) => {
@@ -1388,8 +1391,8 @@ allow_create = true
                     "expected parse failure wrapper, got: {msg}"
                 );
                 assert!(
-                    msg.contains("unknown field") && msg.contains(field),
-                    "expected unknown field `{field}` in error, got: {msg}"
+                    msg.contains(field),
+                    "expected offending key `{field}` named in error, got: {msg}"
                 );
             }
             Err(e) => panic!("expected InternalServerError for unknown field `{field}`, got: {e}"),

--- a/crates/lib/src/config.rs
+++ b/crates/lib/src/config.rs
@@ -1380,9 +1380,7 @@ allow_create = true
         });
     }
 
-    /// Asserts load failed with `InternalServerError` and that the offending key name appears
-    /// in the message. Does not assert on serde/toml phrasing (e.g. "unknown field"), which
-    /// can change across crate versions — only that parse failed and the key is named.
+    // Match on the key name, not serde/toml phrasing (unstable across versions).
     fn assert_unknown_field_error(result: Result<Config, KoraError>, field: &str) {
         match result {
             Err(KoraError::InternalServerError(msg)) => {

--- a/crates/lib/src/config.rs
+++ b/crates/lib/src/config.rs
@@ -1403,9 +1403,7 @@ allow_create = true
     #[test]
     fn test_deny_unknown_fields_misspelled_fee_payer_policy_key() {
         let result = ConfigBuilder::new()
-            .with_custom_section(
-                "[validation.fee_payer_policy.system]\nalow_transfer = false\n",
-            )
+            .with_custom_section("[validation.fee_payer_policy.system]\nalow_transfer = false\n")
             .build_config();
         assert_unknown_field_error(result, "alow_transfer");
     }
@@ -1414,26 +1412,21 @@ allow_create = true
     fn test_deny_unknown_fields_key_under_wrong_table() {
         // allow_burn belongs under spl_token / token_2022, not system
         let result = ConfigBuilder::new()
-            .with_custom_section(
-                "[validation.fee_payer_policy.system]\nallow_burn = false\n",
-            )
+            .with_custom_section("[validation.fee_payer_policy.system]\nallow_burn = false\n")
             .build_config();
         assert_unknown_field_error(result, "allow_burn");
     }
 
     #[test]
     fn test_deny_unknown_fields_unknown_top_level_table() {
-        let result = ConfigBuilder::new()
-            .with_custom_section("[unknown_section]\nfoo = 1\n")
-            .build_config();
+        let result =
+            ConfigBuilder::new().with_custom_section("[unknown_section]\nfoo = 1\n").build_config();
         assert_unknown_field_error(result, "unknown_section");
     }
 
     #[test]
     fn test_deny_unknown_fields_unknown_kora_key() {
-        let result = ConfigBuilder::new()
-            .with_custom_section("typo_key = 1\n")
-            .build_config();
+        let result = ConfigBuilder::new().with_custom_section("typo_key = 1\n").build_config();
         // typo_key is appended after [kora], so it lands in KoraConfig
         assert_unknown_field_error(result, "typo_key");
     }

--- a/crates/lib/src/fee/price.rs
+++ b/crates/lib/src/fee/price.rs
@@ -10,7 +10,7 @@ use std::str::FromStr;
 use utoipa::ToSchema;
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
-#[serde(tag = "type", rename_all = "lowercase")]
+#[serde(tag = "type", rename_all = "lowercase", deny_unknown_fields)]
 pub enum PriceModel {
     Margin { margin: f64 },
     Fixed { amount: u64, token: String, strict: bool },

--- a/crates/lib/src/usage_limit/config.rs
+++ b/crates/lib/src/usage_limit/config.rs
@@ -9,6 +9,7 @@ use super::rules::{InstructionRule, TransactionRule, UsageRule};
 
 /// Unified usage limit configuration
 #[derive(Clone, Serialize, Deserialize, ToSchema)]
+#[serde(deny_unknown_fields)]
 pub struct UsageLimitConfig {
     /// Enable per-wallet usage limiting
     pub enabled: bool,
@@ -66,7 +67,7 @@ impl UsageLimitConfig {
 /// max = 10
 /// ```
 #[derive(Clone, Serialize, Deserialize, ToSchema)]
-#[serde(tag = "type", rename_all = "lowercase")]
+#[serde(tag = "type", rename_all = "lowercase", deny_unknown_fields)]
 pub enum UsageLimitRuleConfig {
     /// Transaction-level limit - counts all transactions for a wallet
     Transaction {

--- a/examples/deploy/kora.toml
+++ b/examples/deploy/kora.toml
@@ -159,8 +159,8 @@ expiry_seconds = 30
 [kora.usage_limit]
 enabled = false
 cache_url = "redis://redis:6379"
-max_transactions = 2
 fallback_if_unavailable = false
+rules = []
 
 [kora.bundle]
 enabled = false

--- a/examples/getting-started/demo/server/kora.toml
+++ b/examples/getting-started/demo/server/kora.toml
@@ -148,8 +148,8 @@ blocked_account_extensions = [
 [kora.usage_limit]
 enabled = false
 cache_url = "redis://redis:6379"
-max_transactions = 2
 fallback_if_unavailable = false
+rules = []
 
 [kora.bundle]
 enabled = false

--- a/examples/jito-bundles/server/kora.toml
+++ b/examples/jito-bundles/server/kora.toml
@@ -142,8 +142,8 @@ blocked_account_extensions = [
 [kora.usage_limit]
 enabled = false
 cache_url = "redis://redis:6379"
-max_transactions = 2
 fallback_if_unavailable = false
+rules = []
 
 [kora.bundle]
 enabled = true

--- a/examples/x402/demo/kora/kora.toml
+++ b/examples/x402/demo/kora/kora.toml
@@ -143,8 +143,8 @@ blocked_account_extensions = [
 [kora.usage_limit]
 enabled = false
 cache_url = "redis://redis:6379"
-max_transactions = 2
 fallback_if_unavailable = false
+rules = []
 
 [kora.bundle]
 enabled = false

--- a/kora.toml
+++ b/kora.toml
@@ -176,8 +176,8 @@ expiry_seconds = 30
 [kora.usage_limit]
 enabled = false
 cache_url = "redis://redis:6379"
-max_transactions = 2
 fallback_if_unavailable = false
+rules = []
 
 [kora.plugins]
 # Enabled transaction plugins for sign/signAndSend flows.


### PR DESCRIPTION
Closes #607.

This PR makes `kora.toml` parsing strict by rejecting unknown configuration keys instead of silently ignoring them. It adds `#[serde(deny_unknown_fields)]` across the configuration hierarchy so misspelled keys or keys placed under the wrong table now fail during `Config::load_config`, affecting both `kora rpc start` and `kora config validate`. `PriceConfig` retains `#[serde(flatten)]`, with strict validation enforced through the tagged `PriceModel` enum. We update shipped configuration files to remove stale keys and adds tests covering unknown fields, misplaced keys, and typoed configuration options.

Tests passed.