### PR TITLE
feat(kora-deploy): add resume capability and buffer cleanup on transient failures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,9 @@ test-ledger/
 tests/src/common/fixtures/lookup_tables.json
 tests/src/common/fixtures/test-accounts/
 
+# kora-deploy state file — contains raw keypair bytes
+.kora-deploy-state.json
+
 # Docs
 sdks/ts/docs-html/
 sdks/ts/docs-md/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3555,6 +3555,7 @@ dependencies = [
  "clap",
  "log",
  "reqwest 0.13.4",
+ "serde",
  "serde_json",
  "solana-client",
  "solana-commitment-config",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3935,6 +3935,7 @@ dependencies = [
  "clap",
  "log",
  "reqwest 0.13.4",
+ "serde",
  "serde_json",
  "solana-client",
  "solana-commitment-config",

--- a/crates/kora-deploy/Cargo.toml
+++ b/crates/kora-deploy/Cargo.toml
@@ -23,6 +23,7 @@ bincode = { workspace = true }
 clap = { workspace = true, features = ["derive"] }
 log = { workspace = true }
 reqwest = { workspace = true }
+serde = { workspace = true }
 serde_json = { workspace = true }
 solana-client = { workspace = true }
 solana-commitment-config = { workspace = true }

--- a/crates/kora-deploy/README.md
+++ b/crates/kora-deploy/README.md
@@ -36,6 +36,43 @@ Flags:
 | `--user-id` | random per run | Tag the paymaster buckets by for usage limits |
 | `--wallet` | `~/.config/solana/id.json` | Owner wallet registered for upgrades; without one the program is immutable |
 | `--program-id` | _(none)_ | Existing program to upgrade; omit to deploy fresh |
+| `--resume` | `false` | Resume a previous deployment from the local `.kora-deploy-state.json` file |
+| `--no-cleanup-on-failure` | `false` | Do not close the buffer on failure, leaving it open so you can `--resume` later |
+
+## Recovering from a failed deploy
+
+When you start a fresh deployment, `kora-deploy` writes a `.kora-deploy-state.json`
+file to your directory. This stores the program and buffer keypairs required to
+deploy your code. If deployment succeeds, the file is automatically removed.
+If it fails (e.g., timeout or rate limit), the file remains for recovery.
+
+**Normal Resume Flow**:
+Run the exact same `kora-deploy` command but add the `--resume` flag.
+It reads `.kora-deploy-state.json`, skips already-written chunks,
+and continues where it left off.
+
+**Cleanup on Failure**:
+By default, failed or interrupted deploys automatically close the buffer
+to return rent to the paymaster. This prevents you from resuming.
+If you anticipate connection issues, pass `--no-cleanup-on-failure`
+on your initial run to leave the buffer open for `--resume`.
+
+**Hash Mismatch**:
+If you recompile your `.so` file before resuming, the hashes won't match.
+`kora-deploy` will refuse to resume to prevent corrupted data.
+Either restore the original `.so` file, or delete the state file
+and start a fresh deploy.
+
+**Manual Recovery / Deploy Timeout**:
+Rarely, the final transaction might time out, leaving an ambiguous state.
+You can check if the paymaster finalized it manually:
+```bash
+solana program show <PROGRAM_ID>
+```
+If it's not live, you can't resume, and automatic cleanup failed,
+the buffer may be stuck. You can manually close it using
+`solana program close` and the keypairs in `.kora-deploy-state.json`,
+then delete the state file to start over.
 
 ## Trade-offs
 

--- a/crates/kora-deploy/README.md
+++ b/crates/kora-deploy/README.md
@@ -71,8 +71,10 @@ solana program show <PROGRAM_ID>
 ```
 If it's not live, you can't resume, and automatic cleanup failed,
 the buffer may be stuck. You can manually close it using
-`solana program close` and the keypairs in `.kora-deploy-state.json`,
-then delete the state file to start over.
+`solana program close`. The `.kora-deploy-state.json` file stores the
+`program_keypair` and `buffer_keypair` as raw JSON byte arrays. To use them
+with the Solana CLI, copy the array of numbers (e.g., `[1,2,...]`) into a new
+file and pass that file to the CLI, then delete the state file to start over.
 
 ## Trade-offs
 

--- a/crates/kora-deploy/src/lib.rs
+++ b/crates/kora-deploy/src/lib.rs
@@ -1,6 +1,14 @@
 #![allow(deprecated)]
 
-use std::{path::Path, str::FromStr, sync::Arc, time::Duration};
+pub mod state;
+
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    str::FromStr,
+    sync::Arc,
+    time::Duration,
+};
 
 use anyhow::{anyhow, bail, Context, Result};
 use base64::{engine::general_purpose::STANDARD as B64, Engine as _};
@@ -9,6 +17,7 @@ use solana_client::nonblocking::rpc_client::RpcClient;
 use solana_commitment_config::CommitmentConfig;
 use solana_loader_v3_interface::{instruction as loader_v3, state::UpgradeableLoaderState};
 use solana_sdk::{
+    hash::hash,
     instruction::{AccountMeta, Instruction},
     message::Message,
     pubkey::Pubkey,
@@ -16,6 +25,8 @@ use solana_sdk::{
     signer::Signer,
     transaction::Transaction,
 };
+
+use crate::state::DeployState;
 
 const WRITE_CHUNK_SIZE: usize = 900;
 const BPF_LOADER_UPGRADEABLE: Pubkey =
@@ -37,6 +48,9 @@ pub struct DeployConfig<'a> {
     /// deploy registry, allowing future upgrades signed by it. Without a wallet the program
     /// is immutable through the paymaster.
     pub wallet: Option<&'a Keypair>,
+    pub resume: bool,
+    pub cleanup_on_failure: bool,
+    pub state_path: PathBuf,
 }
 
 pub struct UpgradeConfig<'a> {
@@ -62,32 +76,204 @@ pub async fn deploy(cfg: &DeployConfig<'_>) -> Result<DeployResult> {
         CommitmentConfig::confirmed(),
     ));
 
-    let kora_pubkey = fetch_kora_pubkey(&http, cfg.kora_url).await?;
-    let program = Keypair::new();
-    let buffer = Keypair::new();
-    let bytes = std::fs::read(cfg.program_so)
+    let state_path = cfg.state_path.as_path();
+
+    macro_rules! cleanup_buffer {
+        ($msg:expr, $cfg:expr, $buffer:expr, $kora_pubkey:expr, $http:expr, $rpc:expr, $state_path:expr) => {
+            if $cfg.cleanup_on_failure {
+                log::warn!("{}, attempting to close buffer for cleanup...", $msg);
+                let close_ix = loader_v3::close_any(
+                    &$buffer.pubkey(),
+                    &$kora_pubkey,
+                    Some(&$kora_pubkey),
+                    None,
+                );
+                match submit_returning_signature(
+                    &$http,
+                    $cfg.kora_url,
+                    &$cfg.user_id,
+                    &$rpc,
+                    &$kora_pubkey,
+                    &[close_ix],
+                    &[],
+                )
+                .await
+                {
+                    Ok(_) => {
+                        if let Err(err) = fs::remove_file(&$state_path) {
+                            log::warn!(
+                                "Buffer closed successfully, but failed to delete state file: {}. Please manually delete {} to start a fresh deployment.",
+                                err,
+                                $state_path.display()
+                            );
+                        }
+                    }
+                    Err(e) => {
+                        log::warn!(
+                            "failed to close buffer: {}; keeping state file for manual recovery",
+                            e
+                        );
+                    }
+                }
+            }
+        };
+    }
+
+    let mut state = if cfg.resume {
+        Some(DeployState::load(state_path)?.ok_or_else(|| {
+            anyhow::anyhow!(
+                "--resume was requested, but no state file was found at {}. Cannot resume.",
+                state_path.display()
+            )
+        })?)
+    } else {
+        if state_path.exists() {
+            anyhow::bail!(
+                "State file exists at {}. A previous deploy failed.\n\
+                Run with `--resume` to continue, or delete the file to start over (WARNING: deleting it orphans the on-chain buffer and leaks SOL).",
+                state_path.display()
+            );
+        }
+        None
+    };
+
+    let bytes = fs::read(cfg.program_so)
         .with_context(|| format!("reading {}", cfg.program_so.display()))?;
-    let program_data = derive_program_data_address(&program.pubkey());
-
-    let buffer_lamports = rpc
-        .get_minimum_balance_for_rent_exemption(UpgradeableLoaderState::size_of_buffer(bytes.len()))
-        .await?;
-    let create_buf = loader_v3::create_buffer(
-        &kora_pubkey,
-        &buffer.pubkey(),
-        &kora_pubkey,
-        buffer_lamports,
-        bytes.len(),
-    )?;
-    submit(&http, cfg.kora_url, &cfg.user_id, &rpc, &kora_pubkey, &create_buf, &[&buffer]).await?;
-
     let chunk_count = bytes.len().div_ceil(WRITE_CHUNK_SIZE);
-    for (i, chunk) in bytes.chunks(WRITE_CHUNK_SIZE).enumerate() {
+    let current_program_hash = hash(&bytes).to_string();
+
+    let (program, buffer, program_data, kora_pubkey, mut written_chunks) = if let Some(ref st) =
+        state
+    {
+        let program = Keypair::try_from(st.program_keypair.as_slice())
+            .context("invalid program keypair in state")?;
+        let buffer = Keypair::try_from(st.buffer_keypair.as_slice())
+            .context("invalid buffer keypair in state")?;
+        let program_data =
+            Pubkey::from_str(&st.program_data).context("invalid program data pubkey in state")?;
+        let kora_pubkey =
+            Pubkey::from_str(&st.kora_pubkey).context("invalid kora pubkey in state")?;
+        log::info!("resuming deployment from state file, skipping {} chunks", st.written_chunks);
+        (program, buffer, program_data, kora_pubkey, st.written_chunks)
+    } else {
+        let kora_pubkey = fetch_kora_pubkey(&http, cfg.kora_url).await?;
+        let program = Keypair::new();
+        let buffer = Keypair::new();
+
+        let buffer_lamports = rpc
+            .get_minimum_balance_for_rent_exemption(UpgradeableLoaderState::size_of_buffer(
+                bytes.len(),
+            ))
+            .await?;
+        let create_buf = loader_v3::create_buffer(
+            &kora_pubkey,
+            &buffer.pubkey(),
+            &kora_pubkey,
+            buffer_lamports,
+            bytes.len(),
+        )?;
+        submit(&http, cfg.kora_url, &cfg.user_id, &rpc, &kora_pubkey, &create_buf, &[&buffer])
+            .await?;
+
+        let program_data = derive_program_data_address(&program.pubkey());
+        let new_state = DeployState {
+            program_keypair: program.to_bytes().to_vec(),
+            buffer_keypair: buffer.to_bytes().to_vec(),
+            program_data: program_data.to_string(),
+            written_chunks: 0,
+            kora_pubkey: kora_pubkey.to_string(),
+            program_hash: current_program_hash.clone(),
+        };
+        if let Err(e) = new_state.save(state_path) {
+            cleanup_buffer!(
+                "failed to save initial state",
+                cfg,
+                buffer,
+                kora_pubkey,
+                http,
+                rpc,
+                state_path
+            );
+            return Err(e.context("failed to save initial deploy state"));
+        }
+        state = Some(new_state);
+
+        (program, buffer, program_data, kora_pubkey, 0)
+    };
+
+    if let Some(ref st) = state {
+        if st.written_chunks > chunk_count {
+            cleanup_buffer!(
+                "written_chunks exceeds chunk_count (corrupted state or smaller .so file)",
+                cfg,
+                buffer,
+                kora_pubkey,
+                http,
+                rpc,
+                state_path
+            );
+            if cfg.cleanup_on_failure {
+                anyhow::bail!("State file is corrupted or .so file is smaller: written_chunks ({}) > total chunk count ({}). Cannot resume. Buffer cleanup was attempted.", st.written_chunks, chunk_count);
+            } else {
+                anyhow::bail!("State file is corrupted or .so file is smaller: written_chunks ({}) > total chunk count ({}). Cannot resume. Buffer cleanup skipped (--cleanup-on-failure=false).", st.written_chunks, chunk_count);
+            }
+        }
+        if st.program_hash != current_program_hash {
+            cleanup_buffer!(
+                "hash mismatch detected during resume",
+                cfg,
+                buffer,
+                kora_pubkey,
+                http,
+                rpc,
+                state_path
+            );
+            if cfg.cleanup_on_failure {
+                anyhow::bail!("The .so file has changed (hash mismatch). Cannot resume. Buffer cleanup was attempted.");
+            } else {
+                anyhow::bail!("The .so file has changed (hash mismatch). Cannot resume. Buffer cleanup skipped (--cleanup-on-failure=false).");
+            }
+        }
+    }
+
+    for (i, chunk) in bytes.chunks(WRITE_CHUNK_SIZE).enumerate().skip(written_chunks) {
         let offset = (i * WRITE_CHUNK_SIZE) as u32;
         let ix = loader_v3::write(&buffer.pubkey(), &kora_pubkey, offset, chunk.to_vec());
-        submit(&http, cfg.kora_url, &cfg.user_id, &rpc, &kora_pubkey, &[ix], &[]).await?;
-        if (i + 1) % 25 == 0 || i + 1 == chunk_count {
-            log::info!("wrote chunk {}/{}", i + 1, chunk_count);
+
+        match submit(&http, cfg.kora_url, &cfg.user_id, &rpc, &kora_pubkey, &[ix], &[]).await {
+            Ok(_) => {
+                written_chunks += 1;
+                if let Some(ref mut st) = state {
+                    st.written_chunks = written_chunks;
+                    if let Err(e) = st.save(state_path) {
+                        cleanup_buffer!(
+                            "failed to save chunk state",
+                            cfg,
+                            buffer,
+                            kora_pubkey,
+                            http,
+                            rpc,
+                            state_path
+                        );
+                        return Err(e.context("failed to save deploy state after chunk write"));
+                    }
+                }
+                if (i + 1) % 25 == 0 || i + 1 == chunk_count {
+                    log::info!("wrote chunk {}/{}", i + 1, chunk_count);
+                }
+            }
+            Err(e) => {
+                cleanup_buffer!(
+                    "chunk write failed",
+                    cfg,
+                    buffer,
+                    kora_pubkey,
+                    http,
+                    rpc,
+                    state_path
+                );
+                return Err(e.context("failed to write chunk"));
+            }
         }
     }
 
@@ -112,8 +298,53 @@ pub async fn deploy(cfg: &DeployConfig<'_>) -> Result<DeployResult> {
         ));
         deploy_signers.push(wallet);
     }
-    submit(&http, cfg.kora_url, &cfg.user_id, &rpc, &kora_pubkey, &deploy_ixs, &deploy_signers)
-        .await?;
+
+    // Check if the program is live (programdata exists) to handle the timeout-but-success scenario.
+    // NOTE: the 36-byte program stub survives forever even after reaping; only programdata
+    // disappearing means the program is gone, so we must check programdata, not the stub.
+    if rpc
+        .get_account_with_commitment(&program_data, CommitmentConfig::confirmed())
+        .await?
+        .value
+        .is_some()
+    {
+        log::info!("Program {} is already live, skipping deployment.", program.pubkey());
+        fs::remove_file(state_path).ok();
+    } else {
+        match submit(
+            &http,
+            cfg.kora_url,
+            &cfg.user_id,
+            &rpc,
+            &kora_pubkey,
+            &deploy_ixs,
+            &deploy_signers,
+        )
+        .await
+        {
+            Ok(_) => {
+                fs::remove_file(state_path).ok();
+            }
+            Err(e) => {
+                cleanup_buffer!(
+                    "deploy transaction failed",
+                    cfg,
+                    buffer,
+                    kora_pubkey,
+                    http,
+                    rpc,
+                    state_path
+                );
+                return Err(anyhow::anyhow!(
+                    "Failed to submit deploy transaction for {}: {}. \n\
+                    Verify status: `solana program show {}`",
+                    program.pubkey(),
+                    e,
+                    program.pubkey()
+                ));
+            }
+        }
+    }
 
     Ok(DeployResult {
         kora_pubkey,
@@ -133,7 +364,7 @@ pub async fn upgrade(cfg: &UpgradeConfig<'_>) -> Result<Signature> {
     let kora_pubkey = fetch_kora_pubkey(&http, cfg.kora_url).await?;
     assert_registered_owner(&rpc, &DEFAULT_REGISTRY_PROGRAM, &cfg.program, &cfg.wallet.pubkey())
         .await?;
-    let bytes = std::fs::read(cfg.program_so)
+    let bytes = fs::read(cfg.program_so)
         .with_context(|| format!("reading {}", cfg.program_so.display()))?;
 
     let buffer = Keypair::new();

--- a/crates/kora-deploy/src/lib.rs
+++ b/crates/kora-deploy/src/lib.rs
@@ -69,59 +69,95 @@ pub struct DeployResult {
     pub buffer: Pubkey,
 }
 
+struct DeployCtx<'a, 'b> {
+    cfg: &'b DeployConfig<'a>,
+    http: &'b reqwest::Client,
+    rpc: &'b Arc<RpcClient>,
+}
+
+macro_rules! cleanup_buffer {
+    ($force:expr, $msg:expr, $err_log:expr, $ctx:expr, $buffer:expr, $kora_pubkey:expr) => {
+        if $force || $ctx.cfg.cleanup_on_failure {
+            log::warn!("{}, attempting to close buffer for cleanup...", $msg);
+            let close_ix = loader_v3::close_any(
+                &$buffer.pubkey(),
+                $kora_pubkey,
+                Some($kora_pubkey),
+                None,
+            );
+            match submit_returning_signature(
+                $ctx.http,
+                $ctx.cfg.kora_url,
+                &$ctx.cfg.user_id,
+                $ctx.rpc,
+                $kora_pubkey,
+                &[close_ix],
+                &[],
+            )
+            .await
+            {
+                Ok(_) => {
+                    let state_path = $ctx.cfg.state_path.as_path();
+                    if state_path.exists() {
+                        if let Err(err) = fs::remove_file(state_path) {
+                            log::warn!(
+                                "Buffer closed successfully, but failed to delete state file: {}. Please manually delete {} to start a fresh deployment.",
+                                err,
+                                state_path.display()
+                            );
+                        }
+                    }
+                }
+                Err(e) => {
+                    $err_log(e);
+                }
+            }
+        }
+    };
+}
+
+/// Orchestrates the program deployment process: handles state initialization,
+/// validates continuity for resuming, executes chunked writes, and finalizes the deploy.
 pub async fn deploy(cfg: &DeployConfig<'_>) -> Result<DeployResult> {
     let http = reqwest::Client::builder().timeout(Duration::from_secs(60)).build()?;
     let rpc = Arc::new(RpcClient::new_with_commitment(
         cfg.rpc_url.to_string(),
         CommitmentConfig::confirmed(),
     ));
+    let ctx = DeployCtx { cfg, http: &http, rpc: &rpc };
 
-    let state_path = cfg.state_path.as_path();
+    let bytes = fs::read(cfg.program_so)
+        .with_context(|| format!("reading {}", cfg.program_so.display()))?;
+    let chunk_count = bytes.len().div_ceil(WRITE_CHUNK_SIZE);
+    let current_program_hash = hash(&bytes).to_string();
 
-    macro_rules! cleanup_buffer {
-        ($msg:expr, $cfg:expr, $buffer:expr, $kora_pubkey:expr, $http:expr, $rpc:expr, $state_path:expr) => {
-            if $cfg.cleanup_on_failure {
-                log::warn!("{}, attempting to close buffer for cleanup...", $msg);
-                let close_ix = loader_v3::close_any(
-                    &$buffer.pubkey(),
-                    &$kora_pubkey,
-                    Some(&$kora_pubkey),
-                    None,
-                );
-                match submit_returning_signature(
-                    &$http,
-                    $cfg.kora_url,
-                    &$cfg.user_id,
-                    &$rpc,
-                    &$kora_pubkey,
-                    &[close_ix],
-                    &[],
-                )
-                .await
-                {
-                    Ok(_) => {
-                        if $state_path.exists() {
-                            if let Err(err) = fs::remove_file(&$state_path) {
-                                log::warn!(
-                                    "Buffer closed successfully, but failed to delete state file: {}. Please manually delete {} to start a fresh deployment.",
-                                    err,
-                                    $state_path.display()
-                                );
-                            }
-                        }
-                    }
-                    Err(e) => {
-                        log::warn!(
-                            "failed to close buffer: {}; keeping state file for manual recovery",
-                            e
-                        );
-                    }
-                }
-            }
-        };
-    }
+    let (program, buffer, program_data, kora_pubkey, mut written_chunks, mut state) =
+        load_or_init_state(&ctx, &bytes, &current_program_hash).await?;
 
-    let mut state = if cfg.resume {
+    validate_state(&ctx, &buffer, &kora_pubkey, &state, &current_program_hash, chunk_count).await?;
+
+    write_chunks(&ctx, &bytes, &buffer, &kora_pubkey, &mut state, &mut written_chunks, chunk_count)
+        .await?;
+
+    finalize_deploy(&ctx, &bytes, &program, &buffer, &program_data, &kora_pubkey).await?;
+
+    Ok(DeployResult {
+        kora_pubkey,
+        program: program.pubkey(),
+        program_data,
+        buffer: buffer.pubkey(),
+    })
+}
+
+/// Loads the existing deployment state if `--resume` is specified, or initializes
+/// a new deployment state and creates the on-chain buffer if starting fresh.
+async fn load_or_init_state(
+    ctx: &DeployCtx<'_, '_>,
+    bytes: &[u8],
+    current_program_hash: &str,
+) -> Result<(Keypair, Keypair, Pubkey, Pubkey, usize, Option<DeployState>)> {
+    let state_path = ctx.cfg.state_path.as_path();
+    let state = if ctx.cfg.resume {
         Some(DeployState::load(state_path)?.ok_or_else(|| {
             anyhow::anyhow!(
                 "--resume was requested, but no state file was found at {}. Cannot resume.",
@@ -139,14 +175,7 @@ pub async fn deploy(cfg: &DeployConfig<'_>) -> Result<DeployResult> {
         None
     };
 
-    let bytes = fs::read(cfg.program_so)
-        .with_context(|| format!("reading {}", cfg.program_so.display()))?;
-    let chunk_count = bytes.len().div_ceil(WRITE_CHUNK_SIZE);
-    let current_program_hash = hash(&bytes).to_string();
-
-    let (program, buffer, program_data, kora_pubkey, mut written_chunks) = if let Some(ref st) =
-        state
-    {
+    if let Some(ref st) = state {
         let program = Keypair::try_from(st.program_keypair.as_slice())
             .context("invalid program keypair in state")?;
         let buffer = Keypair::try_from(st.buffer_keypair.as_slice())
@@ -156,13 +185,14 @@ pub async fn deploy(cfg: &DeployConfig<'_>) -> Result<DeployResult> {
         let kora_pubkey =
             Pubkey::from_str(&st.kora_pubkey).context("invalid kora pubkey in state")?;
         log::info!("resuming deployment from state file, skipping {} chunks", st.written_chunks);
-        (program, buffer, program_data, kora_pubkey, st.written_chunks)
+        Ok((program, buffer, program_data, kora_pubkey, st.written_chunks, state))
     } else {
-        let kora_pubkey = fetch_kora_pubkey(&http, cfg.kora_url).await?;
+        let kora_pubkey = fetch_kora_pubkey(ctx.http, ctx.cfg.kora_url).await?;
         let program = Keypair::new();
         let buffer = Keypair::new();
 
-        let buffer_lamports = rpc
+        let buffer_lamports = ctx
+            .rpc
             .get_minimum_balance_for_rent_exemption(UpgradeableLoaderState::size_of_buffer(
                 bytes.len(),
             ))
@@ -174,8 +204,16 @@ pub async fn deploy(cfg: &DeployConfig<'_>) -> Result<DeployResult> {
             buffer_lamports,
             bytes.len(),
         )?;
-        submit(&http, cfg.kora_url, &cfg.user_id, &rpc, &kora_pubkey, &create_buf, &[&buffer])
-            .await?;
+        submit(
+            ctx.http,
+            ctx.cfg.kora_url,
+            &ctx.cfg.user_id,
+            ctx.rpc,
+            &kora_pubkey,
+            &create_buf,
+            &[&buffer],
+        )
+        .await?;
 
         let program_data = derive_program_data_address(&program.pubkey());
         let new_state = DeployState {
@@ -184,50 +222,52 @@ pub async fn deploy(cfg: &DeployConfig<'_>) -> Result<DeployResult> {
             program_data: program_data.to_string(),
             written_chunks: 0,
             kora_pubkey: kora_pubkey.to_string(),
-            program_hash: current_program_hash.clone(),
+            program_hash: current_program_hash.to_string(),
         };
         if let Err(e) = new_state.save(state_path) {
-            // Force buffer cleanup regardless of cfg.cleanup_on_failure.
-            // Leaving the buffer open serves no purpose here since there is no state file to resume from.
-            log::warn!("failed to save initial state, attempting to close buffer for cleanup...");
-            let close_ix =
-                loader_v3::close_any(&buffer.pubkey(), &kora_pubkey, Some(&kora_pubkey), None);
-            if let Err(cleanup_err) = submit_returning_signature(
-                &http,
-                cfg.kora_url,
-                &cfg.user_id,
-                &rpc,
-                &kora_pubkey,
-                &[close_ix],
-                &[],
-            )
-            .await
-            {
-                log::warn!(
+            cleanup_buffer!(
+                true,
+                "failed to save initial state",
+                |err| log::warn!(
                     "failed to close buffer: {}; please manually close the buffer with pubkey {}",
-                    cleanup_err,
+                    err,
                     buffer.pubkey()
-                );
-            }
+                ),
+                ctx,
+                &buffer,
+                &kora_pubkey
+            );
             return Err(e.context("failed to save initial deploy state"));
         }
-        state = Some(new_state);
 
-        (program, buffer, program_data, kora_pubkey, 0)
-    };
+        Ok((program, buffer, program_data, kora_pubkey, 0, Some(new_state)))
+    }
+}
 
+/// Validates that the loaded deployment state matches the current `.so` file.
+/// Aborts the deployment if a hash mismatch is detected or if the state is corrupted.
+async fn validate_state(
+    ctx: &DeployCtx<'_, '_>,
+    buffer: &Keypair,
+    kora_pubkey: &Pubkey,
+    state: &Option<DeployState>,
+    current_program_hash: &str,
+    chunk_count: usize,
+) -> Result<()> {
     if let Some(ref st) = state {
         if st.program_hash != current_program_hash {
             cleanup_buffer!(
+                false,
                 "hash mismatch detected during resume",
-                cfg,
+                |e| log::warn!(
+                    "failed to close buffer: {}; keeping state file for manual recovery",
+                    e
+                ),
+                ctx,
                 buffer,
-                kora_pubkey,
-                http,
-                rpc,
-                state_path
+                kora_pubkey
             );
-            if cfg.cleanup_on_failure {
+            if ctx.cfg.cleanup_on_failure {
                 anyhow::bail!("The .so file has changed (hash mismatch). Cannot resume. Buffer cleanup was attempted.");
             } else {
                 anyhow::bail!("The .so file has changed (hash mismatch). Cannot resume. Buffer cleanup skipped (--cleanup-on-failure=false).");
@@ -235,40 +275,59 @@ pub async fn deploy(cfg: &DeployConfig<'_>) -> Result<DeployResult> {
         }
         if st.written_chunks > chunk_count {
             cleanup_buffer!(
+                false,
                 "written_chunks exceeds chunk_count (corrupted state or smaller .so file)",
-                cfg,
+                |e| log::warn!(
+                    "failed to close buffer: {}; keeping state file for manual recovery",
+                    e
+                ),
+                ctx,
                 buffer,
-                kora_pubkey,
-                http,
-                rpc,
-                state_path
+                kora_pubkey
             );
-            if cfg.cleanup_on_failure {
+            if ctx.cfg.cleanup_on_failure {
                 anyhow::bail!("State file is corrupted or .so file is smaller: written_chunks ({}) > total chunk count ({}). Cannot resume. Buffer cleanup was attempted.", st.written_chunks, chunk_count);
             } else {
                 anyhow::bail!("State file is corrupted or .so file is smaller: written_chunks ({}) > total chunk count ({}). Cannot resume. Buffer cleanup skipped (--cleanup-on-failure=false).", st.written_chunks, chunk_count);
             }
         }
     }
+    Ok(())
+}
 
-    for (i, chunk) in bytes.chunks(WRITE_CHUNK_SIZE).enumerate().skip(written_chunks) {
+/// Writes the program data chunks to the on-chain buffer, saving state progress
+/// after each successful write to allow resuming in case of failure.
+async fn write_chunks(
+    ctx: &DeployCtx<'_, '_>,
+    bytes: &[u8],
+    buffer: &Keypair,
+    kora_pubkey: &Pubkey,
+    state: &mut Option<DeployState>,
+    written_chunks: &mut usize,
+    chunk_count: usize,
+) -> Result<()> {
+    let state_path = ctx.cfg.state_path.as_path();
+    for (i, chunk) in bytes.chunks(WRITE_CHUNK_SIZE).enumerate().skip(*written_chunks) {
         let offset = (i * WRITE_CHUNK_SIZE) as u32;
-        let ix = loader_v3::write(&buffer.pubkey(), &kora_pubkey, offset, chunk.to_vec());
+        let ix = loader_v3::write(&buffer.pubkey(), kora_pubkey, offset, chunk.to_vec());
 
-        match submit(&http, cfg.kora_url, &cfg.user_id, &rpc, &kora_pubkey, &[ix], &[]).await {
+        match submit(ctx.http, ctx.cfg.kora_url, &ctx.cfg.user_id, ctx.rpc, kora_pubkey, &[ix], &[])
+            .await
+        {
             Ok(_) => {
-                written_chunks += 1;
+                *written_chunks += 1;
                 if let Some(ref mut st) = state {
-                    st.written_chunks = written_chunks;
+                    st.written_chunks = *written_chunks;
                     if let Err(e) = st.save(state_path) {
                         cleanup_buffer!(
+                            false,
                             "failed to save chunk state",
-                            cfg,
+                            |err| {
+                                log::warn!("failed to close buffer: {}; keeping state file for manual recovery", err)
+                            },
+                            ctx,
                             buffer,
-                            kora_pubkey,
-                            http,
-                            rpc,
-                            state_path
+                            kora_pubkey
                         );
                         return Err(e.context("failed to save deploy state after chunk write"));
                     }
@@ -279,35 +338,51 @@ pub async fn deploy(cfg: &DeployConfig<'_>) -> Result<DeployResult> {
             }
             Err(e) => {
                 cleanup_buffer!(
+                    false,
                     "chunk write failed",
-                    cfg,
+                    |err| log::warn!(
+                        "failed to close buffer: {}; keeping state file for manual recovery",
+                        err
+                    ),
+                    ctx,
                     buffer,
-                    kora_pubkey,
-                    http,
-                    rpc,
-                    state_path
+                    kora_pubkey
                 );
                 return Err(e.context("failed to write chunk"));
             }
         }
     }
+    Ok(())
+}
 
-    let program_lamports = rpc
+/// Finalizes the deployment by issuing the deploy transaction to the upgradeable loader,
+/// and safely handles the case where the transaction succeeded but timed out locally.
+async fn finalize_deploy(
+    ctx: &DeployCtx<'_, '_>,
+    bytes: &[u8],
+    program: &Keypair,
+    buffer: &Keypair,
+    program_data: &Pubkey,
+    kora_pubkey: &Pubkey,
+) -> Result<()> {
+    let state_path = ctx.cfg.state_path.as_path();
+    let program_lamports = ctx
+        .rpc
         .get_minimum_balance_for_rent_exemption(UpgradeableLoaderState::size_of_program())
         .await?;
     let mut deploy_ixs = loader_v3::deploy_with_max_program_len(
-        &kora_pubkey,
+        kora_pubkey,
         &program.pubkey(),
         &buffer.pubkey(),
-        &kora_pubkey,
+        kora_pubkey,
         program_lamports,
         bytes.len(),
     )?;
-    let mut deploy_signers: Vec<&Keypair> = vec![&program];
-    if let Some(wallet) = cfg.wallet {
+    let mut deploy_signers: Vec<&Keypair> = vec![program];
+    if let Some(wallet) = ctx.cfg.wallet {
         deploy_ixs.push(register_ix(
             &DEFAULT_REGISTRY_PROGRAM,
-            &kora_pubkey,
+            kora_pubkey,
             &program.pubkey(),
             &wallet.pubkey(),
         ));
@@ -317,8 +392,9 @@ pub async fn deploy(cfg: &DeployConfig<'_>) -> Result<DeployResult> {
     // Check if the program is live (programdata exists) to handle the timeout-but-success scenario.
     // NOTE: the 36-byte program stub survives forever even after reaping; only programdata
     // disappearing means the program is gone, so we must check programdata, not the stub.
-    if rpc
-        .get_account_with_commitment(&program_data, CommitmentConfig::confirmed())
+    if ctx
+        .rpc
+        .get_account_with_commitment(program_data, CommitmentConfig::confirmed())
         .await?
         .value
         .is_some()
@@ -333,11 +409,11 @@ pub async fn deploy(cfg: &DeployConfig<'_>) -> Result<DeployResult> {
         }
     } else {
         match submit(
-            &http,
-            cfg.kora_url,
-            &cfg.user_id,
-            &rpc,
-            &kora_pubkey,
+            ctx.http,
+            ctx.cfg.kora_url,
+            &ctx.cfg.user_id,
+            ctx.rpc,
+            kora_pubkey,
             &deploy_ixs,
             &deploy_signers,
         )
@@ -354,13 +430,15 @@ pub async fn deploy(cfg: &DeployConfig<'_>) -> Result<DeployResult> {
             }
             Err(e) => {
                 cleanup_buffer!(
+                    false,
                     "deploy transaction failed",
-                    cfg,
+                    |err| log::warn!(
+                        "failed to close buffer: {}; keeping state file for manual recovery",
+                        err
+                    ),
+                    ctx,
                     buffer,
-                    kora_pubkey,
-                    http,
-                    rpc,
-                    state_path
+                    kora_pubkey
                 );
                 return Err(anyhow::anyhow!(
                     "Failed to submit deploy transaction for {}: {}. \n\
@@ -372,13 +450,7 @@ pub async fn deploy(cfg: &DeployConfig<'_>) -> Result<DeployResult> {
             }
         }
     }
-
-    Ok(DeployResult {
-        kora_pubkey,
-        program: program.pubkey(),
-        program_data,
-        buffer: buffer.pubkey(),
-    })
+    Ok(())
 }
 
 pub async fn upgrade(cfg: &UpgradeConfig<'_>) -> Result<Signature> {

--- a/crates/kora-deploy/src/lib.rs
+++ b/crates/kora-deploy/src/lib.rs
@@ -270,7 +270,7 @@ async fn validate_state(
             if ctx.cfg.cleanup_on_failure {
                 anyhow::bail!("The .so file has changed (hash mismatch). Cannot resume. Buffer cleanup was attempted.");
             } else {
-                anyhow::bail!("The .so file has changed (hash mismatch). Cannot resume. Buffer cleanup skipped (--cleanup-on-failure=false).");
+                anyhow::bail!("The .so file has changed (hash mismatch). Cannot resume. Buffer cleanup skipped (--no-cleanup-on-failure was set).");
             }
         }
         if st.written_chunks > chunk_count {
@@ -288,7 +288,7 @@ async fn validate_state(
             if ctx.cfg.cleanup_on_failure {
                 anyhow::bail!("State file is corrupted or .so file is smaller: written_chunks ({}) > total chunk count ({}). Cannot resume. Buffer cleanup was attempted.", st.written_chunks, chunk_count);
             } else {
-                anyhow::bail!("State file is corrupted or .so file is smaller: written_chunks ({}) > total chunk count ({}). Cannot resume. Buffer cleanup skipped (--cleanup-on-failure=false).", st.written_chunks, chunk_count);
+                anyhow::bail!("State file is corrupted or .so file is smaller: written_chunks ({}) > total chunk count ({}). Cannot resume. Buffer cleanup skipped (--no-cleanup-on-failure was set).", st.written_chunks, chunk_count);
             }
         }
     }
@@ -392,13 +392,17 @@ async fn finalize_deploy(
     // Check if the program is live (programdata exists) to handle the timeout-but-success scenario.
     // NOTE: the 36-byte program stub survives forever even after reaping; only programdata
     // disappearing means the program is gone, so we must check programdata, not the stub.
-    if ctx
-        .rpc
-        .get_account_with_commitment(program_data, CommitmentConfig::confirmed())
-        .await?
-        .value
-        .is_some()
-    {
+    let is_already_live = if ctx.cfg.resume {
+        ctx.rpc
+            .get_account_with_commitment(program_data, CommitmentConfig::confirmed())
+            .await?
+            .value
+            .is_some()
+    } else {
+        false
+    };
+
+    if is_already_live {
         log::info!("Program {} is already live, skipping deployment.", program.pubkey());
         if let Err(err) = fs::remove_file(state_path) {
             log::warn!(

--- a/crates/kora-deploy/src/lib.rs
+++ b/crates/kora-deploy/src/lib.rs
@@ -187,15 +187,28 @@ pub async fn deploy(cfg: &DeployConfig<'_>) -> Result<DeployResult> {
             program_hash: current_program_hash.clone(),
         };
         if let Err(e) = new_state.save(state_path) {
-            cleanup_buffer!(
-                "failed to save initial state",
-                cfg,
-                buffer,
-                kora_pubkey,
-                http,
-                rpc,
-                state_path
-            );
+            // Force buffer cleanup regardless of cfg.cleanup_on_failure.
+            // Leaving the buffer open serves no purpose here since there is no state file to resume from.
+            log::warn!("failed to save initial state, attempting to close buffer for cleanup...");
+            let close_ix =
+                loader_v3::close_any(&buffer.pubkey(), &kora_pubkey, Some(&kora_pubkey), None);
+            if let Err(cleanup_err) = submit_returning_signature(
+                &http,
+                cfg.kora_url,
+                &cfg.user_id,
+                &rpc,
+                &kora_pubkey,
+                &[close_ix],
+                &[],
+            )
+            .await
+            {
+                log::warn!(
+                    "failed to close buffer: {}; please manually close the buffer with pubkey {}",
+                    cleanup_err,
+                    buffer.pubkey()
+                );
+            }
             return Err(e.context("failed to save initial deploy state"));
         }
         state = Some(new_state);

--- a/crates/kora-deploy/src/lib.rs
+++ b/crates/kora-deploy/src/lib.rs
@@ -311,7 +311,13 @@ pub async fn deploy(cfg: &DeployConfig<'_>) -> Result<DeployResult> {
         .is_some()
     {
         log::info!("Program {} is already live, skipping deployment.", program.pubkey());
-        fs::remove_file(state_path).ok();
+        if let Err(err) = fs::remove_file(state_path) {
+            log::warn!(
+                "Deploy succeeded, but failed to delete state file: {}. Please manually delete {} to start a fresh deployment.",
+                err,
+                state_path.display()
+            );
+        }
     } else {
         match submit(
             &http,
@@ -325,7 +331,13 @@ pub async fn deploy(cfg: &DeployConfig<'_>) -> Result<DeployResult> {
         .await
         {
             Ok(_) => {
-                fs::remove_file(state_path).ok();
+                if let Err(err) = fs::remove_file(state_path) {
+                    log::warn!(
+                        "Deploy succeeded, but failed to delete state file: {}. Please manually delete {} to start a fresh deployment.",
+                        err,
+                        state_path.display()
+                    );
+                }
             }
             Err(e) => {
                 cleanup_buffer!(

--- a/crates/kora-deploy/src/lib.rs
+++ b/crates/kora-deploy/src/lib.rs
@@ -1,6 +1,14 @@
 #![allow(deprecated)]
 
-use std::{path::Path, str::FromStr, sync::Arc, time::Duration};
+pub mod state;
+
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    str::FromStr,
+    sync::Arc,
+    time::Duration,
+};
 
 use anyhow::{anyhow, bail, Context, Result};
 use base64::{engine::general_purpose::STANDARD as B64, Engine as _};
@@ -9,6 +17,7 @@ use solana_client::nonblocking::rpc_client::RpcClient;
 use solana_commitment_config::CommitmentConfig;
 use solana_loader_v3_interface::{instruction as loader_v3, state::UpgradeableLoaderState};
 use solana_sdk::{
+    hash::hash,
     instruction::{AccountMeta, Instruction},
     message::Message,
     pubkey::Pubkey,
@@ -16,6 +25,8 @@ use solana_sdk::{
     signer::Signer,
     transaction::Transaction,
 };
+
+use crate::state::DeployState;
 
 const WRITE_CHUNK_SIZE: usize = 900;
 const BPF_LOADER_UPGRADEABLE: Pubkey =
@@ -37,6 +48,9 @@ pub struct DeployConfig<'a> {
     /// deploy registry, allowing future upgrades signed by it. Without a wallet the program
     /// is immutable through the paymaster.
     pub wallet: Option<&'a Keypair>,
+    pub resume: bool,
+    pub cleanup_on_failure: bool,
+    pub state_path: PathBuf,
 }
 
 pub struct UpgradeConfig<'a> {
@@ -62,32 +76,204 @@ pub async fn deploy(cfg: &DeployConfig<'_>) -> Result<DeployResult> {
         CommitmentConfig::confirmed(),
     ));
 
-    let kora_pubkey = fetch_kora_pubkey(&http, cfg.kora_url).await?;
-    let program = Keypair::new();
-    let buffer = Keypair::new();
-    let bytes = std::fs::read(cfg.program_so)
+    let state_path = cfg.state_path.as_path();
+
+    macro_rules! cleanup_buffer {
+        ($msg:expr, $cfg:expr, $buffer:expr, $kora_pubkey:expr, $http:expr, $rpc:expr, $state_path:expr) => {
+            if $cfg.cleanup_on_failure {
+                log::warn!("{}, attempting to close buffer for cleanup...", $msg);
+                let close_ix = loader_v3::close_any(
+                    &$buffer.pubkey(),
+                    &$kora_pubkey,
+                    Some(&$kora_pubkey),
+                    None,
+                );
+                match submit_returning_signature(
+                    &$http,
+                    $cfg.kora_url,
+                    &$cfg.user_id,
+                    &$rpc,
+                    &$kora_pubkey,
+                    &[close_ix],
+                    &[],
+                )
+                .await
+                {
+                    Ok(_) => {
+                        if let Err(err) = fs::remove_file(&$state_path) {
+                            log::warn!(
+                                "Buffer closed successfully, but failed to delete state file: {}. Please manually delete {} to start a fresh deployment.",
+                                err,
+                                $state_path.display()
+                            );
+                        }
+                    }
+                    Err(e) => {
+                        log::warn!(
+                            "failed to close buffer: {}; keeping state file for manual recovery",
+                            e
+                        );
+                    }
+                }
+            }
+        };
+    }
+
+    let mut state = if cfg.resume {
+        Some(DeployState::load(state_path)?.ok_or_else(|| {
+            anyhow::anyhow!(
+                "--resume was requested, but no state file was found at {}. Cannot resume.",
+                state_path.display()
+            )
+        })?)
+    } else {
+        if state_path.exists() {
+            anyhow::bail!(
+                "State file exists at {}. A previous deploy failed.\n\
+                Run with `--resume` to continue, or delete the file to start over (WARNING: deleting it orphans the on-chain buffer and leaks SOL).",
+                state_path.display()
+            );
+        }
+        None
+    };
+
+    let bytes = fs::read(cfg.program_so)
         .with_context(|| format!("reading {}", cfg.program_so.display()))?;
-    let program_data = derive_program_data_address(&program.pubkey());
-
-    let buffer_lamports = rpc
-        .get_minimum_balance_for_rent_exemption(UpgradeableLoaderState::size_of_buffer(bytes.len()))
-        .await?;
-    let create_buf = loader_v3::create_buffer(
-        &kora_pubkey,
-        &buffer.pubkey(),
-        &kora_pubkey,
-        buffer_lamports,
-        bytes.len(),
-    )?;
-    submit(&http, cfg.kora_url, &cfg.user_id, &rpc, &kora_pubkey, &create_buf, &[&buffer]).await?;
-
     let chunk_count = bytes.len().div_ceil(WRITE_CHUNK_SIZE);
-    for (i, chunk) in bytes.chunks(WRITE_CHUNK_SIZE).enumerate() {
+    let current_program_hash = hash(&bytes).to_string();
+
+    let (program, buffer, program_data, kora_pubkey, mut written_chunks) = if let Some(ref st) =
+        state
+    {
+        let program = Keypair::try_from(st.program_keypair.as_slice())
+            .context("invalid program keypair in state")?;
+        let buffer = Keypair::try_from(st.buffer_keypair.as_slice())
+            .context("invalid buffer keypair in state")?;
+        let program_data =
+            Pubkey::from_str(&st.program_data).context("invalid program data pubkey in state")?;
+        let kora_pubkey =
+            Pubkey::from_str(&st.kora_pubkey).context("invalid kora pubkey in state")?;
+        log::info!("resuming deployment from state file, skipping {} chunks", st.written_chunks);
+        (program, buffer, program_data, kora_pubkey, st.written_chunks)
+    } else {
+        let kora_pubkey = fetch_kora_pubkey(&http, cfg.kora_url).await?;
+        let program = Keypair::new();
+        let buffer = Keypair::new();
+
+        let buffer_lamports = rpc
+            .get_minimum_balance_for_rent_exemption(UpgradeableLoaderState::size_of_buffer(
+                bytes.len(),
+            ))
+            .await?;
+        let create_buf = loader_v3::create_buffer(
+            &kora_pubkey,
+            &buffer.pubkey(),
+            &kora_pubkey,
+            buffer_lamports,
+            bytes.len(),
+        )?;
+        submit(&http, cfg.kora_url, &cfg.user_id, &rpc, &kora_pubkey, &create_buf, &[&buffer])
+            .await?;
+
+        let program_data = derive_program_data_address(&program.pubkey());
+        let new_state = DeployState {
+            program_keypair: program.to_bytes().to_vec(),
+            buffer_keypair: buffer.to_bytes().to_vec(),
+            program_data: program_data.to_string(),
+            written_chunks: 0,
+            kora_pubkey: kora_pubkey.to_string(),
+            program_hash: current_program_hash.clone(),
+        };
+        if let Err(e) = new_state.save(state_path) {
+            cleanup_buffer!(
+                "failed to save initial state",
+                cfg,
+                buffer,
+                kora_pubkey,
+                http,
+                rpc,
+                state_path
+            );
+            return Err(e.context("failed to save initial deploy state"));
+        }
+        state = Some(new_state);
+
+        (program, buffer, program_data, kora_pubkey, 0)
+    };
+
+    if let Some(ref st) = state {
+        if st.program_hash != current_program_hash {
+            cleanup_buffer!(
+                "hash mismatch detected during resume",
+                cfg,
+                buffer,
+                kora_pubkey,
+                http,
+                rpc,
+                state_path
+            );
+            if cfg.cleanup_on_failure {
+                anyhow::bail!("The .so file has changed (hash mismatch). Cannot resume. Buffer cleanup was attempted.");
+            } else {
+                anyhow::bail!("The .so file has changed (hash mismatch). Cannot resume. Buffer cleanup skipped (--cleanup-on-failure=false).");
+            }
+        }
+        if st.written_chunks > chunk_count {
+            cleanup_buffer!(
+                "written_chunks exceeds chunk_count (corrupted state or smaller .so file)",
+                cfg,
+                buffer,
+                kora_pubkey,
+                http,
+                rpc,
+                state_path
+            );
+            if cfg.cleanup_on_failure {
+                anyhow::bail!("State file is corrupted or .so file is smaller: written_chunks ({}) > total chunk count ({}). Cannot resume. Buffer cleanup was attempted.", st.written_chunks, chunk_count);
+            } else {
+                anyhow::bail!("State file is corrupted or .so file is smaller: written_chunks ({}) > total chunk count ({}). Cannot resume. Buffer cleanup skipped (--cleanup-on-failure=false).", st.written_chunks, chunk_count);
+            }
+        }
+    }
+
+    for (i, chunk) in bytes.chunks(WRITE_CHUNK_SIZE).enumerate().skip(written_chunks) {
         let offset = (i * WRITE_CHUNK_SIZE) as u32;
         let ix = loader_v3::write(&buffer.pubkey(), &kora_pubkey, offset, chunk.to_vec());
-        submit(&http, cfg.kora_url, &cfg.user_id, &rpc, &kora_pubkey, &[ix], &[]).await?;
-        if (i + 1) % 25 == 0 || i + 1 == chunk_count {
-            log::info!("wrote chunk {}/{}", i + 1, chunk_count);
+
+        match submit(&http, cfg.kora_url, &cfg.user_id, &rpc, &kora_pubkey, &[ix], &[]).await {
+            Ok(_) => {
+                written_chunks += 1;
+                if let Some(ref mut st) = state {
+                    st.written_chunks = written_chunks;
+                    if let Err(e) = st.save(state_path) {
+                        cleanup_buffer!(
+                            "failed to save chunk state",
+                            cfg,
+                            buffer,
+                            kora_pubkey,
+                            http,
+                            rpc,
+                            state_path
+                        );
+                        return Err(e.context("failed to save deploy state after chunk write"));
+                    }
+                }
+                if (i + 1) % 25 == 0 || i + 1 == chunk_count {
+                    log::info!("wrote chunk {}/{}", i + 1, chunk_count);
+                }
+            }
+            Err(e) => {
+                cleanup_buffer!(
+                    "chunk write failed",
+                    cfg,
+                    buffer,
+                    kora_pubkey,
+                    http,
+                    rpc,
+                    state_path
+                );
+                return Err(e.context("failed to write chunk"));
+            }
         }
     }
 
@@ -112,8 +298,53 @@ pub async fn deploy(cfg: &DeployConfig<'_>) -> Result<DeployResult> {
         ));
         deploy_signers.push(wallet);
     }
-    submit(&http, cfg.kora_url, &cfg.user_id, &rpc, &kora_pubkey, &deploy_ixs, &deploy_signers)
-        .await?;
+
+    // Check if the program is live (programdata exists) to handle the timeout-but-success scenario.
+    // NOTE: the 36-byte program stub survives forever even after reaping; only programdata
+    // disappearing means the program is gone, so we must check programdata, not the stub.
+    if rpc
+        .get_account_with_commitment(&program_data, CommitmentConfig::confirmed())
+        .await?
+        .value
+        .is_some()
+    {
+        log::info!("Program {} is already live, skipping deployment.", program.pubkey());
+        fs::remove_file(state_path).ok();
+    } else {
+        match submit(
+            &http,
+            cfg.kora_url,
+            &cfg.user_id,
+            &rpc,
+            &kora_pubkey,
+            &deploy_ixs,
+            &deploy_signers,
+        )
+        .await
+        {
+            Ok(_) => {
+                fs::remove_file(state_path).ok();
+            }
+            Err(e) => {
+                cleanup_buffer!(
+                    "deploy transaction failed",
+                    cfg,
+                    buffer,
+                    kora_pubkey,
+                    http,
+                    rpc,
+                    state_path
+                );
+                return Err(anyhow::anyhow!(
+                    "Failed to submit deploy transaction for {}: {}. \n\
+                    Verify status: `solana program show {}`",
+                    program.pubkey(),
+                    e,
+                    program.pubkey()
+                ));
+            }
+        }
+    }
 
     Ok(DeployResult {
         kora_pubkey,
@@ -133,7 +364,7 @@ pub async fn upgrade(cfg: &UpgradeConfig<'_>) -> Result<Signature> {
     let kora_pubkey = fetch_kora_pubkey(&http, cfg.kora_url).await?;
     assert_registered_owner(&rpc, &DEFAULT_REGISTRY_PROGRAM, &cfg.program, &cfg.wallet.pubkey())
         .await?;
-    let bytes = std::fs::read(cfg.program_so)
+    let bytes = fs::read(cfg.program_so)
         .with_context(|| format!("reading {}", cfg.program_so.display()))?;
 
     let buffer = Keypair::new();

--- a/crates/kora-deploy/src/lib.rs
+++ b/crates/kora-deploy/src/lib.rs
@@ -100,12 +100,14 @@ pub async fn deploy(cfg: &DeployConfig<'_>) -> Result<DeployResult> {
                 .await
                 {
                     Ok(_) => {
-                        if let Err(err) = fs::remove_file(&$state_path) {
-                            log::warn!(
-                                "Buffer closed successfully, but failed to delete state file: {}. Please manually delete {} to start a fresh deployment.",
-                                err,
-                                $state_path.display()
-                            );
+                        if $state_path.exists() {
+                            if let Err(err) = fs::remove_file(&$state_path) {
+                                log::warn!(
+                                    "Buffer closed successfully, but failed to delete state file: {}. Please manually delete {} to start a fresh deployment.",
+                                    err,
+                                    $state_path.display()
+                                );
+                            }
                         }
                     }
                     Err(e) => {

--- a/crates/kora-deploy/src/lib.rs
+++ b/crates/kora-deploy/src/lib.rs
@@ -244,6 +244,28 @@ async fn load_or_init_state(
     }
 }
 
+enum StateInvariantViolation {
+    HashMismatch,
+    ChunkOverflow { written: usize, total: usize },
+}
+
+fn check_state_invariants(
+    state: &DeployState,
+    current_program_hash: &str,
+    chunk_count: usize,
+) -> Option<StateInvariantViolation> {
+    if state.program_hash != current_program_hash {
+        return Some(StateInvariantViolation::HashMismatch);
+    }
+    if state.written_chunks > chunk_count {
+        return Some(StateInvariantViolation::ChunkOverflow {
+            written: state.written_chunks,
+            total: chunk_count,
+        });
+    }
+    None
+}
+
 /// Validates that the loaded deployment state matches the current `.so` file.
 /// Aborts the deployment if a hash mismatch is detected or if the state is corrupted.
 async fn validate_state(
@@ -255,41 +277,44 @@ async fn validate_state(
     chunk_count: usize,
 ) -> Result<()> {
     if let Some(ref st) = state {
-        if st.program_hash != current_program_hash {
-            cleanup_buffer!(
-                false,
-                "hash mismatch detected during resume",
-                |e| log::warn!(
-                    "failed to close buffer: {}; keeping state file for manual recovery",
-                    e
-                ),
-                ctx,
-                buffer,
-                kora_pubkey
-            );
-            if ctx.cfg.cleanup_on_failure {
-                anyhow::bail!("The .so file has changed (hash mismatch). Cannot resume. Buffer cleanup was attempted.");
-            } else {
-                anyhow::bail!("The .so file has changed (hash mismatch). Cannot resume. Buffer cleanup skipped (--no-cleanup-on-failure was set).");
+        match check_state_invariants(st, current_program_hash, chunk_count) {
+            Some(StateInvariantViolation::HashMismatch) => {
+                cleanup_buffer!(
+                    false,
+                    "hash mismatch detected during resume",
+                    |e| log::warn!(
+                        "failed to close buffer: {}; keeping state file for manual recovery",
+                        e
+                    ),
+                    ctx,
+                    buffer,
+                    kora_pubkey
+                );
+                if ctx.cfg.cleanup_on_failure {
+                    anyhow::bail!("The .so file has changed (hash mismatch). Cannot resume. Buffer cleanup was attempted.");
+                } else {
+                    anyhow::bail!("The .so file has changed (hash mismatch). Cannot resume. Buffer cleanup skipped (--no-cleanup-on-failure was set).");
+                }
             }
-        }
-        if st.written_chunks > chunk_count {
-            cleanup_buffer!(
-                false,
-                "written_chunks exceeds chunk_count (corrupted state or smaller .so file)",
-                |e| log::warn!(
-                    "failed to close buffer: {}; keeping state file for manual recovery",
-                    e
-                ),
-                ctx,
-                buffer,
-                kora_pubkey
-            );
-            if ctx.cfg.cleanup_on_failure {
-                anyhow::bail!("State file is corrupted or .so file is smaller: written_chunks ({}) > total chunk count ({}). Cannot resume. Buffer cleanup was attempted.", st.written_chunks, chunk_count);
-            } else {
-                anyhow::bail!("State file is corrupted or .so file is smaller: written_chunks ({}) > total chunk count ({}). Cannot resume. Buffer cleanup skipped (--no-cleanup-on-failure was set).", st.written_chunks, chunk_count);
+            Some(StateInvariantViolation::ChunkOverflow { written, total }) => {
+                cleanup_buffer!(
+                    false,
+                    "written_chunks exceeds chunk_count (corrupted state or smaller .so file)",
+                    |e| log::warn!(
+                        "failed to close buffer: {}; keeping state file for manual recovery",
+                        e
+                    ),
+                    ctx,
+                    buffer,
+                    kora_pubkey
+                );
+                if ctx.cfg.cleanup_on_failure {
+                    anyhow::bail!("State file is corrupted or .so file is smaller: written_chunks ({}) > total chunk count ({}). Cannot resume. Buffer cleanup was attempted.", written, total);
+                } else {
+                    anyhow::bail!("State file is corrupted or .so file is smaller: written_chunks ({}) > total chunk count ({}). Cannot resume. Buffer cleanup skipped (--no-cleanup-on-failure was set).", written, total);
+                }
             }
+            None => {}
         }
     }
     Ok(())
@@ -744,4 +769,59 @@ async fn wait_for_next_slot(rpc: &RpcClient) -> Result<()> {
         tokio::time::sleep(Duration::from_millis(200)).await;
     }
     bail!("slot never advanced past {start}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::state::DeployState;
+
+    fn make_state(program_hash: &str, written_chunks: usize) -> DeployState {
+        DeployState {
+            program_keypair: vec![0u8; 64],
+            buffer_keypair: vec![0u8; 64],
+            program_data: "11111111111111111111111111111111".to_string(),
+            written_chunks,
+            kora_pubkey: "11111111111111111111111111111111".to_string(),
+            program_hash: program_hash.to_string(),
+        }
+    }
+
+    #[test]
+    fn check_state_invariants_passes_when_valid() {
+        let st = make_state("abc123", 5);
+        assert!(check_state_invariants(&st, "abc123", 10).is_none());
+    }
+
+    #[test]
+    fn check_state_invariants_passes_at_exact_chunk_count() {
+        // written_chunks == chunk_count is valid (all chunks written, ready to finalize)
+        let st = make_state("abc123", 10);
+        assert!(check_state_invariants(&st, "abc123", 10).is_none());
+    }
+
+    #[test]
+    fn check_state_invariants_detects_hash_mismatch() {
+        let st = make_state("old_hash", 5);
+        let violation = check_state_invariants(&st, "new_hash", 10);
+        assert!(matches!(violation, Some(StateInvariantViolation::HashMismatch)));
+    }
+
+    #[test]
+    fn check_state_invariants_hash_mismatch_takes_priority() {
+        // Both conditions true — hash mismatch is checked first.
+        let st = make_state("old_hash", 99);
+        let violation = check_state_invariants(&st, "new_hash", 5);
+        assert!(matches!(violation, Some(StateInvariantViolation::HashMismatch)));
+    }
+
+    #[test]
+    fn check_state_invariants_detects_chunk_overflow() {
+        let st = make_state("abc123", 11);
+        let violation = check_state_invariants(&st, "abc123", 10);
+        assert!(matches!(
+            violation,
+            Some(StateInvariantViolation::ChunkOverflow { written: 11, total: 10 })
+        ));
+    }
 }

--- a/crates/kora-deploy/src/lib.rs
+++ b/crates/kora-deploy/src/lib.rs
@@ -482,6 +482,7 @@ async fn finalize_deploy(
     Ok(())
 }
 
+// TODO: upgrade() has no state persistence, resume support, or buffer cleanup on failure.
 pub async fn upgrade(cfg: &UpgradeConfig<'_>) -> Result<Signature> {
     let http = reqwest::Client::builder().timeout(Duration::from_secs(60)).build()?;
     let rpc = Arc::new(RpcClient::new_with_commitment(

--- a/crates/kora-deploy/src/main.rs
+++ b/crates/kora-deploy/src/main.rs
@@ -1,4 +1,7 @@
-use std::path::{Path, PathBuf};
+use std::{
+    env,
+    path::{Path, PathBuf},
+};
 
 use anyhow::{anyhow, bail, Context, Result};
 use clap::Parser;
@@ -36,6 +39,15 @@ struct Args {
     /// Existing program to upgrade. Omit to deploy a fresh program.
     #[arg(long)]
     program_id: Option<Pubkey>,
+    #[arg(long, help = "Resume a previous deployment from the local state file")]
+    resume: bool,
+    #[arg(
+        long,
+        default_value_t = true,
+        action = clap::ArgAction::Set,
+        help = "Close the buffer back to the fee payer on failure. Defaults to true. Usually skipped if --resume is intended."
+    )]
+    cleanup_on_failure: bool,
 }
 
 #[tokio::main]
@@ -49,6 +61,12 @@ async fn main() -> Result<()> {
 
     match args.program_id {
         Some(program) => {
+            if args.resume {
+                bail!("--resume is currently only supported for fresh deployments, not upgrades.");
+            }
+            if !args.cleanup_on_failure {
+                log::warn!("--cleanup-on-failure=false is not supported during program upgrades and will be ignored.");
+            }
             if !program_is_live(&args.rpc_url, &program).await? {
                 bail!(
                     "program {program} is not live on-chain (never deployed or reaped); \
@@ -69,12 +87,16 @@ async fn run_deploy(args: &Args, wallet: Option<&Keypair>, user_id: String) -> R
         }
     }
 
+    let state_path = env::current_dir()?.join(".kora-deploy-state.json");
     let result = deploy(&DeployConfig {
         kora_url: &args.kora_url,
         rpc_url: &args.rpc_url,
         program_so: &args.program_so,
         user_id,
         wallet,
+        resume: args.resume,
+        cleanup_on_failure: args.cleanup_on_failure,
+        state_path,
     })
     .await?;
 

--- a/crates/kora-deploy/src/main.rs
+++ b/crates/kora-deploy/src/main.rs
@@ -1,4 +1,7 @@
-use std::path::{Path, PathBuf};
+use std::{
+    env,
+    path::{Path, PathBuf},
+};
 
 use anyhow::{anyhow, bail, Context, Result};
 use clap::Parser;
@@ -36,6 +39,20 @@ struct Args {
     /// Existing program to upgrade. Omit to deploy a fresh program.
     #[arg(long)]
     program_id: Option<Pubkey>,
+    #[arg(long, help = "Resume a previous deployment from the local state file")]
+    resume: bool,
+    #[arg(
+        long,
+        overrides_with = "no_cleanup_on_failure",
+        help = "Close the buffer on failure (default). Pass --no-cleanup-on-failure to skip this."
+    )]
+    cleanup_on_failure: bool,
+    #[arg(
+        long,
+        overrides_with = "cleanup_on_failure",
+        help = "Do not close the buffer on failure, leaving it for --resume"
+    )]
+    no_cleanup_on_failure: bool,
 }
 
 #[tokio::main]
@@ -49,6 +66,12 @@ async fn main() -> Result<()> {
 
     match args.program_id {
         Some(program) => {
+            if args.resume {
+                bail!("--resume is currently only supported for fresh deployments, not upgrades.");
+            }
+            if args.no_cleanup_on_failure {
+                log::warn!("--no-cleanup-on-failure is not supported during program upgrades and will be ignored.");
+            }
             if !program_is_live(&args.rpc_url, &program).await? {
                 bail!(
                     "program {program} is not live on-chain (never deployed or reaped); \
@@ -69,12 +92,16 @@ async fn run_deploy(args: &Args, wallet: Option<&Keypair>, user_id: String) -> R
         }
     }
 
+    let state_path = env::current_dir()?.join(".kora-deploy-state.json");
     let result = deploy(&DeployConfig {
         kora_url: &args.kora_url,
         rpc_url: &args.rpc_url,
         program_so: &args.program_so,
         user_id,
         wallet,
+        resume: args.resume,
+        cleanup_on_failure: !args.no_cleanup_on_failure,
+        state_path,
     })
     .await?;
 

--- a/crates/kora-deploy/src/main.rs
+++ b/crates/kora-deploy/src/main.rs
@@ -43,6 +43,7 @@ struct Args {
     resume: bool,
     #[arg(
         long,
+        hide = true,
         overrides_with = "no_cleanup_on_failure",
         help = "Close the buffer on failure (default). Pass --no-cleanup-on-failure to skip this."
     )]

--- a/crates/kora-deploy/src/state.rs
+++ b/crates/kora-deploy/src/state.rs
@@ -1,0 +1,101 @@
+use std::{fs, path::Path};
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct DeployState {
+    pub program_keypair: Vec<u8>,
+    pub buffer_keypair: Vec<u8>,
+    pub program_data: String,
+    pub written_chunks: usize,
+    pub kora_pubkey: String,
+    pub program_hash: String,
+}
+
+impl DeployState {
+    pub fn load(path: &Path) -> Result<Option<Self>> {
+        if !path.exists() {
+            return Ok(None);
+        }
+        let data = fs::read_to_string(path)
+            .with_context(|| format!("failed to read deploy state from {}", path.display()))?;
+        let state = serde_json::from_str(&data)
+            .with_context(|| format!("failed to parse deploy state from {}", path.display()))?;
+        Ok(Some(state))
+    }
+
+    pub fn save(&self, path: &Path) -> Result<()> {
+        let data =
+            serde_json::to_string_pretty(self).context("failed to serialize deploy state")?;
+
+        let temp_path = path.with_extension("tmp");
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            let mut options = fs::OpenOptions::new();
+            options.write(true).create(true).truncate(true).mode(0o600);
+            let mut file = options.open(&temp_path).with_context(|| {
+                format!("failed to open temp deploy state for writing: {}", temp_path.display())
+            })?;
+            use std::io::Write;
+            file.write_all(data.as_bytes()).with_context(|| {
+                format!("failed to write temp deploy state to {}", temp_path.display())
+            })?;
+            file.sync_data().context("failed to sync temp deploy state to disk")?;
+        }
+        #[cfg(not(unix))]
+        {
+            let mut file = fs::File::create(&temp_path).with_context(|| {
+                format!("failed to create temp deploy state: {}", temp_path.display())
+            })?;
+            use std::io::Write;
+            file.write_all(data.as_bytes()).with_context(|| {
+                format!("failed to write temp deploy state to {}", temp_path.display())
+            })?;
+            file.sync_data().context("failed to sync temp deploy state to disk")?;
+        }
+
+        fs::rename(&temp_path, path).with_context(|| {
+            format!("failed to rename {} to {}", temp_path.display(), path.display())
+        })?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::{env::temp_dir, process};
+
+    #[test]
+    fn test_deploy_state_save_and_load() -> Result<()> {
+        let state = DeployState {
+            program_keypair: vec![1, 2, 3],
+            buffer_keypair: vec![4, 5, 6],
+            program_data: "Base58ProgramData11111111111111111111111111".to_string(),
+            written_chunks: 42,
+            kora_pubkey: "Base58KoraPubkey111111111111111111111111111".to_string(),
+            program_hash: "dummyhash123".to_string(),
+        };
+
+        let temp_file = temp_dir().join(format!("kora-deploy-state-test-{}.json", process::id()));
+
+        let _ = fs::remove_file(&temp_file);
+        assert!(DeployState::load(&temp_file)?.is_none());
+
+        state.save(&temp_file)?;
+
+        let tmp_file = temp_file.with_extension("tmp");
+        assert!(!tmp_file.exists(), "temporary file should be cleaned up after atomic rename");
+
+        let loaded = DeployState::load(&temp_file)?.expect("state should exist");
+        assert_eq!(state, loaded);
+
+        fs::remove_file(&temp_file)?;
+
+        Ok(())
+    }
+}

--- a/crates/kora-deploy/src/state.rs
+++ b/crates/kora-deploy/src/state.rs
@@ -3,7 +3,7 @@ use std::{fs, path::Path};
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Serialize, Deserialize)]
 pub struct DeployState {
     pub program_keypair: Vec<u8>,
     pub buffer_keypair: Vec<u8>,
@@ -92,7 +92,7 @@ mod tests {
         assert!(!tmp_file.exists(), "temporary file should be cleaned up after atomic rename");
 
         let loaded = DeployState::load(&temp_file)?.expect("state should exist");
-        assert_eq!(state, loaded);
+        assert!(state == loaded);
 
         fs::remove_file(&temp_file)?;
 

--- a/crates/kora-deploy/src/state.rs
+++ b/crates/kora-deploy/src/state.rs
@@ -1,4 +1,4 @@
-use std::{fs, path::Path};
+use std::{fs, io::Write, path::Path};
 
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
@@ -39,7 +39,6 @@ impl DeployState {
             let mut file = options.open(&temp_path).with_context(|| {
                 format!("failed to open temp deploy state for writing: {}", temp_path.display())
             })?;
-            use std::io::Write;
             file.write_all(data.as_bytes()).with_context(|| {
                 format!("failed to write temp deploy state to {}", temp_path.display())
             })?;
@@ -47,10 +46,18 @@ impl DeployState {
         }
         #[cfg(not(unix))]
         {
-            let mut file = fs::File::create(&temp_path).with_context(|| {
-                format!("failed to create temp deploy state: {}", temp_path.display())
-            })?;
-            use std::io::Write;
+            // share_mode(0) limits concurrent access, but does not enforce
+            // file-level ACL restrictions (unlike Unix 0o600).
+            use std::os::windows::fs::OpenOptionsExt;
+            let mut file = fs::OpenOptions::new()
+                .write(true)
+                .create(true)
+                .truncate(true)
+                .share_mode(0)
+                .open(&temp_path)
+                .with_context(|| {
+                    format!("failed to create temp deploy state: {}", temp_path.display())
+                })?;
             file.write_all(data.as_bytes()).with_context(|| {
                 format!("failed to write temp deploy state to {}", temp_path.display())
             })?;

--- a/crates/kora-deploy/src/state.rs
+++ b/crates/kora-deploy/src/state.rs
@@ -1,3 +1,7 @@
+#[cfg(unix)]
+use std::os::unix::fs::OpenOptionsExt;
+#[cfg(not(unix))]
+use std::os::windows::fs::OpenOptionsExt;
 use std::{fs, io::Write, path::Path};
 
 use anyhow::{Context, Result};
@@ -33,7 +37,6 @@ impl DeployState {
 
         #[cfg(unix)]
         {
-            use std::os::unix::fs::OpenOptionsExt;
             let mut options = fs::OpenOptions::new();
             options.write(true).create(true).truncate(true).mode(0o600);
             let mut file = options.open(&temp_path).with_context(|| {
@@ -48,7 +51,6 @@ impl DeployState {
         {
             // share_mode(0) limits concurrent access, but does not enforce
             // file-level ACL restrictions (unlike Unix 0o600).
-            use std::os::windows::fs::OpenOptionsExt;
             let mut file = fs::OpenOptions::new()
                 .write(true)
                 .create(true)

--- a/crates/kora-deploy/src/state.rs
+++ b/crates/kora-deploy/src/state.rs
@@ -7,6 +7,7 @@ use std::{fs, io::Write, path::Path};
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 
+// NOTE: keypairs are raw bytes in JSON; file security relies on OS-level permissions (see save()).
 #[derive(Clone, PartialEq, Serialize, Deserialize)]
 pub struct DeployState {
     pub program_keypair: Vec<u8>,
@@ -77,7 +78,8 @@ impl DeployState {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::{env::temp_dir, process};
+    use solana_sdk::pubkey::Pubkey;
+    use std::env::temp_dir;
 
     #[test]
     fn test_deploy_state_save_and_load() -> Result<()> {
@@ -90,7 +92,8 @@ mod tests {
             program_hash: "dummyhash123".to_string(),
         };
 
-        let temp_file = temp_dir().join(format!("kora-deploy-state-test-{}.json", process::id()));
+        let temp_file =
+            temp_dir().join(format!("kora-deploy-state-test-{}.json", Pubkey::new_unique()));
 
         let _ = fs::remove_file(&temp_file);
         assert!(DeployState::load(&temp_file)?.is_none());

--- a/examples/devnet-deploy-paymaster/src/suite/happy.rs
+++ b/examples/devnet-deploy-paymaster/src/suite/happy.rs
@@ -1,4 +1,4 @@
-use std::path::Path;
+use std::{env, path::Path};
 
 use anyhow::Result;
 use kora_deploy::{close, deploy, upgrade, verify_upgrade_authority, DeployConfig, UpgradeConfig};
@@ -14,6 +14,10 @@ pub async fn run(kora_url: &str, rpc_url: &str, program_so: &Path) -> Result<()>
         program_so,
         user_id: user_id.clone(),
         wallet: Some(&owner),
+        resume: false,
+        cleanup_on_failure: true,
+        state_path: env::temp_dir()
+            .join(format!(".kora-deploy-state-{}.json", Pubkey::new_unique())),
     })
     .await?;
     println!("  deployed program {} (owner {})", result.program, owner.pubkey());


### PR DESCRIPTION
Adds resume capability and automatic buffer cleanup to kora-deploy, persisting local state so deployments can recover from transient failures instead of leaving orphaned on-chain buffers.

- Resume interrupted deployments with `--resume`, guarded by SHA-256 hash verification and chunk bounds checking
- Buffers are closed automatically on failure by default; pass `--no-cleanup-on-failure` to leave the buffer open for a later `--resume`
- Detect already-succeeded deploys after a timeout by checking ProgramData before resubmitting, skipping this check entirely on fresh (non-resume) deploys
- Force buffer cleanup when the initial state save fails, since the buffer can't be recovered any other way in that case
- Refactor deploy() into smaller functions with a shared, parametrized cleanup_buffer! macro
- Add `.kora-deploy-state.json` to `.gitignore` since it contains raw keypair bytes
- Add `share_mode(0)` on the non-Unix save path as a partial mitigation (concurrency guard only, not an ACL restriction full Windows permission support is out of scope here)
- Add unit tests for the state-invariant checks (hash mismatch, chunk-count overflow) via a standalone `check_state_invariants()` helper
- Document the resume/recovery flow and new flags in the README