### PR TITLE
Improve initialize-atas diagnostics for invalid and missing mints

### DIFF
--- a/crates/lib/src/admin/token_util.rs
+++ b/crates/lib/src/admin/token_util.rs
@@ -4,7 +4,7 @@ use crate::{
     state::{get_request_signer_with_signer_key, get_signer_pool},
     token::token::TokenType,
     transaction::TransactionUtil,
-    validator::cross_cluster::check_cross_cluster_mints,
+    validator::cross_cluster::probe_missing_mints,
 };
 use solana_client::nonblocking::rpc_client::RpcClient;
 use solana_compute_budget_interface::ComputeBudgetInstruction;
@@ -287,8 +287,7 @@ pub async fn find_missing_atas(
                     format!("Failed to fetch mint account for {mint}: account not found");
                 if config.validation.cross_cluster_check {
                     let mut warnings = Vec::new();
-                    check_cross_cluster_mints(
-                        rpc_client,
+                    probe_missing_mints(
                         &[mint.to_string()],
                         &config.validation.cross_cluster_endpoints,
                         &mut warnings,

--- a/crates/lib/src/admin/token_util.rs
+++ b/crates/lib/src/admin/token_util.rs
@@ -490,7 +490,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_find_missing_atas_cross_cluster_probe_success() {
+    async fn test_find_missing_atas_cross_cluster_probe_finds_mint() {
         let mint = Pubkey::new_unique();
 
         let mut server = mockito::Server::new_async().await;

--- a/crates/lib/src/admin/token_util.rs
+++ b/crates/lib/src/admin/token_util.rs
@@ -4,6 +4,7 @@ use crate::{
     state::{get_request_signer_with_signer_key, get_signer_pool},
     token::token::TokenType,
     transaction::TransactionUtil,
+    validator::cross_cluster::check_cross_cluster_mints,
 };
 use solana_client::nonblocking::rpc_client::RpcClient;
 use solana_compute_budget_interface::ComputeBudgetInstruction;
@@ -32,6 +33,7 @@ This funciton is tested via the makefile, as it's a CLI command and requires a v
 
 const DEFAULT_CHUNK_SIZE: usize = 10;
 
+#[derive(Debug)]
 pub struct ATAToCreate {
     pub mint: Pubkey,
     pub ata: Pubkey,
@@ -278,12 +280,48 @@ pub async fn find_missing_atas(
     // program id, and deriving with the legacy program id would yield a different PDA that
     // disagrees with execution.
     for mint in &token_mints {
-        let mint_account =
-            CacheUtil::get_account(config, rpc_client, mint, false).await.map_err(|e| {
-                KoraError::RpcError(format!("Failed to fetch mint account for {mint}: {e}"))
-            })?;
+        let mint_account = match CacheUtil::get_account(config, rpc_client, mint, false).await {
+            Ok(account) => account,
+            Err(KoraError::AccountNotFound(_)) => {
+                let mut error_msg =
+                    format!("Failed to fetch mint account for {mint}: account not found");
+                if config.validation.cross_cluster_check {
+                    let mut warnings = Vec::new();
+                    check_cross_cluster_mints(
+                        rpc_client,
+                        &[mint.to_string()],
+                        &config.validation.cross_cluster_endpoints,
+                        &mut warnings,
+                    )
+                    .await;
+                    if !warnings.is_empty() {
+                        error_msg.push_str("\n\n");
+                        error_msg.push_str(&warnings.join("\n"));
+                    }
+                }
+                return Err(KoraError::RpcError(error_msg));
+            }
+            Err(e) => {
+                return Err(KoraError::RpcError(format!(
+                    "Failed to fetch mint account for {mint}: {e}"
+                )));
+            }
+        };
 
-        let token_program = TokenType::get_token_program_from_owner(&mint_account.owner)?;
+        let token_program = match TokenType::get_token_program_from_owner(&mint_account.owner) {
+            Ok(program) => program,
+            Err(KoraError::TokenOperationError(_)) => {
+                let owner_name = if mint_account.owner == solana_system_interface::program::ID {
+                    "System Program".to_string()
+                } else {
+                    mint_account.owner.to_string()
+                };
+                return Err(KoraError::RpcError(format!(
+                    "Invalid token program owner for mint {mint} (owner: {owner_name}): must be SPL Token or Token-2022",
+                )));
+            }
+            Err(e) => return Err(e),
+        };
         let token_program_id = token_program.program_id();
         let ata =
             get_associated_token_address_with_program_id(payment_address, mint, &token_program_id);
@@ -318,6 +356,9 @@ mod tests {
         },
         config_mock::{ConfigMockBuilder, ValidationConfigBuilder},
     };
+    use base64::Engine;
+    use solana_sdk::account::Account;
+    use solana_system_interface::program::ID as SYSTEM_PROGRAM_ID;
     use spl_associated_token_account_interface::address::{
         get_associated_token_address, get_associated_token_address_with_program_id,
     };
@@ -447,6 +488,177 @@ mod tests {
             "Existing Token-2022 ATA must be detected as present, got {} ATAs to create",
             result.len()
         );
+    }
+
+    #[tokio::test]
+    async fn test_find_missing_atas_cross_cluster_probe_success() {
+        let mint = Pubkey::new_unique();
+
+        let mut server = mockito::Server::new_async().await;
+        // Mock a successful JSON-RPC getMultipleAccounts response for the mint
+        let encoded_data = base64::engine::general_purpose::STANDARD.encode(vec![0; 82]); // Dummy mint data
+        let _m = server
+            .mock("POST", "/")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(
+                serde_json::json!({
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "result": {
+                        "context": { "slot": 1 },
+                        "value": [
+                            {
+                                "data": [encoded_data, "base64"],
+                                "executable": false,
+                                "lamports": 1000,
+                                "owner": spl_token_interface::id().to_string(),
+                                "rentEpoch": 0
+                            }
+                        ]
+                    }
+                })
+                .to_string(),
+            )
+            .create_async()
+            .await;
+
+        let url = server.url();
+
+        let _m_config = ConfigMockBuilder::new()
+            .with_validation(
+                ValidationConfigBuilder::new()
+                    .with_allowed_spl_paid_tokens(SplTokenConfig::Allowlist(vec![mint.to_string()]))
+                    .with_cross_cluster_check(true)
+                    .with_cross_cluster_endpoints(vec![url.clone()])
+                    .build(),
+            )
+            .build_and_setup();
+
+        let cache_ctx = CacheUtil::get_account_context();
+        cache_ctx.checkpoint();
+
+        let payment_address = Pubkey::new_unique();
+        let rpc_client = create_mock_rpc_client_account_not_found();
+
+        let responses = Arc::new(Mutex::new(VecDeque::from([Err(KoraError::AccountNotFound(
+            mint.to_string(),
+        ))])));
+
+        let responses_clone = responses.clone();
+        cache_ctx
+            .expect()
+            .times(1)
+            .returning(move |_, _, _, _| responses_clone.lock().unwrap().pop_front().unwrap());
+
+        let config = get_config().unwrap();
+        let result = find_missing_atas(&config, &rpc_client, &payment_address).await;
+
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        if let KoraError::RpcError(msg) = err {
+            assert!(msg.contains("Failed to fetch mint account for"), "got: {}", msg);
+            assert!(msg.contains("found on:"), "got: {}", msg);
+            assert!(msg.contains("possible cluster mismatch"), "got: {}", msg);
+            assert!(msg.contains(&url), "got: {}", msg);
+        } else {
+            panic!("Expected RpcError, got {:?}", err);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_find_missing_atas_cross_cluster_probe() {
+        let mint = Pubkey::new_unique();
+
+        let _m = ConfigMockBuilder::new()
+            .with_validation(
+                ValidationConfigBuilder::new()
+                    .with_allowed_spl_paid_tokens(SplTokenConfig::Allowlist(vec![mint.to_string()]))
+                    .with_cross_cluster_check(true)
+                    .with_cross_cluster_endpoints(vec!["http://localhost:12345".to_string()])
+                    .build(),
+            )
+            .build_and_setup();
+
+        let cache_ctx = CacheUtil::get_account_context();
+        cache_ctx.checkpoint();
+
+        let payment_address = Pubkey::new_unique();
+        let rpc_client = create_mock_rpc_client_account_not_found();
+
+        let responses = Arc::new(Mutex::new(VecDeque::from([Err(KoraError::AccountNotFound(
+            mint.to_string(),
+        ))])));
+
+        let responses_clone = responses.clone();
+        cache_ctx
+            .expect()
+            .times(1)
+            .returning(move |_, _, _, _| responses_clone.lock().unwrap().pop_front().unwrap());
+
+        let config = get_config().unwrap();
+        let result = find_missing_atas(&config, &rpc_client, &payment_address).await;
+
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        if let KoraError::RpcError(msg) = err {
+            assert!(msg.contains("Failed to fetch mint account for"), "got: {}", msg);
+            assert!(
+                msg.contains("cross-cluster check skipped")
+                    || msg.contains("cross-cluster check inconclusive"),
+                "got: {}",
+                msg
+            );
+        } else {
+            panic!("Expected RpcError, got {:?}", err);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_find_missing_atas_wrong_owner() {
+        let mint = Pubkey::new_unique();
+
+        let _m = ConfigMockBuilder::new()
+            .with_validation(
+                ValidationConfigBuilder::new()
+                    .with_allowed_spl_paid_tokens(SplTokenConfig::Allowlist(vec![mint.to_string()]))
+                    .build(),
+            )
+            .build_and_setup();
+
+        let cache_ctx = CacheUtil::get_account_context();
+        cache_ctx.checkpoint();
+
+        let payment_address = Pubkey::new_unique();
+        let rpc_client = create_mock_rpc_client_account_not_found();
+
+        // Return a mock account that is owned by the wrong program.
+        let responses = Arc::new(Mutex::new(VecDeque::from([Ok(Account {
+            lamports: 1000,
+            data: vec![0; 82], // valid mint length
+            owner: SYSTEM_PROGRAM_ID,
+            executable: false,
+            rent_epoch: 0,
+        })])));
+
+        let responses_clone = responses.clone();
+        cache_ctx
+            .expect()
+            .times(1)
+            .returning(move |_, _, _, _| responses_clone.lock().unwrap().pop_front().unwrap());
+
+        let config = get_config().unwrap();
+        let result = find_missing_atas(&config, &rpc_client, &payment_address).await;
+
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        if let KoraError::RpcError(msg) = err {
+            assert!(msg.contains("Invalid token program owner for mint"));
+            assert!(msg.contains("owner: System Program"));
+            assert!(msg.contains("must be SPL Token or Token-2022"));
+        } else {
+            panic!("Expected RpcError, got {:?}", err);
+        }
     }
 
     #[tokio::test]

--- a/crates/lib/src/tests/config_mock.rs
+++ b/crates/lib/src/tests/config_mock.rs
@@ -357,6 +357,16 @@ impl ValidationConfigBuilder {
         self.config.fee_payer_policy = policy;
         self
     }
+
+    pub fn with_cross_cluster_check(mut self, enabled: bool) -> Self {
+        self.config.cross_cluster_check = enabled;
+        self
+    }
+
+    pub fn with_cross_cluster_endpoints(mut self, endpoints: Vec<String>) -> Self {
+        self.config.cross_cluster_endpoints = endpoints;
+        self
+    }
 }
 
 pub struct KoraConfigBuilder {

--- a/crates/lib/src/validator/config_validator.rs
+++ b/crates/lib/src/validator/config_validator.rs
@@ -18,6 +18,7 @@ use crate::{
     validator::{
         account_validator::{validate_account, AccountType},
         cache_validator::CacheValidator,
+        cross_cluster::check_cross_cluster_mints,
         signer_validator::SignerValidator,
     },
     KoraError,
@@ -34,14 +35,6 @@ use spl_token_interface::ID as SPL_TOKEN_PROGRAM_ID;
 
 const MIN_SIGN_TIMEOUT_SECONDS: u64 = 1;
 const HIGH_SIGN_MAX_RETRIES_WARNING_THRESHOLD: u32 = 10;
-const CROSS_CLUSTER_TIMEOUT_SECS: u64 = 5;
-
-enum ProbeOutcome {
-    Found(Vec<String>),
-    NotFound,
-    /// RPC error or timeout cannot conclude the mint is absent on this cluster.
-    Failed,
-}
 
 pub struct ConfigValidator {}
 
@@ -98,129 +91,6 @@ impl ConfigValidator {
                     token_str
                 ));
             }
-        }
-    }
-
-    pub async fn check_cross_cluster_mints(
-        rpc_client: &RpcClient,
-        tokens: &[String],
-        endpoints: &[String],
-        warnings: &mut Vec<String>,
-    ) {
-        let pubkeys: Vec<(String, Pubkey)> = tokens
-            .iter()
-            .filter_map(|t| Pubkey::from_str(t).ok().map(|pk| (t.clone(), pk)))
-            .collect();
-
-        if pubkeys.is_empty() {
-            return;
-        }
-
-        let pks: Vec<Pubkey> = pubkeys.iter().map(|(_, pk)| *pk).collect();
-        let accounts = match rpc_client.get_multiple_accounts(&pks).await {
-            Ok(a) => a,
-            Err(_) => {
-                warnings.push(
-                    "cross-cluster check skipped (could not reach connected cluster)".to_string(),
-                );
-                return;
-            }
-        };
-
-        let missing: Vec<String> = pubkeys
-            .iter()
-            .zip(accounts.iter())
-            .filter_map(|((addr, _), acct)| acct.is_none().then_some(addr.clone()))
-            .collect();
-
-        if missing.is_empty() {
-            return;
-        }
-
-        let probe_futures: Vec<_> = endpoints
-            .iter()
-            .map(|rpc_url| {
-                let missing = missing.clone();
-                let url = rpc_url.clone();
-                async move {
-                    let client = RpcClient::new(url.clone());
-                    let missing_pks: Vec<Pubkey> =
-                        missing.iter().filter_map(|addr| Pubkey::from_str(addr).ok()).collect();
-
-                    let result = tokio::time::timeout(
-                        std::time::Duration::from_secs(CROSS_CLUSTER_TIMEOUT_SECS),
-                        client.get_multiple_accounts(&missing_pks),
-                    )
-                    .await;
-
-                    match result {
-                        Ok(Ok(accounts)) => {
-                            let found: Vec<String> = missing
-                                .iter()
-                                .zip(accounts.iter())
-                                .filter_map(|(addr, acct)| acct.is_some().then_some(addr.clone()))
-                                .collect();
-                            if found.is_empty() {
-                                (url, ProbeOutcome::NotFound)
-                            } else {
-                                (url, ProbeOutcome::Found(found))
-                            }
-                        }
-                        Ok(Err(_)) => (url, ProbeOutcome::Failed),
-                        Err(_) => (url, ProbeOutcome::Failed),
-                    }
-                }
-            })
-            .collect();
-
-        let probe_results = futures::future::join_all(probe_futures).await;
-        Self::emit_cluster_warnings(&missing, &probe_results, warnings);
-    }
-
-    fn emit_cluster_warnings(
-        missing: &[String],
-        probe_results: &[(String, ProbeOutcome)],
-        warnings: &mut Vec<String>,
-    ) {
-        for mint_addr in missing {
-            let found_on: Vec<&str> = probe_results
-                .iter()
-                .filter_map(|(cluster_name, outcome)| match outcome {
-                    ProbeOutcome::Found(mints) if mints.contains(mint_addr) => {
-                        Some(cluster_name.as_str())
-                    }
-                    _ => None,
-                })
-                .collect();
-
-            let conclusive: Vec<&str> = probe_results
-                .iter()
-                .filter_map(|(name, outcome)| match outcome {
-                    ProbeOutcome::Found(_) | ProbeOutcome::NotFound => Some(name.as_str()),
-                    ProbeOutcome::Failed => None,
-                })
-                .collect();
-
-            let warning = if !found_on.is_empty() {
-                format!(
-                    "mint {} not found on the connected cluster\n  found on: {}\n  possible cluster mismatch",
-                    mint_addr,
-                    found_on.join(", ")
-                )
-            } else if conclusive.is_empty() {
-                format!(
-                    "mint {} not found on the connected cluster\n  cross-cluster check inconclusive (all probes failed or timed out)",
-                    mint_addr,
-                )
-            } else {
-                format!(
-                    "mint {} not found on the connected cluster or on: {}",
-                    mint_addr,
-                    conclusive.join(", ")
-                )
-            };
-
-            warnings.push(warning);
         }
     }
 
@@ -1011,7 +881,7 @@ impl ConfigValidator {
                 .collect();
             all_tokens.sort_unstable();
             all_tokens.dedup();
-            Self::check_cross_cluster_mints(
+            check_cross_cluster_mints(
                 rpc_client,
                 &all_tokens,
                 &config.validation.cross_cluster_endpoints,
@@ -3403,68 +3273,6 @@ mod tests {
         assert_eq!(warnings.len(), 2);
         assert!(warnings.iter().any(|w| w.contains("Vote Program")));
         assert!(warnings.iter().any(|w| w.contains(&custom)));
-    }
-
-    #[test]
-    fn test_missing_mint_triggers_warning() {
-        let mint = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v".to_string();
-        let probe_results: Vec<(String, ProbeOutcome)> = vec![
-            ("devnet".into(), ProbeOutcome::NotFound),
-            ("testnet".into(), ProbeOutcome::Failed),
-        ];
-        let mut warnings = Vec::new();
-        ConfigValidator::emit_cluster_warnings(&[mint.clone()], &probe_results, &mut warnings);
-
-        assert_eq!(warnings.len(), 1);
-        assert!(
-            warnings[0].contains(&mint)
-                && warnings[0].contains("not found on the connected cluster or on:"),
-            "unexpected warning: {}",
-            warnings[0]
-        );
-    }
-
-    #[test]
-    fn test_all_probes_failed() {
-        let mint = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v".to_string();
-        let probe_results: Vec<(String, ProbeOutcome)> =
-            vec![("devnet".into(), ProbeOutcome::Failed), ("testnet".into(), ProbeOutcome::Failed)];
-        let mut warnings = Vec::new();
-        ConfigValidator::emit_cluster_warnings(&[mint.clone()], &probe_results, &mut warnings);
-
-        assert_eq!(warnings.len(), 1);
-        assert!(
-            warnings[0].contains(&mint) && warnings[0].contains("cross-cluster check inconclusive"),
-            "unexpected warning: {}",
-            warnings[0]
-        );
-    }
-
-    #[test]
-    fn test_existing_mint_no_warning() {
-        let probe_results: Vec<(String, ProbeOutcome)> = vec![];
-        let mut warnings = Vec::new();
-        ConfigValidator::emit_cluster_warnings(&[], &probe_results, &mut warnings);
-
-        assert!(warnings.is_empty());
-    }
-
-    #[test]
-    fn test_mint_found_on_other_cluster_warning() {
-        let mint = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v".to_string();
-        let probe_results: Vec<(String, ProbeOutcome)> = vec![
-            ("devnet".into(), ProbeOutcome::Found(vec![mint.clone()])),
-            ("testnet".into(), ProbeOutcome::NotFound),
-        ];
-        let mut warnings = Vec::new();
-        ConfigValidator::emit_cluster_warnings(&[mint.clone()], &probe_results, &mut warnings);
-
-        assert_eq!(warnings.len(), 1);
-        let w = &warnings[0];
-        assert!(w.contains(&mint), "mint address missing from warning");
-        assert!(w.contains("found on:"), "expected 'found on:' in warning");
-        assert!(w.contains("devnet"), "expected cluster name in warning");
-        assert!(w.contains("possible cluster mismatch"), "expected mismatch note");
     }
 
     #[tokio::test]

--- a/crates/lib/src/validator/cross_cluster.rs
+++ b/crates/lib/src/validator/cross_cluster.rs
@@ -43,14 +43,23 @@ pub(crate) async fn check_cross_cluster_mints(
         .filter_map(|((addr, _), acct)| acct.is_none().then_some(addr.clone()))
         .collect();
 
-    if missing.is_empty() {
+    probe_missing_mints(&missing, endpoints, warnings).await;
+}
+
+pub(crate) async fn probe_missing_mints(
+    missing: &[String],
+    endpoints: &[String],
+    warnings: &mut Vec<String>,
+) {
+    // No probes can be performed without configured endpoints.
+    if missing.is_empty() || endpoints.is_empty() {
         return;
     }
 
     let probe_futures: Vec<_> = endpoints
         .iter()
         .map(|rpc_url| {
-            let missing = missing.clone();
+            let missing = missing.to_vec();
             let url = rpc_url.clone();
             async move {
                 let client = RpcClient::new(url.clone());
@@ -84,7 +93,7 @@ pub(crate) async fn check_cross_cluster_mints(
         .collect();
 
     let probe_results = futures::future::join_all(probe_futures).await;
-    emit_cluster_warnings(&missing, &probe_results, warnings);
+    emit_cluster_warnings(missing, &probe_results, warnings);
 }
 
 pub(crate) fn emit_cluster_warnings(
@@ -137,6 +146,7 @@ pub(crate) fn emit_cluster_warnings(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::slice::from_ref;
 
     #[test]
     fn test_missing_mint_triggers_warning() {
@@ -146,7 +156,7 @@ mod tests {
             ("testnet".into(), ProbeOutcome::Failed),
         ];
         let mut warnings = Vec::new();
-        emit_cluster_warnings(&[mint.clone()], &probe_results, &mut warnings);
+        emit_cluster_warnings(from_ref(&mint), &probe_results, &mut warnings);
 
         assert_eq!(warnings.len(), 1);
         assert!(
@@ -163,7 +173,7 @@ mod tests {
         let probe_results: Vec<(String, ProbeOutcome)> =
             vec![("devnet".into(), ProbeOutcome::Failed), ("testnet".into(), ProbeOutcome::Failed)];
         let mut warnings = Vec::new();
-        emit_cluster_warnings(&[mint.clone()], &probe_results, &mut warnings);
+        emit_cluster_warnings(from_ref(&mint), &probe_results, &mut warnings);
 
         assert_eq!(warnings.len(), 1);
         assert!(
@@ -190,7 +200,7 @@ mod tests {
             ("testnet".into(), ProbeOutcome::NotFound),
         ];
         let mut warnings = Vec::new();
-        emit_cluster_warnings(&[mint.clone()], &probe_results, &mut warnings);
+        emit_cluster_warnings(from_ref(&mint), &probe_results, &mut warnings);
 
         assert_eq!(warnings.len(), 1);
         let w = &warnings[0];

--- a/crates/lib/src/validator/cross_cluster.rs
+++ b/crates/lib/src/validator/cross_cluster.rs
@@ -51,8 +51,12 @@ pub(crate) async fn probe_missing_mints(
     endpoints: &[String],
     warnings: &mut Vec<String>,
 ) {
-    // No probes can be performed without configured endpoints.
-    if missing.is_empty() || endpoints.is_empty() {
+    if missing.is_empty() {
+        return;
+    }
+
+    if endpoints.is_empty() {
+        warnings.push("cross-cluster check enabled but no endpoints configured".to_string());
         return;
     }
 

--- a/crates/lib/src/validator/cross_cluster.rs
+++ b/crates/lib/src/validator/cross_cluster.rs
@@ -1,0 +1,202 @@
+use solana_client::nonblocking::rpc_client::RpcClient;
+use solana_program::pubkey::Pubkey;
+use std::{str::FromStr, time::Duration};
+use tokio::time::timeout;
+
+/// Time in seconds before giving up on a cross-cluster probe to avoid hanging validation.
+const CROSS_CLUSTER_TIMEOUT_SECS: u64 = 5;
+
+pub(crate) enum ProbeOutcome {
+    Found(Vec<String>),
+    NotFound,
+    /// RPC error or timeout cannot conclude the mint is absent on this cluster.
+    Failed,
+}
+
+pub(crate) async fn check_cross_cluster_mints(
+    rpc_client: &RpcClient,
+    tokens: &[String],
+    endpoints: &[String],
+    warnings: &mut Vec<String>,
+) {
+    let pubkeys: Vec<(String, Pubkey)> =
+        tokens.iter().filter_map(|t| Pubkey::from_str(t).ok().map(|pk| (t.clone(), pk))).collect();
+
+    if pubkeys.is_empty() {
+        return;
+    }
+
+    let pks: Vec<Pubkey> = pubkeys.iter().map(|(_, pk)| *pk).collect();
+    let accounts = match rpc_client.get_multiple_accounts(&pks).await {
+        Ok(a) => a,
+        Err(_) => {
+            warnings.push(
+                "cross-cluster check skipped (could not reach connected cluster)".to_string(),
+            );
+            return;
+        }
+    };
+
+    let missing: Vec<String> = pubkeys
+        .iter()
+        .zip(accounts.iter())
+        .filter_map(|((addr, _), acct)| acct.is_none().then_some(addr.clone()))
+        .collect();
+
+    if missing.is_empty() {
+        return;
+    }
+
+    let probe_futures: Vec<_> = endpoints
+        .iter()
+        .map(|rpc_url| {
+            let missing = missing.clone();
+            let url = rpc_url.clone();
+            async move {
+                let client = RpcClient::new(url.clone());
+                let missing_pks: Vec<Pubkey> =
+                    missing.iter().filter_map(|addr| Pubkey::from_str(addr).ok()).collect();
+
+                let result = timeout(
+                    Duration::from_secs(CROSS_CLUSTER_TIMEOUT_SECS),
+                    client.get_multiple_accounts(&missing_pks),
+                )
+                .await;
+
+                match result {
+                    Ok(Ok(accounts)) => {
+                        let found: Vec<String> = missing
+                            .iter()
+                            .zip(accounts.iter())
+                            .filter_map(|(addr, acct)| acct.is_some().then_some(addr.clone()))
+                            .collect();
+                        if found.is_empty() {
+                            (url, ProbeOutcome::NotFound)
+                        } else {
+                            (url, ProbeOutcome::Found(found))
+                        }
+                    }
+                    Ok(Err(_)) => (url, ProbeOutcome::Failed),
+                    Err(_) => (url, ProbeOutcome::Failed),
+                }
+            }
+        })
+        .collect();
+
+    let probe_results = futures::future::join_all(probe_futures).await;
+    emit_cluster_warnings(&missing, &probe_results, warnings);
+}
+
+pub(crate) fn emit_cluster_warnings(
+    missing: &[String],
+    probe_results: &[(String, ProbeOutcome)],
+    warnings: &mut Vec<String>,
+) {
+    for mint_addr in missing {
+        let found_on: Vec<&str> = probe_results
+            .iter()
+            .filter_map(|(cluster_name, outcome)| match outcome {
+                ProbeOutcome::Found(mints) if mints.contains(mint_addr) => {
+                    Some(cluster_name.as_str())
+                }
+                _ => None,
+            })
+            .collect();
+
+        let conclusive: Vec<&str> = probe_results
+            .iter()
+            .filter_map(|(name, outcome)| match outcome {
+                ProbeOutcome::Found(_) | ProbeOutcome::NotFound => Some(name.as_str()),
+                ProbeOutcome::Failed => None,
+            })
+            .collect();
+
+        let warning = if !found_on.is_empty() {
+            format!(
+                "mint {} not found on the connected cluster\n  found on: {}\n  possible cluster mismatch",
+                mint_addr,
+                found_on.join(", ")
+            )
+        } else if conclusive.is_empty() {
+            format!(
+                "mint {} not found on the connected cluster\n  cross-cluster check inconclusive (all probes failed or timed out)",
+                mint_addr,
+            )
+        } else {
+            format!(
+                "mint {} not found on the connected cluster or on: {}",
+                mint_addr,
+                conclusive.join(", ")
+            )
+        };
+
+        warnings.push(warning);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_missing_mint_triggers_warning() {
+        let mint = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v".to_string();
+        let probe_results: Vec<(String, ProbeOutcome)> = vec![
+            ("devnet".into(), ProbeOutcome::NotFound),
+            ("testnet".into(), ProbeOutcome::Failed),
+        ];
+        let mut warnings = Vec::new();
+        emit_cluster_warnings(&[mint.clone()], &probe_results, &mut warnings);
+
+        assert_eq!(warnings.len(), 1);
+        assert!(
+            warnings[0].contains(&mint)
+                && warnings[0].contains("not found on the connected cluster or on:"),
+            "unexpected warning: {}",
+            warnings[0]
+        );
+    }
+
+    #[test]
+    fn test_all_probes_failed() {
+        let mint = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v".to_string();
+        let probe_results: Vec<(String, ProbeOutcome)> =
+            vec![("devnet".into(), ProbeOutcome::Failed), ("testnet".into(), ProbeOutcome::Failed)];
+        let mut warnings = Vec::new();
+        emit_cluster_warnings(&[mint.clone()], &probe_results, &mut warnings);
+
+        assert_eq!(warnings.len(), 1);
+        assert!(
+            warnings[0].contains(&mint) && warnings[0].contains("cross-cluster check inconclusive"),
+            "unexpected warning: {}",
+            warnings[0]
+        );
+    }
+
+    #[test]
+    fn test_existing_mint_no_warning() {
+        let probe_results: Vec<(String, ProbeOutcome)> = vec![];
+        let mut warnings = Vec::new();
+        emit_cluster_warnings(&[], &probe_results, &mut warnings);
+
+        assert!(warnings.is_empty());
+    }
+
+    #[test]
+    fn test_mint_found_on_other_cluster_warning() {
+        let mint = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v".to_string();
+        let probe_results: Vec<(String, ProbeOutcome)> = vec![
+            ("devnet".into(), ProbeOutcome::Found(vec![mint.clone()])),
+            ("testnet".into(), ProbeOutcome::NotFound),
+        ];
+        let mut warnings = Vec::new();
+        emit_cluster_warnings(&[mint.clone()], &probe_results, &mut warnings);
+
+        assert_eq!(warnings.len(), 1);
+        let w = &warnings[0];
+        assert!(w.contains(&mint), "mint address missing from warning");
+        assert!(w.contains("found on:"), "expected 'found on:' in warning");
+        assert!(w.contains("devnet"), "expected cluster name in warning");
+        assert!(w.contains("possible cluster mismatch"), "expected mismatch note");
+    }
+}

--- a/crates/lib/src/validator/mod.rs
+++ b/crates/lib/src/validator/mod.rs
@@ -2,6 +2,7 @@ pub mod account_validator;
 pub mod bundle_validator;
 pub mod cache_validator;
 pub mod config_validator;
+pub mod cross_cluster;
 pub mod math_validator;
 #[macro_use]
 pub mod macros;


### PR DESCRIPTION
Improve `initialize-atas` diagnostics for missing and invalid mints.

- Add cross-cluster hints for missing mints.
- Use human-readable program owner names.
- Avoid a redundant local RPC during cross-cluster probing.

Closes #608