### PR TITLE
fix(ci): restore pnpm vulnerability audit

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -38,7 +38,7 @@ jobs:
           node-version: 'lts/*'
       - uses: pnpm/action-setup@v6.0.7
         with:
-          version: 10.12.3
+          version: 11.13.0
           run_install: false
       - run: pnpm audit --ignore-unfixable
 

--- a/.github/workflows/typescript-integration.yml
+++ b/.github/workflows/typescript-integration.yml
@@ -74,7 +74,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v6.0.7
         with:
-          version: 10.12.3
+          version: 11.13.0
           run_install: false
 
       - name: Get pnpm store directory

--- a/.github/workflows/typescript-publish.yml
+++ b/.github/workflows/typescript-publish.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v6.0.7
         with:
-          version: 10.12.3
+          version: 11.13.0
           run_install: false
 
       - name: Get pnpm store directory

--- a/.github/workflows/typescript-unit.yml
+++ b/.github/workflows/typescript-unit.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v6.0.7
         with:
-          version: 10.12.3
+          version: 11.13.0
           run_install: false
 
       - name: Get pnpm store directory

--- a/sdks/package.json
+++ b/sdks/package.json
@@ -7,20 +7,5 @@
   "keywords": [],
   "author": "",
   "license": "ISC",
-  "packageManager": "pnpm@10.12.3",
-  "pnpm": {
-    "overrides": {
-      "markdown-it": ">=14.1.1",
-      "diff": ">=4.0.4",
-      "js-yaml": ">=4.1.1",
-      "brace-expansion@^2": "2.0.3",
-      "picomatch@^2": "2.3.2",
-      "picomatch@^4": "4.0.4",
-      "yaml@^2": "2.8.3",
-      "flatted@^3": "3.4.2",
-      "minimatch@^3": "3.1.5",
-      "minimatch@^5": "5.1.8",
-      "minimatch@^9": "9.0.7"
-    }
-  }
+  "packageManager": "pnpm@11.13.0"
 }

--- a/sdks/pnpm-workspace.yaml
+++ b/sdks/pnpm-workspace.yaml
@@ -1,2 +1,20 @@
 packages:
   - "ts"
+
+allowBuilds:
+  unrs-resolver: true
+
+auditConfig: {}
+
+overrides:
+  markdown-it: ">=14.1.1"
+  diff: ">=4.0.4"
+  js-yaml: ">=4.1.1"
+  brace-expansion@^2: 2.0.3
+  picomatch@^2: 2.3.2
+  picomatch@^4: 4.0.4
+  yaml@^2: 2.8.3
+  flatted@^3: 3.4.2
+  minimatch@^3: 3.1.5
+  minimatch@^5: 5.1.8
+  minimatch@^9: 9.0.7


### PR DESCRIPTION
Fixes the failing `pnpm-audit` job in the Security workflow ([failing run](https://github.com/solana-foundation/kora/actions/runs/29380031906/job/87241507603)).

npm retired the legacy audit endpoint, so `pnpm audit` on pnpm 10 fails with:

```
ERR_PNPM_AUDIT_BAD_RESPONSE  The audit endpoint (at https://registry.npmjs.org/-/npm/v1/security/audits) responded with 410
```

Same fix as solana-foundation/subscriptions@d27254a:

- Pin pnpm 11.13.0 (`packageManager` + the four workflows that set up pnpm), which uses npm's bulk advisory endpoint
- Move `pnpm.overrides` from `sdks/package.json` to `sdks/pnpm-workspace.yaml` (pnpm 11 no longer reads the `pnpm` field in package.json)
- Add the explicit `allowBuilds` policy pnpm 11 requires (`unrs-resolver: true`, matching subscriptions); without it `pnpm install` fails with `ERR_PNPM_IGNORED_BUILDS`
- Commit the `auditConfig: {}` stub since `pnpm audit --ignore-unfixable` rewrites it on every run

Verified locally with pnpm 11.13.0: `install --frozen-lockfile`, `audit --ignore-unfixable`, `build`, and the SDK unit tests (41 passed) all succeed. No lockfile change needed (lockfile v9 is shared between pnpm 10 and 11).