### PR TITLE
feat(validation): gate confidential Token-2022 rejection behind a config flag

### DIFF
--- a/crates/lib/src/config.rs
+++ b/crates/lib/src/config.rs
@@ -425,6 +425,8 @@ pub struct Token2022Config {
     pub blocked_account_extensions: Vec<String>,
     #[serde(default)]
     pub transfer_hook_policy: TransferHookPolicy,
+    #[serde(default)]
+    pub allow_confidential_transfers: bool,
     #[serde(skip)]
     parsed_blocked_mint_extensions: Option<Vec<ExtensionType>>,
     #[serde(skip)]

--- a/crates/lib/src/rpc_server/openapi/spec/combined_api.json
+++ b/crates/lib/src/rpc_server/openapi/spec/combined_api.json
@@ -2154,6 +2154,10 @@
       "Token2022Config": {
         "type": "object",
         "properties": {
+          "allow_confidential_transfers": {
+            "type": "boolean",
+            "default": false
+          },
           "blocked_account_extensions": {
             "type": "array",
             "items": {

--- a/crates/lib/src/transaction/instruction_util.rs
+++ b/crates/lib/src/transaction/instruction_util.rs
@@ -3578,10 +3578,20 @@ impl IxUtils {
                         spl_token_2022_interface::instruction::TokenInstruction::ConfidentialTransferExtension
                         | spl_token_2022_interface::instruction::TokenInstruction::ConfidentialTransferFeeExtension
                         | spl_token_2022_interface::instruction::TokenInstruction::ConfidentialMintBurnExtension => {
-                            return Err(KoraError::InvalidTransaction(
-                                "Confidential Token-2022 instructions are not supported"
-                                    .to_string(),
-                            ));
+                            let allowed = crate::state::get_config()
+                                .map(|c| c.validation.token_2022.allow_confidential_transfers)
+                                .unwrap_or(false);
+                            if allowed {
+                                Self::push_unhandled_token2022_extension(
+                                    &mut parsed_instructions,
+                                    instruction,
+                                );
+                            } else {
+                                return Err(KoraError::InvalidTransaction(
+                                    "Confidential Token-2022 instructions are not supported"
+                                        .to_string(),
+                                ));
+                            }
                         }
                         _ => {
                             Self::push_unhandled_token2022_extension(

--- a/crates/lib/src/transaction/token2022_security.rs
+++ b/crates/lib/src/transaction/token2022_security.rs
@@ -156,7 +156,10 @@ impl Token2022SecurityParser {
                 | TokenInstruction::MemoTransferExtension
                 | TokenInstruction::CpiGuardExtension
                 | TokenInstruction::InitializeNonTransferableMint
-                | TokenInstruction::WithdrawExcessLamports => {
+                | TokenInstruction::WithdrawExcessLamports
+                | TokenInstruction::ConfidentialTransferExtension
+                | TokenInstruction::ConfidentialTransferFeeExtension
+                | TokenInstruction::ConfidentialMintBurnExtension => {
                     parsed.push(Self::unsupported_fee_payer_account_check(
                         instruction,
                         "unsupported Token-2022 extension instruction",

--- a/sdks/ts/src/types/index.ts
+++ b/sdks/ts/src/types/index.ts
@@ -294,6 +294,8 @@ export interface ValidationConfig {
  * Blocked extensions for Token2022.
  */
 export interface Token2022Config {
+    /** Allow confidential Token-2022 transfer instructions instead of rejecting them */
+    allow_confidential_transfers?: boolean;
     /** List of blocked account extensions */
     blocked_account_extensions: string[];
     /** List of blocked mint extensions */


### PR DESCRIPTION
Confidential Token-2022 instructions (ConfidentialTransfer, ConfidentialTransferFee, ConfidentialMintBurn) are rejected unconditionally during instruction parsing. Add validation.token2022.allow_confidential_transfers (default false, preserving current behavior); when enabled, they are parsed as unhandled extensions like other Token-2022 extensions instead of erroring.