### PR TITLE
fix: security hardening for transaction validation and fee-payer accounting

### DIFF
--- a/crates/lib/src/config.rs
+++ b/crates/lib/src/config.rs
@@ -261,8 +261,8 @@ pub struct SystemInstructionPolicy {
     pub allow_transfer: bool,
     /// Allow fee payer to be the authority in System Assign/AssignWithSeed instructions
     pub allow_assign: bool,
-    /// Allow fee payer to be the funder, or the account being created, in System
-    /// CreateAccount/CreateAccountWithSeed/CreateAccountAllowPrefund instructions
+    /// Allow fee payer to be the funder, the seeded base signer, or the account being created, in
+    /// System CreateAccount/CreateAccountWithSeed/CreateAccountAllowPrefund instructions
     pub allow_create_account: bool,
     /// Allow fee payer to be the account in System Allocate/AllocateWithSeed instructions
     pub allow_allocate: bool,

--- a/crates/lib/src/constant.rs
+++ b/crates/lib/src/constant.rs
@@ -163,6 +163,8 @@ pub mod instruction_indexes {
 
     pub mod spl_token_close_account {
         pub const REQUIRED_NUMBER_OF_ACCOUNTS: usize = 3;
+        pub const ACCOUNT_INDEX: usize = 0;
+        pub const DESTINATION_INDEX: usize = 1;
         pub const OWNER_INDEX: usize = 2;
     }
 

--- a/crates/lib/src/fee/fee.rs
+++ b/crates/lib/src/fee/fee.rs
@@ -15,9 +15,10 @@ use crate::{
         token::{AtaCreationInstructionInfo, TokenType, TokenUtil, TransferHookValidationFlow},
     },
     transaction::{
-        ParsedALTInstructionData, ParsedALTInstructionType, ParsedSPLInstructionData,
-        ParsedSPLInstructionType, ParsedSystemInstructionData, ParsedSystemInstructionType,
-        VersionedTransactionOps, VersionedTransactionResolved,
+        ParsedALTInstructionData, ParsedALTInstructionType,
+        ParsedBpfLoaderUpgradeableInstructionData, ParsedBpfLoaderUpgradeableInstructionType,
+        ParsedSPLInstructionData, ParsedSPLInstructionType, ParsedSystemInstructionData,
+        ParsedSystemInstructionType, VersionedTransactionOps, VersionedTransactionResolved,
     },
 };
 use solana_sdk::instruction::Instruction;
@@ -626,6 +627,52 @@ impl FeeConfigUtil {
                     })?;
                 }
             }
+        }
+
+        // Loader-v3 ExtendProgram/ExtendProgramChecked grow a ProgramData account and top up its
+        // rent from the payer. When the fee payer funds the extension, count that rent so a large
+        // extension cannot bypass max_allowed_lamports.
+        let mut fee_payer_extension_byte_sizes: Vec<u32> = Vec::new();
+        {
+            let bpf_v3_instructions =
+                transaction.get_or_parse_bpf_loader_upgradeable_instructions()?;
+            for instruction in [
+                ParsedBpfLoaderUpgradeableInstructionType::ExtendProgram,
+                ParsedBpfLoaderUpgradeableInstructionType::ExtendProgramChecked,
+            ]
+            .iter()
+            .flat_map(|ty| bpf_v3_instructions.get(ty).map(Vec::as_slice).unwrap_or(&[]))
+            {
+                let (payer, additional_bytes) = match instruction {
+                    ParsedBpfLoaderUpgradeableInstructionData::ExtendProgram {
+                        payer,
+                        additional_bytes,
+                        ..
+                    }
+                    | ParsedBpfLoaderUpgradeableInstructionData::ExtendProgramChecked {
+                        payer,
+                        additional_bytes,
+                        ..
+                    } => (payer, *additional_bytes),
+                    _ => continue,
+                };
+
+                if *payer == Some(*fee_payer_pubkey) {
+                    fee_payer_extension_byte_sizes.push(additional_bytes);
+                }
+            }
+        }
+
+        // Conservatively charge the rent-exempt minimum for the added bytes per extension
+        // (matching the ATA-creation accounting below).
+        for additional_bytes in fee_payer_extension_byte_sizes {
+            let extension_rent = rpc_client
+                .get_minimum_balance_for_rent_exemption(additional_bytes as usize)
+                .await?;
+            total = total.checked_add(extension_rent as i128).ok_or_else(|| {
+                log::error!("Outflow calculation overflow in ExtendProgram rent");
+                KoraError::ValidationError("Outflow calculation overflow".to_string())
+            })?;
         }
 
         // ATA Create/CreateIdempotent can be no-ops during simulation depending on prestate.
@@ -1268,6 +1315,79 @@ mod tests {
         .await
         .unwrap();
         assert_eq!(outflow, 0, "CreateAccount funded by other account should not affect outflow");
+    }
+
+    #[tokio::test]
+    async fn test_calculate_fee_payer_outflow_extend_program() {
+        let _m = ConfigMockBuilder::new().build_and_setup();
+        let fee_payer = Pubkey::new_unique();
+        let program = Pubkey::new_unique();
+        let rent = 1_000_000u64;
+
+        let mocked_rpc_client = RpcMockBuilder::new()
+            .with_custom_mock(
+                solana_client::rpc_request::RpcRequest::GetMinimumBalanceForRentExemption,
+                serde_json::json!(rent),
+            )
+            .build();
+        let config = get_config().unwrap();
+
+        // Fee payer funds the extension: the extension rent counts toward outflow.
+        let ix = solana_loader_v3_interface::instruction::extend_program(
+            &program,
+            Some(&fee_payer),
+            4096,
+        );
+        let message = VersionedMessage::Legacy(Message::new(&[ix], Some(&fee_payer)));
+        let mut resolved =
+            TransactionUtil::new_unsigned_versioned_transaction_resolved(message).unwrap();
+        let outflow = FeeConfigUtil::calculate_fee_payer_outflow(
+            &fee_payer,
+            &mut resolved,
+            &mocked_rpc_client,
+            &config,
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            outflow, rent as i128,
+            "fee-payer-funded ExtendProgram rent should count as outflow"
+        );
+
+        // A different payer funds the extension: no outflow for the fee payer.
+        let other_payer = Pubkey::new_unique();
+        let ix = solana_loader_v3_interface::instruction::extend_program(
+            &program,
+            Some(&other_payer),
+            4096,
+        );
+        let message = VersionedMessage::Legacy(Message::new(&[ix], Some(&fee_payer)));
+        let mut resolved =
+            TransactionUtil::new_unsigned_versioned_transaction_resolved(message).unwrap();
+        let outflow = FeeConfigUtil::calculate_fee_payer_outflow(
+            &fee_payer,
+            &mut resolved,
+            &mocked_rpc_client,
+            &config,
+        )
+        .await
+        .unwrap();
+        assert_eq!(outflow, 0, "extension funded by another payer should not affect outflow");
+
+        // No payer funds the extension: nothing counts toward the fee payer's outflow.
+        let ix = solana_loader_v3_interface::instruction::extend_program(&program, None, 4096);
+        let message = VersionedMessage::Legacy(Message::new(&[ix], Some(&fee_payer)));
+        let mut resolved =
+            TransactionUtil::new_unsigned_versioned_transaction_resolved(message).unwrap();
+        let outflow = FeeConfigUtil::calculate_fee_payer_outflow(
+            &fee_payer,
+            &mut resolved,
+            &mocked_rpc_client,
+            &config,
+        )
+        .await
+        .unwrap();
+        assert_eq!(outflow, 0, "extension with no payer should not affect outflow");
     }
 
     #[tokio::test]

--- a/crates/lib/src/fee/fee.rs
+++ b/crates/lib/src/fee/fee.rs
@@ -664,6 +664,45 @@ impl FeeConfigUtil {
             })?;
         }
 
+        // A fee-payer-authorized close to a third party moves the closed account's rent out.
+        let close_accounts = spl_instructions
+            .get(&ParsedSPLInstructionType::SplTokenCloseAccount)
+            .unwrap_or(&empty_vec);
+        for instruction in close_accounts {
+            if let ParsedSPLInstructionData::SplTokenCloseAccount {
+                owner,
+                account,
+                destination,
+                ..
+            } = instruction
+            {
+                let is_fee_payer_authority = *owner == *fee_payer_pubkey;
+                let is_fee_payer_recipient = *destination == *fee_payer_pubkey;
+
+                if !is_fee_payer_authority && !is_fee_payer_recipient {
+                    continue;
+                }
+
+                if is_fee_payer_authority && is_fee_payer_recipient {
+                    continue;
+                }
+
+                let lamports = rpc_client.get_account(account).await?.lamports;
+
+                if is_fee_payer_recipient {
+                    total = total.checked_sub(lamports as i128).ok_or_else(|| {
+                        log::error!("Inflow calculation overflow in SplTokenCloseAccount");
+                        KoraError::ValidationError("Inflow calculation overflow".to_string())
+                    })?;
+                } else {
+                    total = total.checked_add(lamports as i128).ok_or_else(|| {
+                        log::error!("Outflow calculation overflow in SplTokenCloseAccount");
+                        KoraError::ValidationError("Outflow calculation overflow".to_string())
+                    })?;
+                }
+            }
+        }
+
         Ok(total)
     }
 }
@@ -1439,6 +1478,118 @@ mod tests {
         assert_eq!(
             outflow, -2_000_000,
             "ALT close into the fee payer from an unrelated authority should be treated as inflow"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_calculate_fee_payer_outflow_close_account() {
+        let _m = ConfigMockBuilder::new().with_cache_enabled(false).build_and_setup();
+        let fee_payer = Pubkey::new_unique();
+        let closed_account = Pubkey::new_unique();
+        let recipient = Pubkey::new_unique();
+        let other_authority = Pubkey::new_unique();
+        let rent_account = AccountMockBuilder::new().with_lamports(2_157_600).build();
+        let config = get_config().unwrap();
+
+        let mocked_rpc_client =
+            RpcMockBuilder::new().build_with_sequential_accounts(vec![&rent_account]);
+        let close_ix = spl_token_interface::instruction::close_account(
+            &spl_token_interface::id(),
+            &closed_account,
+            &recipient,
+            &fee_payer,
+            &[],
+        )
+        .unwrap();
+        let message = VersionedMessage::Legacy(Message::new(&[close_ix], Some(&fee_payer)));
+        let mut resolved =
+            TransactionUtil::new_unsigned_versioned_transaction_resolved(message).unwrap();
+        let outflow = FeeConfigUtil::calculate_fee_payer_outflow(
+            &fee_payer,
+            &mut resolved,
+            &mocked_rpc_client,
+            &config,
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            outflow, 2_157_600,
+            "Fee-payer-authorized close to a third party should count the closed-account rent as outflow"
+        );
+
+        let mocked_rpc_client =
+            RpcMockBuilder::new().build_with_sequential_accounts(vec![&rent_account]);
+        let close_ix = spl_token_interface::instruction::close_account(
+            &spl_token_interface::id(),
+            &closed_account,
+            &fee_payer,
+            &fee_payer,
+            &[],
+        )
+        .unwrap();
+        let message = VersionedMessage::Legacy(Message::new(&[close_ix], Some(&fee_payer)));
+        let mut resolved =
+            TransactionUtil::new_unsigned_versioned_transaction_resolved(message).unwrap();
+        let outflow = FeeConfigUtil::calculate_fee_payer_outflow(
+            &fee_payer,
+            &mut resolved,
+            &mocked_rpc_client,
+            &config,
+        )
+        .await
+        .unwrap();
+        assert_eq!(outflow, 0, "Close back to the fee payer should be neutral");
+
+        let mocked_rpc_client =
+            RpcMockBuilder::new().build_with_sequential_accounts(vec![&rent_account]);
+        let close_ix = spl_token_2022_interface::instruction::close_account(
+            &spl_token_2022_interface::id(),
+            &closed_account,
+            &fee_payer,
+            &other_authority,
+            &[],
+        )
+        .unwrap();
+        let message = VersionedMessage::Legacy(Message::new(&[close_ix], Some(&fee_payer)));
+        let mut resolved =
+            TransactionUtil::new_unsigned_versioned_transaction_resolved(message).unwrap();
+        let outflow = FeeConfigUtil::calculate_fee_payer_outflow(
+            &fee_payer,
+            &mut resolved,
+            &mocked_rpc_client,
+            &config,
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            outflow, -2_157_600,
+            "Close into the fee payer from an unrelated authority should be net inflow"
+        );
+
+        let mocked_rpc_client =
+            RpcMockBuilder::new().build_with_sequential_accounts(vec![&rent_account]);
+        let close_ix = spl_token_interface::instruction::close_account(
+            &spl_token_interface::id(),
+            &closed_account,
+            &recipient,
+            &other_authority,
+            &[],
+        )
+        .unwrap();
+        let message = VersionedMessage::Legacy(Message::new(&[close_ix], Some(&fee_payer)));
+        let mut resolved =
+            TransactionUtil::new_unsigned_versioned_transaction_resolved(message).unwrap();
+        let outflow = FeeConfigUtil::calculate_fee_payer_outflow(
+            &fee_payer,
+            &mut resolved,
+            &mocked_rpc_client,
+            &config,
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            outflow, 0,
+            "Close where the fee payer is neither authority nor recipient should be zero"
         );
     }
 

--- a/crates/lib/src/lighthouse/assertion.rs
+++ b/crates/lib/src/lighthouse/assertion.rs
@@ -131,6 +131,49 @@ impl LighthouseUtil {
         Ok(())
     }
 
+    /// In a V0 message, lookup-table-loaded accounts share one index space with the static
+    /// `account_keys` and are addressed at indices `>= account_keys.len()`. Inserting static keys
+    /// raises that boundary, so every existing compiled-instruction index pointing into the loaded
+    /// region must move up by the number of inserted keys to keep resolving the same account.
+    fn shift_loaded_account_indices(
+        instructions: &mut [CompiledInstruction],
+        static_boundary: usize,
+        inserted: usize,
+    ) -> Result<(), KoraError> {
+        for instruction in instructions {
+            Self::shift_index_if_loaded(
+                &mut instruction.program_id_index,
+                static_boundary,
+                inserted,
+            )?;
+            for index in &mut instruction.accounts {
+                Self::shift_index_if_loaded(index, static_boundary, inserted)?;
+            }
+        }
+        Ok(())
+    }
+
+    fn shift_index_if_loaded(
+        index: &mut u8,
+        static_boundary: usize,
+        inserted: usize,
+    ) -> Result<(), KoraError> {
+        if (*index as usize) < static_boundary {
+            return Ok(());
+        }
+        let shifted = (*index as usize)
+            .checked_add(inserted)
+            .filter(|value| *value <= u8::MAX as usize)
+            .ok_or_else(|| {
+                KoraError::ValidationError(
+                    "Lighthouse assertion would overflow the transaction account index space"
+                        .to_string(),
+                )
+            })?;
+        *index = shifted as u8;
+        Ok(())
+    }
+
     /// Append an instruction to a versioned transaction
     fn append_instruction_to_transaction(
         transaction: &mut VersionedTransaction,
@@ -169,6 +212,8 @@ impl LighthouseUtil {
                 Ok(())
             }
             VersionedMessage::V0(message) => {
+                let static_keys_before = message.account_keys.len();
+
                 let (program_id_index, program_added) =
                     Self::find_or_add_account(&mut message.account_keys, &instruction.program_id)?;
                 if program_added {
@@ -189,6 +234,15 @@ impl LighthouseUtil {
                         Self::increment_readonly_unsigned_accounts(&mut message.header)?;
                     }
                     account_indices.push(index);
+                }
+
+                let inserted = message.account_keys.len() - static_keys_before;
+                if inserted > 0 && !message.address_table_lookups.is_empty() {
+                    Self::shift_loaded_account_indices(
+                        &mut message.instructions,
+                        static_keys_before,
+                        inserted,
+                    )?;
                 }
 
                 message.instructions.push(CompiledInstruction {
@@ -438,5 +492,178 @@ mod tests {
         } else {
             panic!("Expected ValidationError");
         }
+    }
+
+    fn v0_transaction_with_lookup(
+        account_keys: Vec<Pubkey>,
+        num_readonly_unsigned_accounts: u8,
+        instructions: Vec<CompiledInstruction>,
+        lookup_key: Pubkey,
+        writable_indexes: Vec<u8>,
+    ) -> VersionedTransaction {
+        let message = v0::Message {
+            header: MessageHeader {
+                num_required_signatures: 1,
+                num_readonly_signed_accounts: 0,
+                num_readonly_unsigned_accounts,
+            },
+            account_keys,
+            recent_blockhash: Hash::new_unique(),
+            instructions,
+            address_table_lookups: vec![v0::MessageAddressTableLookup {
+                account_key: lookup_key,
+                writable_indexes,
+                readonly_indexes: vec![],
+            }],
+        };
+
+        VersionedTransaction { signatures: vec![], message: VersionedMessage::V0(message) }
+    }
+
+    #[test]
+    fn test_append_v0_with_lookup_rebases_loaded_indices() {
+        let fee_payer = Keypair::new().pubkey();
+        let program = Pubkey::new_unique();
+        let lookup_key = Pubkey::new_unique();
+
+        let original =
+            CompiledInstruction { program_id_index: 1, accounts: vec![0, 2, 3], data: vec![9] };
+        let mut transaction = v0_transaction_with_lookup(
+            vec![fee_payer, program],
+            1,
+            vec![original],
+            lookup_key,
+            vec![0, 1],
+        );
+
+        let assertion_ix = LighthouseUtil::build_fee_payer_assertion(&fee_payer, 1_000_000);
+        LighthouseUtil::append_instruction_to_transaction(&mut transaction, assertion_ix).unwrap();
+
+        let VersionedMessage::V0(message) = &transaction.message else {
+            panic!("expected V0 message");
+        };
+
+        assert_eq!(message.account_keys, vec![fee_payer, program, LIGHTHOUSE_PROGRAM_ID]);
+        assert_eq!(message.header.num_readonly_unsigned_accounts, 2);
+
+        // Loaded indices 2 and 3 must move to 3 and 4 so they still resolve to the same
+        // lookup-loaded accounts now that the static boundary grew from 2 to 3.
+        assert_eq!(message.instructions[0].program_id_index, 1);
+        assert_eq!(message.instructions[0].accounts, vec![0, 3, 4]);
+
+        assert_eq!(message.instructions[1].program_id_index, 2);
+        assert_eq!(message.instructions[1].accounts, vec![0]);
+    }
+
+    #[test]
+    fn test_append_v0_with_lookup_rebases_multiple_instructions() {
+        let fee_payer = Keypair::new().pubkey();
+        let program = Pubkey::new_unique();
+        let lookup_key = Pubkey::new_unique();
+
+        // Two pre-existing instructions, each mixing static (0,1) and loaded (2,3) operands, to
+        // exercise the shift loop across more than one instruction.
+        let ix_a =
+            CompiledInstruction { program_id_index: 1, accounts: vec![0, 2, 3], data: vec![1] };
+        let ix_b =
+            CompiledInstruction { program_id_index: 1, accounts: vec![3, 0, 2], data: vec![2] };
+        let mut transaction = v0_transaction_with_lookup(
+            vec![fee_payer, program],
+            1,
+            vec![ix_a, ix_b],
+            lookup_key,
+            vec![0, 1],
+        );
+
+        let assertion_ix = LighthouseUtil::build_fee_payer_assertion(&fee_payer, 1_000_000);
+        LighthouseUtil::append_instruction_to_transaction(&mut transaction, assertion_ix).unwrap();
+
+        let VersionedMessage::V0(message) = &transaction.message else {
+            panic!("expected V0 message");
+        };
+
+        assert_eq!(message.account_keys, vec![fee_payer, program, LIGHTHOUSE_PROGRAM_ID]);
+        // Both instructions' loaded operands (2,3) shift to (3,4); static operands (0,1) stay.
+        assert_eq!(message.instructions[0].accounts, vec![0, 3, 4]);
+        assert_eq!(message.instructions[1].accounts, vec![4, 0, 3]);
+        // Appended assertion references the fee payer at static index 0.
+        assert_eq!(message.instructions[2].program_id_index, 2);
+        assert_eq!(message.instructions[2].accounts, vec![0]);
+    }
+
+    #[test]
+    fn test_append_v0_with_lookup_shifts_loaded_program_id_index() {
+        let fee_payer = Keypair::new().pubkey();
+        let static_account = Pubkey::new_unique();
+        let lookup_key = Pubkey::new_unique();
+
+        // The invoked program is loaded from the lookup table, so program_id_index sits in the
+        // loaded region and must shift along with the account operands.
+        let original =
+            CompiledInstruction { program_id_index: 2, accounts: vec![0, 3], data: vec![9] };
+        let mut transaction = v0_transaction_with_lookup(
+            vec![fee_payer, static_account],
+            1,
+            vec![original],
+            lookup_key,
+            vec![0, 1],
+        );
+
+        let assertion_ix = LighthouseUtil::build_fee_payer_assertion(&fee_payer, 1_000_000);
+        LighthouseUtil::append_instruction_to_transaction(&mut transaction, assertion_ix).unwrap();
+
+        let VersionedMessage::V0(message) = &transaction.message else {
+            panic!("expected V0 message");
+        };
+
+        // Lighthouse inserted at static index 2, growing the boundary from 2 to 3.
+        assert_eq!(message.account_keys, vec![fee_payer, static_account, LIGHTHOUSE_PROGRAM_ID]);
+        // Loaded program_id_index 2 -> 3 and loaded operand 3 -> 4.
+        assert_eq!(message.instructions[0].program_id_index, 3);
+        assert_eq!(message.instructions[0].accounts, vec![0, 4]);
+    }
+
+    #[test]
+    fn test_append_v0_with_lookup_no_shift_when_program_present() {
+        let fee_payer = Keypair::new().pubkey();
+        let lookup_key = Pubkey::new_unique();
+
+        // Lighthouse program already a static key; no new key is inserted, so nothing shifts.
+        let original =
+            CompiledInstruction { program_id_index: 1, accounts: vec![0, 2, 3], data: vec![9] };
+        let mut transaction = v0_transaction_with_lookup(
+            vec![fee_payer, LIGHTHOUSE_PROGRAM_ID],
+            1,
+            vec![original],
+            lookup_key,
+            vec![0, 1],
+        );
+
+        let assertion_ix = LighthouseUtil::build_fee_payer_assertion(&fee_payer, 1_000_000);
+        LighthouseUtil::append_instruction_to_transaction(&mut transaction, assertion_ix).unwrap();
+
+        let VersionedMessage::V0(message) = &transaction.message else {
+            panic!("expected V0 message");
+        };
+
+        assert_eq!(message.account_keys, vec![fee_payer, LIGHTHOUSE_PROGRAM_ID]);
+        assert_eq!(message.header.num_readonly_unsigned_accounts, 1);
+        assert_eq!(message.instructions[0].accounts, vec![0, 2, 3]);
+        assert_eq!(message.instructions[1].accounts, vec![0]);
+    }
+
+    #[test]
+    fn test_shift_index_if_loaded_bounds() {
+        let mut below = 10u8;
+        LighthouseUtil::shift_index_if_loaded(&mut below, 20, 5).unwrap();
+        assert_eq!(below, 10);
+
+        let mut at_boundary = 20u8;
+        LighthouseUtil::shift_index_if_loaded(&mut at_boundary, 20, 3).unwrap();
+        assert_eq!(at_boundary, 23);
+
+        let mut overflow = 255u8;
+        let err = LighthouseUtil::shift_index_if_loaded(&mut overflow, 0, 1).unwrap_err();
+        assert!(matches!(err, KoraError::ValidationError(_)));
     }
 }

--- a/crates/lib/src/plugin/plugin_deploy_authority.rs
+++ b/crates/lib/src/plugin/plugin_deploy_authority.rs
@@ -248,16 +248,15 @@ impl TransactionPlugin for DeployAuthorityPlugin {
                         )));
                     }
                 }
-                ParsedBpfLoaderUpgradeableInstructionData::ExtendProgram { payer, .. } => {
-                    if let Some(p) = payer {
-                        if p != fee_payer {
-                            return Err(KoraError::InvalidTransaction(format!(
-                                "DeployAuthority plugin: ExtendProgram payer must be the fee \
-                                 payer ({fee_payer}), got {p} in {}",
-                                context.method_name()
-                            )));
-                        }
-                    }
+                ParsedBpfLoaderUpgradeableInstructionData::ExtendProgram { .. } => {
+                    // The unchecked variant has no authority account, so the plugin cannot verify
+                    // Kora is the program's authority. Without that check it would fund rent growth
+                    // for a foreign program. Require ExtendProgramChecked instead.
+                    return Err(KoraError::InvalidTransaction(format!(
+                        "DeployAuthority plugin: unchecked ExtendProgram is not allowed; use \
+                         ExtendProgramChecked so the authority can be verified (context: {})",
+                        context.method_name()
+                    )));
                 }
                 ParsedBpfLoaderUpgradeableInstructionData::ExtendProgramChecked {
                     authority,
@@ -913,6 +912,40 @@ mod tests {
         let err = run_plugin(&config, &rpc_client, &fee_payer, ix).await.expect_err("must reject");
         assert!(
             matches!(&err, KoraError::InvalidTransaction(msg) if msg.contains("ExtendProgramChecked")),
+            "{err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn v3_rejects_extend_program_checked_with_kora_authority_attacker_payer() {
+        // Authority is Kora, so the authority check passes and execution reaches the payer
+        // branch. A non-Kora payer must still be rejected — Kora co-signs an extension of its
+        // own program only when itself (or no one) funds it.
+        use solana_loader_v3_interface::instruction as loader_v3;
+        let (config, rpc_client) = build_runner_v3();
+        let fee_payer = Pubkey::new_unique();
+        let attacker = Pubkey::new_unique();
+        let program = Pubkey::new_unique();
+        let ix = loader_v3::extend_program_checked(&program, &fee_payer, Some(&attacker), 64);
+        let err = run_plugin(&config, &rpc_client, &fee_payer, ix).await.expect_err("must reject");
+        assert!(
+            matches!(&err, KoraError::InvalidTransaction(msg) if msg.contains("payer must be")),
+            "{err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn v3_rejects_unchecked_extend_program() {
+        // The unchecked variant has no authority account, so the plugin cannot confirm Kora is the
+        // program's authority and would otherwise fund rent growth for a foreign program.
+        use solana_loader_v3_interface::instruction as loader_v3;
+        let (config, rpc_client) = build_runner_v3();
+        let fee_payer = Pubkey::new_unique();
+        let program = Pubkey::new_unique();
+        let ix = loader_v3::extend_program(&program, Some(&fee_payer), 64);
+        let err = run_plugin(&config, &rpc_client, &fee_payer, ix).await.expect_err("must reject");
+        assert!(
+            matches!(&err, KoraError::InvalidTransaction(msg) if msg.contains("unchecked ExtendProgram")),
             "{err:?}"
         );
     }

--- a/crates/lib/src/transaction/instruction_util.rs
+++ b/crates/lib/src/transaction/instruction_util.rs
@@ -149,6 +149,8 @@ pub enum ParsedSPLInstructionData {
     // Includes close account
     SplTokenCloseAccount {
         owner: Pubkey,
+        account: Pubkey,
+        destination: Pubkey,
         multisig_signers: Vec<Pubkey>,
         is_2022: bool,
     },
@@ -2796,6 +2798,12 @@ impl IxUtils {
                                     owner: instruction.accounts
                                         [instruction_indexes::spl_token_close_account::OWNER_INDEX]
                                         .pubkey,
+                                    account: instruction.accounts
+                                        [instruction_indexes::spl_token_close_account::ACCOUNT_INDEX]
+                                        .pubkey,
+                                    destination: instruction.accounts
+                                        [instruction_indexes::spl_token_close_account::DESTINATION_INDEX]
+                                        .pubkey,
                                     multisig_signers: Self::extract_multisig_signers(instruction, 3),
                                     is_2022: false,
                                 });
@@ -3182,6 +3190,12 @@ impl IxUtils {
                                 .push(ParsedSPLInstructionData::SplTokenCloseAccount {
                                     owner: instruction.accounts
                                         [instruction_indexes::spl_token_close_account::OWNER_INDEX]
+                                        .pubkey,
+                                    account: instruction.accounts
+                                        [instruction_indexes::spl_token_close_account::ACCOUNT_INDEX]
+                                        .pubkey,
+                                    destination: instruction.accounts
+                                        [instruction_indexes::spl_token_close_account::DESTINATION_INDEX]
                                         .pubkey,
                                     multisig_signers: Self::extract_multisig_signers(instruction, 3),
                                     is_2022: true,

--- a/crates/lib/src/transaction/instruction_util.rs
+++ b/crates/lib/src/transaction/instruction_util.rs
@@ -66,6 +66,7 @@ pub enum ParsedSystemInstructionData {
     // Includes assign and assign with seed
     SystemAssign {
         authority: Pubkey,
+        owner: Pubkey,
     },
     // Includes allocate and allocate with seed
     SystemAllocate {
@@ -2031,18 +2032,19 @@ impl IxUtils {
                             recipient: instruction_indexes::system_withdraw_nonce_account::RECIPIENT_INDEX
                         });
                     }
-                    Ok(SystemInstruction::Assign { .. }) => {
+                    Ok(SystemInstruction::Assign { owner }) => {
                         parse_system_instruction!(
                             parsed_instructions,
                             instruction,
                             system_assign,
                             SystemAssign,
                             SystemAssign {
+                                owner: owner;
                                 authority: instruction_indexes::system_assign::AUTHORITY_INDEX
                             }
                         );
                     }
-                    Ok(SystemInstruction::AssignWithSeed { .. }) => {
+                    Ok(SystemInstruction::AssignWithSeed { owner, .. }) => {
                         // Note: uses system_assign_with_seed for validation but maps to SystemAssign type
                         validate_number_accounts!(instruction, instruction_indexes::system_assign_with_seed::REQUIRED_NUMBER_OF_ACCOUNTS);
                         parsed_instructions
@@ -2052,6 +2054,7 @@ impl IxUtils {
                                 authority: instruction.accounts
                                     [instruction_indexes::system_assign_with_seed::AUTHORITY_INDEX]
                                     .pubkey,
+                                owner,
                             });
                     }
                     Ok(SystemInstruction::Allocate { .. }) => {

--- a/crates/lib/src/transaction/instruction_util.rs
+++ b/crates/lib/src/transaction/instruction_util.rs
@@ -528,6 +528,8 @@ pub const PARSED_DATA_FIELD_FREEZE_AUTHORITY: &str = "freezeAuthority";
 pub const PARSED_DATA_FIELD_AUTHORITY_TYPE: &str = "authorityType";
 pub const PARSED_DATA_FIELD_MULTISIG_ACCOUNT: &str = "multisig";
 pub const PARSED_DATA_FIELD_SIGNERS: &str = "signers";
+pub const PARSED_DATA_FIELD_M: &str = "m";
+pub const PARSED_DATA_FIELD_RENT_SYSVAR: &str = "rentSysvar";
 
 impl IxUtils {
     /// Helper method to extract a field as a string from JSON with proper error handling
@@ -1720,13 +1722,34 @@ impl IxUtils {
                 let current_authority =
                     Self::get_field_as_pubkey(info, PARSED_DATA_FIELD_AUTHORITY)?;
 
+                let new_authority = match info.get(PARSED_DATA_FIELD_NEW_AUTHORITY) {
+                    Some(v) if !v.is_null() => {
+                        Some(Self::get_field_as_pubkey(info, PARSED_DATA_FIELD_NEW_AUTHORITY)?)
+                    }
+                    _ => None,
+                };
+
                 let account_idx = Self::get_account_index(account_keys_hashmap, &account)?;
                 let current_authority_idx =
                     Self::get_account_index(account_keys_hashmap, &current_authority)?;
 
-                // SetAuthority has variable data - we reconstruct minimal version
-                // Real validation happens when checking if fee payer is the authority
-                let data = vec![6];
+                // authority_type is dropped during parsing and never read downstream; any
+                // valid variant lets TokenInstruction::unpack succeed so the policy gate fires.
+                let data = if is_spl_token_program {
+                    spl_token_interface::instruction::TokenInstruction::SetAuthority {
+                        authority_type:
+                            spl_token_interface::instruction::AuthorityType::AccountOwner,
+                        new_authority: new_authority.into(),
+                    }
+                    .pack()
+                } else {
+                    spl_token_2022_interface::instruction::TokenInstruction::SetAuthority {
+                        authority_type:
+                            spl_token_2022_interface::instruction::AuthorityType::AccountOwner,
+                        new_authority: new_authority.into(),
+                    }
+                    .pack()
+                };
 
                 Ok(CompiledInstruction {
                     program_id_index,
@@ -1799,20 +1822,65 @@ impl IxUtils {
             }
             PARSED_DATA_FIELD_INITIALIZE_MINT | PARSED_DATA_FIELD_INITIALIZE_MINT2 => {
                 let mint = Self::get_field_as_pubkey(info, PARSED_DATA_FIELD_MINT)?;
-                // mint_authority is in instruction data, not used for reconstruction
-                let _mint_authority =
+                let mint_authority =
                     Self::get_field_as_pubkey(info, PARSED_DATA_FIELD_MINT_AUTHORITY)?;
+                let decimals =
+                    u8::try_from(Self::get_field_as_u64(info, PARSED_DATA_FIELD_DECIMALS)?)
+                        .map_err(|_| {
+                            KoraError::SerializationError(
+                                "Mint 'decimals' exceeds u8 range".to_string(),
+                            )
+                        })?;
+                let freeze_authority = match info.get(PARSED_DATA_FIELD_FREEZE_AUTHORITY) {
+                    Some(v) if !v.is_null() => {
+                        Some(Self::get_field_as_pubkey(info, PARSED_DATA_FIELD_FREEZE_AUTHORITY)?)
+                    }
+                    _ => None,
+                };
 
                 let mint_idx = Self::get_account_index(account_keys_hashmap, &mint)?;
 
-                // InitializeMint has discriminator only, authority is in data
-                let data = if instruction_type == PARSED_DATA_FIELD_INITIALIZE_MINT {
-                    vec![0] // InitializeMint discriminator
+                if instruction_type == PARSED_DATA_FIELD_INITIALIZE_MINT {
+                    let rent = Self::get_field_as_pubkey(info, PARSED_DATA_FIELD_RENT_SYSVAR)?;
+                    let rent_idx = Self::get_account_index(account_keys_hashmap, &rent)?;
+                    let data = if is_spl_token_program {
+                        spl_token_interface::instruction::TokenInstruction::InitializeMint {
+                            decimals,
+                            mint_authority,
+                            freeze_authority: freeze_authority.into(),
+                        }
+                        .pack()
+                    } else {
+                        spl_token_2022_interface::instruction::TokenInstruction::InitializeMint {
+                            decimals,
+                            mint_authority,
+                            freeze_authority: freeze_authority.into(),
+                        }
+                        .pack()
+                    };
+                    Ok(CompiledInstruction {
+                        program_id_index,
+                        accounts: vec![mint_idx, rent_idx],
+                        data,
+                    })
                 } else {
-                    vec![20] // InitializeMint2 discriminator
-                };
-
-                Ok(CompiledInstruction { program_id_index, accounts: vec![mint_idx], data })
+                    let data = if is_spl_token_program {
+                        spl_token_interface::instruction::TokenInstruction::InitializeMint2 {
+                            decimals,
+                            mint_authority,
+                            freeze_authority: freeze_authority.into(),
+                        }
+                        .pack()
+                    } else {
+                        spl_token_2022_interface::instruction::TokenInstruction::InitializeMint2 {
+                            decimals,
+                            mint_authority,
+                            freeze_authority: freeze_authority.into(),
+                        }
+                        .pack()
+                    };
+                    Ok(CompiledInstruction { program_id_index, accounts: vec![mint_idx], data })
+                }
             }
             PARSED_DATA_FIELD_INITIALIZE_ACCOUNT
             | PARSED_DATA_FIELD_INITIALIZE_ACCOUNT2
@@ -1834,7 +1902,20 @@ impl IxUtils {
                     }
                     PARSED_DATA_FIELD_INITIALIZE_ACCOUNT2 => {
                         // InitializeAccount2: [account, mint, rent], owner in data
-                        (vec![16], vec![account_idx, mint_idx])
+                        let rent = Self::get_field_as_pubkey(info, PARSED_DATA_FIELD_RENT_SYSVAR)?;
+                        let rent_idx = Self::get_account_index(account_keys_hashmap, &rent)?;
+                        let data = if is_spl_token_program {
+                            spl_token_interface::instruction::TokenInstruction::InitializeAccount2 {
+                                owner,
+                            }
+                            .pack()
+                        } else {
+                            spl_token_2022_interface::instruction::TokenInstruction::InitializeAccount2 {
+                                owner,
+                            }
+                            .pack()
+                        };
+                        (data, vec![account_idx, mint_idx, rent_idx])
                     }
                     PARSED_DATA_FIELD_INITIALIZE_ACCOUNT3 => {
                         // InitializeAccount3: [account, mint], owner in data
@@ -1860,19 +1941,70 @@ impl IxUtils {
                 let multisig = Self::get_field_as_pubkey(info, PARSED_DATA_FIELD_MULTISIG_ACCOUNT)?;
                 let multisig_idx = Self::get_account_index(account_keys_hashmap, &multisig)?;
 
-                // Extract signer pubkeys from signers array (not currently used for reconstruction)
-                let _signers_value = info.get(PARSED_DATA_FIELD_SIGNERS).ok_or_else(|| {
-                    KoraError::SerializationError("Missing 'signers' field".to_string())
-                })?;
+                let m = u8::try_from(Self::get_field_as_u64(info, PARSED_DATA_FIELD_M)?)
+                    .map_err(|_| {
+                        KoraError::SerializationError(
+                            "Multisig threshold 'm' exceeds u8 range".to_string(),
+                        )
+                    })?;
 
-                // Discriminator based on instruction variant
-                let data = if instruction_type == PARSED_DATA_FIELD_INITIALIZE_MULTISIG {
-                    vec![2] // InitializeMultisig discriminator
-                } else {
-                    vec![19] // InitializeMultisig2 discriminator
-                };
+                let signers = info
+                    .get(PARSED_DATA_FIELD_SIGNERS)
+                    .and_then(|v| v.as_array())
+                    .ok_or_else(|| {
+                        KoraError::SerializationError(
+                            "Missing or invalid 'signers' field".to_string(),
+                        )
+                    })?;
+                let mut signer_indices = Vec::with_capacity(signers.len());
+                for signer in signers {
+                    let signer_str = signer.as_str().ok_or_else(|| {
+                        KoraError::SerializationError("'signers' entry is not a string".to_string())
+                    })?;
+                    let signer_pubkey = signer_str.parse::<Pubkey>().map_err(|e| {
+                        KoraError::SerializationError(format!(
+                            "Invalid multisig signer '{}': {}",
+                            signer_str,
+                            sanitize_error!(e)
+                        ))
+                    })?;
+                    signer_indices
+                        .push(Self::get_account_index(account_keys_hashmap, &signer_pubkey)?);
+                }
 
-                Ok(CompiledInstruction { program_id_index, accounts: vec![multisig_idx], data })
+                let (data, mut accounts) =
+                    if instruction_type == PARSED_DATA_FIELD_INITIALIZE_MULTISIG {
+                        let rent = Self::get_field_as_pubkey(info, PARSED_DATA_FIELD_RENT_SYSVAR)?;
+                        let rent_idx = Self::get_account_index(account_keys_hashmap, &rent)?;
+                        let data = if is_spl_token_program {
+                            spl_token_interface::instruction::TokenInstruction::InitializeMultisig {
+                                m,
+                            }
+                            .pack()
+                        } else {
+                            spl_token_2022_interface::instruction::TokenInstruction::InitializeMultisig {
+                                m,
+                            }
+                            .pack()
+                        };
+                        (data, vec![multisig_idx, rent_idx])
+                    } else {
+                        let data = if is_spl_token_program {
+                            spl_token_interface::instruction::TokenInstruction::InitializeMultisig2 {
+                                m,
+                            }
+                            .pack()
+                        } else {
+                            spl_token_2022_interface::instruction::TokenInstruction::InitializeMultisig2 {
+                                m,
+                            }
+                            .pack()
+                        };
+                        (data, vec![multisig_idx])
+                    };
+                accounts.extend(signer_indices);
+
+                Ok(CompiledInstruction { program_id_index, accounts, data })
             }
             PARSED_DATA_FIELD_FREEZE_ACCOUNT => {
                 let account = Self::get_field_as_pubkey(info, PARSED_DATA_FIELD_ACCOUNT)?;
@@ -6282,6 +6414,276 @@ mod tests {
         assert_eq!(compiled.program_id_index, 0);
         assert_eq!(compiled.accounts, vec![1, 2, 3, 4]); // source, mint, delegate, owner indices
         assert_eq!(compiled.data, instruction.data);
+    }
+
+    #[test]
+    fn test_reconstruct_spl_token_initialize_multisig_preserves_signers_and_threshold() {
+        let multisig = Pubkey::new_unique();
+        let fee_payer = Pubkey::new_unique();
+        let other_signer = Pubkey::new_unique();
+        let m = 1u8;
+
+        let real_ix = spl_token_interface::instruction::initialize_multisig(
+            &spl_token_interface::ID,
+            &multisig,
+            &[&fee_payer, &other_signer],
+            m,
+        )
+        .expect("Failed to create initialize_multisig instruction");
+
+        let message = Message::new(&[real_ix.clone()], None);
+        let account_keys_for_parsing = AccountKeys::new(&message.account_keys, None);
+        let parsed = parse_instruction::parse(
+            &spl_token_interface::ID,
+            &message.instructions[0],
+            &account_keys_for_parsing,
+            None,
+        )
+        .expect("Failed to parse initialize_multisig instruction");
+
+        let account_keys = message.account_keys.clone();
+        let compiled = IxUtils::reconstruct_spl_token_instruction(
+            &parsed,
+            &IxUtils::build_account_keys_hashmap(&account_keys),
+        )
+        .expect("Failed to reconstruct initialize_multisig instruction");
+
+        assert_eq!(compiled.data, real_ix.data);
+
+        let unpacked =
+            spl_token_interface::instruction::TokenInstruction::unpack(&compiled.data).unwrap();
+        assert!(matches!(
+            unpacked,
+            spl_token_interface::instruction::TokenInstruction::InitializeMultisig { m: got }
+                if got == m
+        ));
+
+        let reconstructed_signers: Vec<Pubkey> =
+            compiled.accounts[2..].iter().map(|i| account_keys[*i as usize]).collect();
+        assert!(reconstructed_signers.contains(&fee_payer));
+        assert!(reconstructed_signers.contains(&other_signer));
+    }
+
+    #[test]
+    fn test_reconstruct_spl_token_initialize_multisig2_preserves_signers_and_threshold() {
+        let multisig = Pubkey::new_unique();
+        let fee_payer = Pubkey::new_unique();
+        let other_signer = Pubkey::new_unique();
+        let m = 2u8;
+
+        let real_ix = spl_token_interface::instruction::initialize_multisig2(
+            &spl_token_interface::ID,
+            &multisig,
+            &[&fee_payer, &other_signer],
+            m,
+        )
+        .expect("Failed to create initialize_multisig2 instruction");
+
+        let message = Message::new(&[real_ix.clone()], None);
+        let account_keys_for_parsing = AccountKeys::new(&message.account_keys, None);
+        let parsed = parse_instruction::parse(
+            &spl_token_interface::ID,
+            &message.instructions[0],
+            &account_keys_for_parsing,
+            None,
+        )
+        .expect("Failed to parse initialize_multisig2 instruction");
+
+        let account_keys = message.account_keys.clone();
+        let compiled = IxUtils::reconstruct_spl_token_instruction(
+            &parsed,
+            &IxUtils::build_account_keys_hashmap(&account_keys),
+        )
+        .expect("Failed to reconstruct initialize_multisig2 instruction");
+
+        assert_eq!(compiled.data, real_ix.data);
+
+        let unpacked =
+            spl_token_interface::instruction::TokenInstruction::unpack(&compiled.data).unwrap();
+        assert!(matches!(
+            unpacked,
+            spl_token_interface::instruction::TokenInstruction::InitializeMultisig2 { m: got }
+                if got == m
+        ));
+
+        // InitializeMultisig2 has no rent sysvar, so signer accounts start at index 1.
+        let reconstructed_signers: Vec<Pubkey> =
+            compiled.accounts[1..].iter().map(|i| account_keys[*i as usize]).collect();
+        assert!(reconstructed_signers.contains(&fee_payer));
+        assert!(reconstructed_signers.contains(&other_signer));
+    }
+
+    #[test]
+    fn test_reconstruct_spl_token_initialize_mint_preserves_data_and_rent() {
+        let mint = Pubkey::new_unique();
+        let mint_authority = Pubkey::new_unique();
+        let freeze_authority = Pubkey::new_unique();
+        let decimals = 6u8;
+
+        let real_ix = spl_token_interface::instruction::initialize_mint(
+            &spl_token_interface::ID,
+            &mint,
+            &mint_authority,
+            Some(&freeze_authority),
+            decimals,
+        )
+        .expect("Failed to create initialize_mint instruction");
+
+        let message = Message::new(&[real_ix.clone()], None);
+        let account_keys_for_parsing = AccountKeys::new(&message.account_keys, None);
+        let parsed = parse_instruction::parse(
+            &spl_token_interface::ID,
+            &message.instructions[0],
+            &account_keys_for_parsing,
+            None,
+        )
+        .expect("Failed to parse initialize_mint instruction");
+
+        let account_keys = message.account_keys.clone();
+        let compiled = IxUtils::reconstruct_spl_token_instruction(
+            &parsed,
+            &IxUtils::build_account_keys_hashmap(&account_keys),
+        )
+        .expect("Failed to reconstruct initialize_mint instruction");
+
+        assert_eq!(compiled.data, real_ix.data);
+        assert_eq!(compiled.accounts.len(), real_ix.accounts.len());
+        assert!(matches!(
+            spl_token_interface::instruction::TokenInstruction::unpack(&compiled.data).unwrap(),
+            spl_token_interface::instruction::TokenInstruction::InitializeMint { .. }
+        ));
+    }
+
+    #[test]
+    fn test_reconstruct_spl_token_initialize_mint2_preserves_data() {
+        let mint = Pubkey::new_unique();
+        let mint_authority = Pubkey::new_unique();
+        let decimals = 9u8;
+
+        let real_ix = spl_token_interface::instruction::initialize_mint2(
+            &spl_token_interface::ID,
+            &mint,
+            &mint_authority,
+            None,
+            decimals,
+        )
+        .expect("Failed to create initialize_mint2 instruction");
+
+        let message = Message::new(&[real_ix.clone()], None);
+        let account_keys_for_parsing = AccountKeys::new(&message.account_keys, None);
+        let parsed = parse_instruction::parse(
+            &spl_token_interface::ID,
+            &message.instructions[0],
+            &account_keys_for_parsing,
+            None,
+        )
+        .expect("Failed to parse initialize_mint2 instruction");
+
+        let account_keys = message.account_keys.clone();
+        let compiled = IxUtils::reconstruct_spl_token_instruction(
+            &parsed,
+            &IxUtils::build_account_keys_hashmap(&account_keys),
+        )
+        .expect("Failed to reconstruct initialize_mint2 instruction");
+
+        assert_eq!(compiled.data, real_ix.data);
+        assert!(matches!(
+            spl_token_interface::instruction::TokenInstruction::unpack(&compiled.data).unwrap(),
+            spl_token_interface::instruction::TokenInstruction::InitializeMint2 { .. }
+        ));
+    }
+
+    #[test]
+    fn test_reconstruct_spl_token_set_authority_unpacks_and_preserves_new_authority() {
+        let account = Pubkey::new_unique();
+        let current_authority = Pubkey::new_unique();
+        let new_authority = Pubkey::new_unique();
+
+        let real_ix = spl_token_interface::instruction::set_authority(
+            &spl_token_interface::ID,
+            &account,
+            Some(&new_authority),
+            spl_token_interface::instruction::AuthorityType::MintTokens,
+            &current_authority,
+            &[],
+        )
+        .expect("Failed to create set_authority instruction");
+
+        let message = Message::new(&[real_ix.clone()], None);
+        let account_keys_for_parsing = AccountKeys::new(&message.account_keys, None);
+        let parsed = parse_instruction::parse(
+            &spl_token_interface::ID,
+            &message.instructions[0],
+            &account_keys_for_parsing,
+            None,
+        )
+        .expect("Failed to parse set_authority instruction");
+
+        let account_keys = message.account_keys.clone();
+        let compiled = IxUtils::reconstruct_spl_token_instruction(
+            &parsed,
+            &IxUtils::build_account_keys_hashmap(&account_keys),
+        )
+        .expect("Failed to reconstruct set_authority instruction");
+
+        // The defect was a discriminator-only reconstruction that failed to unpack, silently
+        // skipping the allow_set_authority gate. It must now unpack, and the gate-relevant
+        // new_authority must survive; authority_type is not read downstream.
+        match spl_token_interface::instruction::TokenInstruction::unpack(&compiled.data)
+            .expect("reconstructed SetAuthority must unpack")
+        {
+            spl_token_interface::instruction::TokenInstruction::SetAuthority {
+                new_authority: got,
+                ..
+            } => assert_eq!(Option::<Pubkey>::from(got), Some(new_authority)),
+            other => panic!("expected SetAuthority, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_reconstruct_spl_token_initialize_account2_preserves_owner() {
+        let account = Pubkey::new_unique();
+        let mint = Pubkey::new_unique();
+        let owner = Pubkey::new_unique();
+
+        let real_ix = spl_token_interface::instruction::initialize_account2(
+            &spl_token_interface::ID,
+            &account,
+            &mint,
+            &owner,
+        )
+        .expect("Failed to create initialize_account2 instruction");
+
+        let message = Message::new(&[real_ix.clone()], None);
+        let account_keys_for_parsing = AccountKeys::new(&message.account_keys, None);
+        let parsed = parse_instruction::parse(
+            &spl_token_interface::ID,
+            &message.instructions[0],
+            &account_keys_for_parsing,
+            None,
+        )
+        .expect("Failed to parse initialize_account2 instruction");
+
+        let account_keys = message.account_keys.clone();
+        let compiled = IxUtils::reconstruct_spl_token_instruction(
+            &parsed,
+            &IxUtils::build_account_keys_hashmap(&account_keys),
+        )
+        .expect("Failed to reconstruct initialize_account2 instruction");
+
+        assert_eq!(compiled.data, real_ix.data);
+        assert_eq!(
+            compiled.accounts.len(),
+            instruction_indexes::spl_token_initialize_account2::REQUIRED_NUMBER_OF_ACCOUNTS
+        );
+
+        let unpacked =
+            spl_token_interface::instruction::TokenInstruction::unpack(&compiled.data).unwrap();
+        assert!(matches!(
+            unpacked,
+            spl_token_interface::instruction::TokenInstruction::InitializeAccount2 { owner: got }
+                if got == owner
+        ));
     }
 
     #[test]

--- a/crates/lib/src/transaction/instruction_util.rs
+++ b/crates/lib/src/transaction/instruction_util.rs
@@ -56,6 +56,8 @@ pub enum ParsedSystemInstructionData {
         payer: Pubkey,
         new_account: Pubkey,
         owner: Pubkey,
+        // CreateAccountWithSeed has a distinct required `base` signer; None for plain CreateAccount.
+        base: Option<Pubkey>,
     },
     // Includes withdraw nonce account
     SystemWithdrawNonceAccount {
@@ -2130,13 +2132,34 @@ impl IxUtils {
             // Handle System Program transfers and account creation
             if program_id == SYSTEM_PROGRAM_ID {
                 match bincode::deserialize::<SystemInstruction>(&instruction.data) {
-                    Ok(SystemInstruction::CreateAccount { lamports, owner, .. })
-                    | Ok(SystemInstruction::CreateAccountWithSeed { lamports, owner, .. }) => {
+                    Ok(SystemInstruction::CreateAccount { lamports, owner, .. }) => {
                         parse_system_instruction!(parsed_instructions, instruction, system_create_account, SystemCreateAccount, SystemCreateAccount {
-                            lamports: lamports, owner: owner;
+                            lamports: lamports, owner: owner, base: None;
                             payer: instruction_indexes::system_create_account::PAYER_INDEX,
                             new_account: instruction_indexes::system_create_account::NEW_ACCOUNT_INDEX
                         });
+                    }
+                    Ok(SystemInstruction::CreateAccountWithSeed {
+                        lamports, owner, base, ..
+                    }) => {
+                        validate_number_accounts!(
+                            instruction,
+                            instruction_indexes::system_create_account::REQUIRED_NUMBER_OF_ACCOUNTS
+                        );
+                        parsed_instructions
+                            .entry(ParsedSystemInstructionType::SystemCreateAccount)
+                            .or_default()
+                            .push(ParsedSystemInstructionData::SystemCreateAccount {
+                                lamports,
+                                owner,
+                                payer: instruction.accounts
+                                    [instruction_indexes::system_create_account::PAYER_INDEX]
+                                    .pubkey,
+                                new_account: instruction.accounts
+                                    [instruction_indexes::system_create_account::NEW_ACCOUNT_INDEX]
+                                    .pubkey,
+                                base: Some(base),
+                            });
                     }
                     Ok(SystemInstruction::Transfer { lamports }) => {
                         parse_system_instruction!(parsed_instructions, instruction, system_transfer, SystemTransfer, SystemTransfer {
@@ -2260,6 +2283,7 @@ impl IxUtils {
                                     payer,
                                     new_account,
                                     owner,
+                                    base: None,
                                 });
                         }
                     }
@@ -4622,11 +4646,13 @@ mod tests {
                 payer: parsed_payer,
                 new_account: parsed_new_account,
                 owner: parsed_owner,
+                base: parsed_base,
             } => {
                 assert_eq!(*parsed_lamports, lamports);
                 assert_eq!(*parsed_payer, payer.pubkey());
                 assert_eq!(*parsed_new_account, new_account.pubkey());
                 assert_eq!(*parsed_owner, owner);
+                assert_eq!(*parsed_base, None);
             }
             _ => panic!("Expected SystemCreateAccount variant"),
         }
@@ -4680,11 +4706,13 @@ mod tests {
                 payer: parsed_payer,
                 new_account: parsed_new_account,
                 owner: parsed_owner,
+                base: parsed_base,
             } => {
                 assert_eq!(*parsed_lamports, lamports);
                 assert_eq!(*parsed_payer, payer.pubkey());
                 assert_eq!(*parsed_new_account, new_account);
                 assert_eq!(*parsed_owner, owner);
+                assert_eq!(*parsed_base, Some(payer.pubkey()));
             }
             _ => panic!("Expected SystemCreateAccount variant"),
         }
@@ -4752,6 +4780,7 @@ mod tests {
                 payer: parsed_payer,
                 new_account: parsed_new_account,
                 owner: parsed_owner,
+                base: _,
             } => {
                 assert_eq!(*parsed_lamports, lamports);
                 assert_eq!(*parsed_payer, funder.pubkey());

--- a/crates/lib/src/transaction/token2022_security.rs
+++ b/crates/lib/src/transaction/token2022_security.rs
@@ -152,14 +152,46 @@ impl Token2022SecurityParser {
                         parsed.push(parsed_instruction);
                     }
                 }
-                TokenInstruction::DefaultAccountStateExtension
-                | TokenInstruction::MemoTransferExtension
-                | TokenInstruction::CpiGuardExtension
-                | TokenInstruction::InitializeNonTransferableMint
-                | TokenInstruction::WithdrawExcessLamports => {
+                TokenInstruction::DefaultAccountStateExtension => {
+                    parsed.push(Self::unsupported_fee_payer_account_check(
+                        instruction,
+                        "DefaultAccountState extension instruction",
+                        Some(ExtensionType::DefaultAccountState),
+                    ));
+                }
+                TokenInstruction::MemoTransferExtension => {
+                    parsed.push(Self::unsupported_fee_payer_account_check(
+                        instruction,
+                        "MemoTransfer extension instruction",
+                        Some(ExtensionType::MemoTransfer),
+                    ));
+                }
+                TokenInstruction::CpiGuardExtension => {
+                    parsed.push(Self::unsupported_fee_payer_account_check(
+                        instruction,
+                        "CpiGuard extension instruction",
+                        Some(ExtensionType::CpiGuard),
+                    ));
+                }
+                TokenInstruction::InitializeImmutableOwner => {
+                    parsed.push(Self::unsupported_fee_payer_account_check(
+                        instruction,
+                        "InitializeImmutableOwner instruction",
+                        Some(ExtensionType::ImmutableOwner),
+                    ));
+                }
+                TokenInstruction::InitializeNonTransferableMint => {
+                    parsed.push(Self::unsupported_fee_payer_account_check(
+                        instruction,
+                        "InitializeNonTransferableMint instruction",
+                        Some(ExtensionType::NonTransferable),
+                    ));
+                }
+                TokenInstruction::WithdrawExcessLamports => {
                     parsed.push(Self::unsupported_fee_payer_account_check(
                         instruction,
                         "unsupported Token-2022 extension instruction",
+                        None,
                     ));
                 }
                 _ => {}
@@ -270,6 +302,7 @@ impl Token2022SecurityParser {
                 Ok(Some(Self::unsupported_fee_payer_account_check(
                     instruction,
                     "Token2022 HarvestWithheldTokensToMint",
+                    None,
                 )))
             }
         }
@@ -789,10 +822,11 @@ impl Token2022SecurityParser {
     fn unsupported_fee_payer_account_check(
         instruction: &Instruction,
         instruction_name: &'static str,
+        extension_type: Option<ExtensionType>,
     ) -> Token2022SecurityInstruction {
         Token2022SecurityInstruction {
             instruction_name,
-            extension_type: None,
+            extension_type,
             accounts: Self::instruction_accounts(instruction),
             account_usage_policy: Token2022AccountUsagePolicy::RejectIfFeePayerPresent,
             update_authority: None,

--- a/crates/lib/src/transaction/versioned_transaction.rs
+++ b/crates/lib/src/transaction/versioned_transaction.rs
@@ -656,10 +656,14 @@ impl LookupTableUtil {
         lookup_table_lookups: &[MessageAddressTableLookup],
         alt_cache: AltCache<'_>,
     ) -> Result<Vec<Pubkey>, KoraError> {
-        let mut resolved_addresses = Vec::new();
+        // Solana orders loaded accounts as all writable across every table, then all readonly
+        // across every table. Resolving per-table would mis-order indices for multi-table
+        // messages and decompile instructions against the wrong accounts.
+        let mut writable_addresses = Vec::new();
+        let mut readonly_addresses = Vec::new();
 
         if lookup_table_lookups.is_empty() {
-            return Ok(resolved_addresses);
+            return Ok(writable_addresses);
         }
 
         let mut local = HashMap::new();
@@ -701,7 +705,7 @@ impl LookupTableUtil {
 
             for &index in &lookup.writable_indexes {
                 if let Some(address) = addresses.get(index as usize) {
-                    resolved_addresses.push(*address);
+                    writable_addresses.push(*address);
                 } else {
                     return Err(KoraError::InvalidTransaction(format!(
                         "Lookup table index {index} out of bounds for writable addresses"
@@ -711,7 +715,7 @@ impl LookupTableUtil {
 
             for &index in &lookup.readonly_indexes {
                 if let Some(address) = addresses.get(index as usize) {
-                    resolved_addresses.push(*address);
+                    readonly_addresses.push(*address);
                 } else {
                     return Err(KoraError::InvalidTransaction(format!(
                         "Lookup table index {index} out of bounds for readonly addresses"
@@ -720,7 +724,8 @@ impl LookupTableUtil {
             }
         }
 
-        Ok(resolved_addresses)
+        writable_addresses.extend(readonly_addresses);
+        Ok(writable_addresses)
     }
 }
 
@@ -1467,6 +1472,50 @@ mod tests {
         assert_eq!(resolved_addresses[0], address1);
         assert_eq!(resolved_addresses[1], address3);
         assert_eq!(resolved_addresses[2], address2);
+    }
+
+    #[tokio::test]
+    async fn test_resolve_lookup_table_addresses_multi_table_canonical_ordering() {
+        let config = setup_test_config();
+        let _m = setup_config_mock(config.clone());
+
+        let kora_ata = Pubkey::new_unique();
+        let attacker_ata = Pubkey::new_unique();
+        let earlier_table = Pubkey::new_unique();
+        let later_table = Pubkey::new_unique();
+
+        let mut alt_cache: HashMap<Pubkey, Vec<Pubkey>> = HashMap::new();
+        alt_cache.insert(earlier_table, vec![kora_ata]);
+        alt_cache.insert(later_table, vec![attacker_ata]);
+
+        let rpc_client = RpcMockBuilder::new().build();
+
+        // Kora's ATA is readonly in the earlier table; the attacker ATA is writable in the later
+        // table. Solana loads all writable across tables before all readonly, so the canonical
+        // order is [attacker_ata, kora_ata] regardless of table position.
+        let lookups = vec![
+            solana_message::v0::MessageAddressTableLookup {
+                account_key: earlier_table,
+                writable_indexes: vec![],
+                readonly_indexes: vec![0],
+            },
+            solana_message::v0::MessageAddressTableLookup {
+                account_key: later_table,
+                writable_indexes: vec![0],
+                readonly_indexes: vec![],
+            },
+        ];
+
+        let resolved = LookupTableUtil::resolve_lookup_table_addresses(
+            &config,
+            &rpc_client,
+            &lookups,
+            Some(&mut alt_cache),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(resolved, vec![attacker_ata, kora_ata]);
     }
 
     #[tokio::test]

--- a/crates/lib/src/usage_limit/usage_tracker.rs
+++ b/crates/lib/src/usage_limit/usage_tracker.rs
@@ -185,6 +185,7 @@ impl UsageTracker {
             .unwrap_or(&vec![])
         {
             if let ParsedSPLInstructionData::SplTokenTransfer {
+                source_address,
                 destination_address,
                 owner,
                 multisig_signers,
@@ -220,7 +221,24 @@ impl UsageTracker {
                     )
                     .await?
                 {
-                    return Ok(Some(*owner));
+                    // Key usage by the funding wallet (the source token account's owner), not the
+                    // transfer authority, which can be a rotatable delegate or multisig member.
+                    let source_account = match CacheUtil::get_account(
+                        config,
+                        rpc_client,
+                        source_address,
+                        true,
+                    )
+                    .await
+                    {
+                        Ok(account) => account,
+                        Err(e) => return Err(e),
+                    };
+                    let source_token_program =
+                        TokenType::get_token_program_from_owner(&source_account.owner)?;
+                    let source_token_account =
+                        source_token_program.unpack_token_account(&source_account.data)?;
+                    return Ok(Some(source_token_account.owner()));
                 }
             }
         }
@@ -1048,7 +1066,9 @@ mod tests {
         let destination_ata = Pubkey::new_unique();
         let mint = Pubkey::new_unique();
         let destination_account = create_mock_token_account(&fee_payer.pubkey(), &mint);
-        let rpc_client = RpcMockBuilder::new().with_account_info(&destination_account).build();
+        let source_account = create_mock_token_account(&owner.pubkey(), &mint);
+        let rpc_client = RpcMockBuilder::new()
+            .build_with_sequential_accounts(vec![&destination_account, &source_account]);
         let config = ConfigMockBuilder::new().build();
 
         let mut tx = make_spl_transfer_transaction(
@@ -1073,6 +1093,46 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_extract_user_delegated_transfer_returns_source_owner_not_delegate() {
+        let store = Arc::new(InMemoryUsageStore::new());
+        let tracker = UsageTracker::new(true, store, vec![], HashSet::new(), false);
+
+        let fee_payer = Keypair::new();
+        let source_owner = Pubkey::new_unique();
+        let delegate = Keypair::new();
+        let destination_ata = Pubkey::new_unique();
+        let mint = Pubkey::new_unique();
+        let destination_account = create_mock_token_account(&fee_payer.pubkey(), &mint);
+        let source_account = create_mock_token_account(&source_owner, &mint);
+        let rpc_client = RpcMockBuilder::new()
+            .build_with_sequential_accounts(vec![&destination_account, &source_account]);
+        let config = ConfigMockBuilder::new().build();
+
+        // The transfer authority is a delegate (signed), but the source account is owned by
+        // source_owner. Usage identity must be the funding wallet, not the rotatable delegate.
+        let mut tx = make_spl_transfer_transaction(
+            &delegate.pubkey(),
+            &[],
+            &[&delegate],
+            destination_ata,
+            &fee_payer,
+        );
+
+        let result = tracker
+            .extract_user_from_payment_instruction(
+                &mut tx,
+                &config,
+                &fee_payer.pubkey(),
+                &rpc_client,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(result, Some(source_owner));
+        assert_ne!(result, Some(delegate.pubkey()));
+    }
+
+    #[tokio::test]
     async fn test_extract_user_multisig_owner_returns_owner_when_threshold_is_met() {
         let store = Arc::new(InMemoryUsageStore::new());
         let tracker = UsageTracker::new(true, store, vec![], HashSet::new(), false);
@@ -1089,8 +1149,12 @@ mod tests {
             2,
             &[signer_one.pubkey(), signer_two.pubkey(), signer_three.pubkey()],
         );
-        let rpc_client = RpcMockBuilder::new()
-            .build_with_sequential_accounts(vec![&destination_account, &multisig_account]);
+        let source_account = create_mock_token_account(&multisig_owner, &mint);
+        let rpc_client = RpcMockBuilder::new().build_with_sequential_accounts(vec![
+            &destination_account,
+            &multisig_account,
+            &source_account,
+        ]);
         let config = ConfigMockBuilder::new().build();
 
         let mut tx = make_spl_transfer_transaction(

--- a/crates/lib/src/usage_limit/usage_tracker.rs
+++ b/crates/lib/src/usage_limit/usage_tracker.rs
@@ -11,7 +11,6 @@ use crate::{
     config::Config,
     error::KoraError,
     sanitize_error,
-    state::get_signer_pool,
     token::token::TokenType,
     transaction::{
         ParsedSPLInstructionData, ParsedSPLInstructionType, VersionedTransactionOps,
@@ -38,7 +37,6 @@ pub struct UsageTracker {
     store: Arc<dyn UsageStore>,
     rules: Vec<UsageRule>,
     instruction_rule_indices: Vec<usize>,
-    kora_signers: HashSet<Pubkey>,
     fallback_if_unavailable: bool,
 }
 
@@ -47,7 +45,6 @@ impl UsageTracker {
         enabled: bool,
         store: Arc<dyn UsageStore>,
         rules: Vec<UsageRule>,
-        kora_signers: HashSet<Pubkey>,
         fallback_if_unavailable: bool,
     ) -> Self {
         // Pre-compute instruction rule indices at initialization
@@ -64,14 +61,7 @@ impl UsageTracker {
                 })
                 .collect();
 
-        Self {
-            enabled,
-            store,
-            rules,
-            instruction_rule_indices,
-            kora_signers,
-            fallback_if_unavailable,
-        }
+        Self { enabled, store, rules, instruction_rule_indices, fallback_if_unavailable }
     }
 
     fn get_usage_limiter() -> Result<Option<&'static UsageTracker>, KoraError> {
@@ -246,15 +236,6 @@ impl UsageTracker {
         Ok(None)
     }
 
-    /// Extract kora signer from transaction signers
-    fn extract_kora_signer(&self, transaction: &VersionedTransactionResolved) -> Option<Pubkey> {
-        transaction
-            .signer_pubkeys()
-            .iter()
-            .find(|signer| self.kora_signers.contains(signer))
-            .copied()
-    }
-
     fn current_timestamp() -> u64 {
         SystemTime::now().duration_since(SystemTime::UNIX_EPOCH).map(|d| d.as_secs()).unwrap_or(0)
     }
@@ -399,12 +380,6 @@ impl UsageTracker {
             return set_limiter(None);
         }
 
-        let kora_signers = get_signer_pool()?
-            .get_signers_info()
-            .iter()
-            .filter_map(|info| info.public_key.parse().ok())
-            .collect();
-
         let resolved_cache_url = usage_config.resolved_cache_url();
         let (store, backend): (Arc<dyn UsageStore>, &str) =
             if let Some(cache_url) = &resolved_cache_url {
@@ -446,7 +421,6 @@ impl UsageTracker {
             usage_config.enabled,
             store,
             rules,
-            kora_signers,
             usage_config.fallback_if_unavailable,
         )))
     }
@@ -478,7 +452,18 @@ impl UsageTracker {
             return Ok(());
         };
 
-        if tracker.has_instruction_rules() {
+        tracker.check_transaction(config, transaction, user_id, fee_payer, rpc_client).await
+    }
+
+    async fn check_transaction(
+        &self,
+        config: &Config,
+        transaction: &mut VersionedTransactionResolved,
+        user_id: Option<&str>,
+        fee_payer: &Pubkey,
+        rpc_client: &RpcClient,
+    ) -> Result<(), KoraError> {
+        if self.has_instruction_rules() {
             transaction.get_or_parse_system_instructions()?;
             transaction.get_or_parse_spl_instructions()?;
         }
@@ -490,8 +475,7 @@ impl UsageTracker {
             user_id_str.to_string()
         } else {
             // Paid mode: extract payer from payment instruction
-            tracker
-                .extract_user_from_payment_instruction(transaction, config, fee_payer, rpc_client)
+            self.extract_user_from_payment_instruction(transaction, config, fee_payer, rpc_client)
                 .await?
                 .ok_or_else(|| {
                     KoraError::ValidationError(
@@ -501,20 +485,20 @@ impl UsageTracker {
                 .to_string()
         };
 
-        let kora_signer = tracker.extract_kora_signer(transaction);
-
+        // Bind usage accounting to the signer selected for this request (the signer Kora actually
+        // signs with), not whichever pool signer happens to appear first in the message.
         let mut ctx = LimiterContext {
             transaction,
             user_id: resolved_user_id,
-            kora_signer,
+            kora_signer: Some(*fee_payer),
             timestamp: Self::current_timestamp(),
         };
 
-        match tracker.check_and_record(&mut ctx).await {
+        match self.check_and_record(&mut ctx).await {
             Ok(LimiterResult::Allowed) => Ok(()),
             Ok(LimiterResult::Denied { reason }) => Err(KoraError::UsageLimitExceeded(reason)),
             Err(e)
-                if tracker.fallback_if_unavailable
+                if self.fallback_if_unavailable
                     && matches!(e, KoraError::InternalServerError(_)) =>
             {
                 log::warn!("Usage limiter error (fallback enabled): {e}");
@@ -608,7 +592,7 @@ mod tests {
             }],
         };
         let rules = config.build_rules().unwrap();
-        UsageTracker::new(true, store, rules, HashSet::new(), false)
+        UsageTracker::new(true, store, rules, false)
     }
 
     #[tokio::test]
@@ -671,7 +655,7 @@ mod tests {
             }],
         };
         let rules = config.build_rules().unwrap();
-        UsageTracker::new(true, store, rules, HashSet::new(), false)
+        UsageTracker::new(true, store, rules, false)
     }
 
     #[tokio::test]
@@ -797,7 +781,7 @@ mod tests {
             rules: vec![], // No rules = unlimited
         };
         let rules = config.build_rules().unwrap();
-        let tracker = UsageTracker::new(true, store, rules, HashSet::new(), false);
+        let tracker = UsageTracker::new(true, store, rules, false);
 
         let user_id = "test-user-unlimited".to_string();
 
@@ -834,7 +818,7 @@ mod tests {
         };
 
         let rules = config.build_rules().unwrap();
-        let tracker = UsageTracker::new(true, store, rules, HashSet::new(), false);
+        let tracker = UsageTracker::new(true, store, rules, false);
 
         let user_id = "test-user-multiple-rules".to_string();
         // Use realistic timestamp (current time) so expiry calculations work correctly
@@ -961,6 +945,87 @@ mod tests {
             .contains("Usage limiter unavailable and fallback disabled"));
     }
 
+    #[tokio::test]
+    async fn test_usage_limit_binds_to_selected_signer_not_first_message_signer() {
+        let store: Arc<dyn UsageStore> = Arc::new(InMemoryUsageStore::new());
+        let rules = UsageLimitConfig {
+            enabled: true,
+            cache_url: None,
+            fallback_if_unavailable: false,
+            rules: vec![UsageLimitRuleConfig::Instruction {
+                program: solana_system_interface::program::ID.to_string(),
+                instruction: "CreateAccount".to_string(),
+                max: 3,
+                window_seconds: None,
+            }],
+        }
+        .build_rules()
+        .unwrap();
+        let tracker = UsageTracker::new(true, store, rules, false);
+
+        let config = ConfigMockBuilder::new().build();
+        let rpc_client = RpcMockBuilder::new().build();
+
+        // signer_a is the message fee payer (first signer slot); signer_b funds the CreateAccount
+        // and is the signer Kora is asked to sign with.
+        let signer_a = Keypair::new();
+        let signer_b = Keypair::new();
+        let new_account = Keypair::new();
+
+        let build_tx = || {
+            let create_ix = solana_system_interface::instruction::create_account(
+                &signer_b.pubkey(),
+                &new_account.pubkey(),
+                1_000_000,
+                0,
+                &solana_system_interface::program::ID,
+            );
+            let message = Message::new(&[create_ix], Some(&signer_a.pubkey()));
+            TransactionUtil::new_unsigned_versioned_transaction_resolved(VersionedMessage::Legacy(
+                message,
+            ))
+            .unwrap()
+        };
+
+        // Selecting signer_b binds counting to signer_b: its CreateAccount is subsidized, so the
+        // 4th request trips the limit.
+        for attempt in 1..=3 {
+            let mut tx = build_tx();
+            tracker
+                .check_transaction(
+                    &config,
+                    &mut tx,
+                    Some("user-b"),
+                    &signer_b.pubkey(),
+                    &rpc_client,
+                )
+                .await
+                .unwrap_or_else(|e| panic!("request #{attempt} for signer_b should pass: {e}"));
+        }
+        let mut tx = build_tx();
+        let err = tracker
+            .check_transaction(&config, &mut tx, Some("user-b"), &signer_b.pubkey(), &rpc_client)
+            .await
+            .expect_err("4th request for signer_b must exceed the CreateAccount limit");
+        assert!(matches!(err, KoraError::UsageLimitExceeded(_)));
+
+        // Selecting signer_a (the first message signer) does not subsidize the CreateAccount whose
+        // payer is signer_b, so accounting stays at zero and the limit is never reached.
+        for attempt in 1..=5 {
+            let mut tx = build_tx();
+            tracker
+                .check_transaction(
+                    &config,
+                    &mut tx,
+                    Some("user-a"),
+                    &signer_a.pubkey(),
+                    &rpc_client,
+                )
+                .await
+                .unwrap_or_else(|e| panic!("request #{attempt} for signer_a should pass: {e}"));
+        }
+    }
+
     fn create_mock_spl_multisig_account(
         required_signers: u8,
         signer_pubkeys: &[Pubkey],
@@ -1025,7 +1090,7 @@ mod tests {
     #[tokio::test]
     async fn test_extract_user_unsigned_owner_returns_none() {
         let store = Arc::new(InMemoryUsageStore::new());
-        let tracker = UsageTracker::new(true, store, vec![], HashSet::new(), false);
+        let tracker = UsageTracker::new(true, store, vec![], false);
 
         let fee_payer = Keypair::new();
         let victim_owner = Keypair::new();
@@ -1059,7 +1124,7 @@ mod tests {
     #[tokio::test]
     async fn test_extract_user_signed_owner_returns_owner() {
         let store = Arc::new(InMemoryUsageStore::new());
-        let tracker = UsageTracker::new(true, store, vec![], HashSet::new(), false);
+        let tracker = UsageTracker::new(true, store, vec![], false);
 
         let fee_payer = Keypair::new();
         let owner = Keypair::new();
@@ -1095,7 +1160,7 @@ mod tests {
     #[tokio::test]
     async fn test_extract_user_delegated_transfer_returns_source_owner_not_delegate() {
         let store = Arc::new(InMemoryUsageStore::new());
-        let tracker = UsageTracker::new(true, store, vec![], HashSet::new(), false);
+        let tracker = UsageTracker::new(true, store, vec![], false);
 
         let fee_payer = Keypair::new();
         let source_owner = Pubkey::new_unique();
@@ -1135,7 +1200,7 @@ mod tests {
     #[tokio::test]
     async fn test_extract_user_multisig_owner_returns_owner_when_threshold_is_met() {
         let store = Arc::new(InMemoryUsageStore::new());
-        let tracker = UsageTracker::new(true, store, vec![], HashSet::new(), false);
+        let tracker = UsageTracker::new(true, store, vec![], false);
 
         let fee_payer = Keypair::new();
         let signer_one = Keypair::new();
@@ -1181,7 +1246,7 @@ mod tests {
     #[tokio::test]
     async fn test_extract_user_multisig_owner_returns_none_when_threshold_is_not_met() {
         let store = Arc::new(InMemoryUsageStore::new());
-        let tracker = UsageTracker::new(true, store, vec![], HashSet::new(), false);
+        let tracker = UsageTracker::new(true, store, vec![], false);
 
         let fee_payer = Keypair::new();
         let signer_one = Keypair::new();
@@ -1231,7 +1296,7 @@ mod tests {
             rules: vec![UsageLimitRuleConfig::Transaction { max, window_seconds: None }],
         };
         let rules = config.build_rules().unwrap();
-        let tracker = Arc::new(UsageTracker::new(true, store, rules, HashSet::new(), false));
+        let tracker = Arc::new(UsageTracker::new(true, store, rules, false));
         let user_id = "concurrent-user".to_string();
         let mut handles = Vec::new();
 
@@ -1273,8 +1338,7 @@ mod tests {
             ],
         };
         let rules = config.build_rules().unwrap();
-        let tracker =
-            Arc::new(UsageTracker::new(true, store.clone(), rules, HashSet::new(), false));
+        let tracker = Arc::new(UsageTracker::new(true, store.clone(), rules, false));
         let user_id = "multi-rule-concurrent-user".to_string();
         let mut handles = Vec::new();
 

--- a/crates/lib/src/validator/transaction_validator.rs
+++ b/crates/lib/src/validator/transaction_validator.rs
@@ -306,8 +306,21 @@ impl TransactionValidator {
             self.fee_payer_policy.system.allow_transfer, "System Transfer");
 
         validate_system!(self, system_instructions, SystemAssign,
-            ParsedSystemInstructionData::SystemAssign { authority } => authority,
-            self.fee_payer_policy.system.allow_assign, "System Assign");
+        ParsedSystemInstructionData::SystemAssign { authority, owner } => authority,
+        self.fee_payer_policy.system.allow_assign, "System Assign", {
+            if !self.allow_all_programs && !self.allowed_programs.contains(owner) {
+                return Err(KoraError::InvalidTransaction(format!(
+                    "Assign owner program {} is not in the allowed programs list",
+                    owner
+                )));
+            }
+            if self.disallowed_accounts.contains(owner) {
+                return Err(KoraError::InvalidTransaction(format!(
+                    "Assign owner program {} is in the disallowed accounts list",
+                    owner
+                )));
+            }
+        });
 
         validate_system!(self, system_instructions, SystemAllocate,
             ParsedSystemInstructionData::SystemAllocate { account } => account,
@@ -1769,7 +1782,8 @@ mod tests {
     #[serial]
     async fn test_fee_payer_policy_assign() {
         let fee_payer = Pubkey::new_unique();
-        let new_owner = Pubkey::new_unique();
+        // Owner must be in the allowed programs list; the test config allows the System program.
+        let new_owner = SYSTEM_PROGRAM_ID;
 
         // Test with allow_assign = true
 
@@ -1803,6 +1817,69 @@ mod tests {
         let validator = TransactionValidator::new(config, fee_payer).unwrap();
 
         let instruction = assign(&fee_payer, &new_owner);
+        let message = VersionedMessage::Legacy(Message::new(&[instruction], Some(&fee_payer)));
+        let mut transaction =
+            TransactionUtil::new_unsigned_versioned_transaction_resolved(message).unwrap();
+        assert!(validator
+            .validate_transaction(config, &mut transaction, &rpc_client)
+            .await
+            .is_err());
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_fee_payer_policy_assign_rejects_off_policy_owner() {
+        use solana_system_interface::instruction::assign_with_seed;
+
+        let fee_payer = Pubkey::new_unique();
+        let off_policy_owner = Pubkey::new_unique();
+        let rpc_client = RpcMockBuilder::new().build();
+
+        let mut policy = FeePayerPolicy::default();
+        policy.system.allow_assign = true;
+
+        // allow_assign is true, but an owner outside the allowed programs list is still rejected.
+        setup_config_with_policy(policy.clone());
+        let config = get_config().unwrap();
+        let validator = TransactionValidator::new(config, fee_payer).unwrap();
+
+        let instruction = assign(&fee_payer, &off_policy_owner);
+        let message = VersionedMessage::Legacy(Message::new(&[instruction], Some(&fee_payer)));
+        let mut transaction =
+            TransactionUtil::new_unsigned_versioned_transaction_resolved(message).unwrap();
+        assert!(validator
+            .validate_transaction(config, &mut transaction, &rpc_client)
+            .await
+            .is_err());
+
+        let instruction = assign_with_seed(&fee_payer, &fee_payer, "seed", &off_policy_owner);
+        let message = VersionedMessage::Legacy(Message::new(&[instruction], Some(&fee_payer)));
+        let mut transaction =
+            TransactionUtil::new_unsigned_versioned_transaction_resolved(message).unwrap();
+        assert!(validator
+            .validate_transaction(config, &mut transaction, &rpc_client)
+            .await
+            .is_err());
+
+        // An owner in disallowed_accounts is rejected even when present in allowed_programs.
+        setup_config_with_policy_and_disallowed(
+            policy,
+            vec![SYSTEM_PROGRAM_ID.to_string(), off_policy_owner.to_string()],
+            vec![off_policy_owner.to_string()],
+        );
+        let config = get_config().unwrap();
+        let validator = TransactionValidator::new(config, fee_payer).unwrap();
+
+        let instruction = assign(&fee_payer, &off_policy_owner);
+        let message = VersionedMessage::Legacy(Message::new(&[instruction], Some(&fee_payer)));
+        let mut transaction =
+            TransactionUtil::new_unsigned_versioned_transaction_resolved(message).unwrap();
+        assert!(validator
+            .validate_transaction(config, &mut transaction, &rpc_client)
+            .await
+            .is_err());
+
+        let instruction = assign_with_seed(&fee_payer, &fee_payer, "seed", &off_policy_owner);
         let message = VersionedMessage::Legacy(Message::new(&[instruction], Some(&fee_payer)));
         let mut transaction =
             TransactionUtil::new_unsigned_versioned_transaction_resolved(message).unwrap();

--- a/crates/lib/src/validator/transaction_validator.rs
+++ b/crates/lib/src/validator/transaction_validator.rs
@@ -326,23 +326,30 @@ impl TransactionValidator {
             ParsedSystemInstructionData::SystemAllocate { account } => account,
             self.fee_payer_policy.system.allow_allocate, "System Allocate");
 
-        validate_system!(self, system_instructions, SystemCreateAccount,
-            ParsedSystemInstructionData::SystemCreateAccount { payer, .. } => payer,
-            self.fee_payer_policy.system.allow_create_account, "System Create Account");
-
-        // Prefund lets the fee payer be the account created (bricked), not just the funder above.
-        // Re-run the same policy gate keyed on new_account.
-        validate_system!(self, system_instructions, SystemCreateAccount,
-            ParsedSystemInstructionData::SystemCreateAccount { new_account, .. } => new_account,
-            self.fee_payer_policy.system.allow_create_account, "System Create Account");
-
-        // Owner allowlist/blocklist holds for every CreateAccount owner in a Kora-signed tx, not
-        // only when Kora is the funding payer or the created account.
+        // allow_create_account gates Kora participating as the funder (payer), the seeded base
+        // signer, or the account being created (prefund brick). The owner allowlist/blocklist
+        // holds for every CreateAccount owner in a Kora-signed tx regardless of Kora's role.
         for instruction in system_instructions
             .get(&ParsedSystemInstructionType::SystemCreateAccount)
             .unwrap_or(&vec![])
         {
-            if let ParsedSystemInstructionData::SystemCreateAccount { owner, .. } = instruction {
+            if let ParsedSystemInstructionData::SystemCreateAccount {
+                payer,
+                owner,
+                base,
+                new_account,
+                ..
+            } = instruction
+            {
+                let fee_payer_participates = *payer == self.fee_payer_pubkey
+                    || *base == Some(self.fee_payer_pubkey)
+                    || *new_account == self.fee_payer_pubkey;
+                if fee_payer_participates && !self.fee_payer_policy.system.allow_create_account {
+                    return Err(KoraError::InvalidTransaction(
+                        "Fee payer cannot be used for 'System Create Account'".to_string(),
+                    ));
+                }
+
                 self.validate_create_account_owner(owner)?;
             }
         }
@@ -3457,6 +3464,132 @@ mod tests {
         let result = validator.validate_transaction(config, &mut transaction, &rpc_client).await;
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("not in the allowed programs list"));
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_create_account_with_seed_base_signer_gated_by_allow_create_account() {
+        use solana_system_interface::instruction::create_account_with_seed;
+
+        let fee_payer = Pubkey::new_unique(); // Kora, used only as the seeded base signer
+        let attacker = Pubkey::new_unique(); // the create payer / funder
+        let seed = "seed";
+        let new_account = Pubkey::create_with_seed(&fee_payer, seed, &SYSTEM_PROGRAM_ID).unwrap();
+
+        let rpc_client = RpcMockBuilder::new().build();
+        let mut policy = FeePayerPolicy::default();
+        policy.system.allow_create_account = false;
+        setup_config_with_policy(policy);
+
+        let config = get_config().unwrap();
+        let validator = TransactionValidator::new(config, fee_payer).unwrap();
+
+        // Owner is System (allowed), so the rejection must come from the allow_create_account gate
+        // recognizing Kora as the seeded base signer, not from the owner allowlist.
+        let instruction = create_account_with_seed(
+            &attacker,
+            &new_account,
+            &fee_payer,
+            seed,
+            1000,
+            0,
+            &SYSTEM_PROGRAM_ID,
+        );
+        let message = VersionedMessage::Legacy(Message::new(&[instruction], Some(&fee_payer)));
+        let mut transaction =
+            TransactionUtil::new_unsigned_versioned_transaction_resolved(message).unwrap();
+
+        let result = validator.validate_transaction(config, &mut transaction, &rpc_client).await;
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("Fee payer cannot be used for 'System Create Account'"));
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_create_account_with_seed_base_read_from_instruction_data() {
+        let fee_payer = Pubkey::new_unique(); // Kora, the seeded base in the instruction data
+        let attacker = Pubkey::new_unique(); // the create payer / funder
+        let decoy = Pubkey::new_unique();
+        let seed = "seed";
+        let new_account = Pubkey::create_with_seed(&fee_payer, seed, &SYSTEM_PROGRAM_ID).unwrap();
+
+        let rpc_client = RpcMockBuilder::new().build();
+        let mut policy = FeePayerPolicy::default();
+        policy.system.allow_create_account = false;
+        setup_config_with_policy(policy);
+
+        let config = get_config().unwrap();
+        let validator = TransactionValidator::new(config, fee_payer).unwrap();
+
+        // The authoritative base lives in the instruction data. A decoy sits at the account slot
+        // a positional gate would read, with Kora referenced as a signer elsewhere — the runtime
+        // accepts this (base is a signer at any index), so the gate must key off the data base.
+        let instruction = Instruction::new_with_bincode(
+            SYSTEM_PROGRAM_ID,
+            &solana_system_interface::instruction::SystemInstruction::CreateAccountWithSeed {
+                base: fee_payer,
+                seed: seed.to_string(),
+                lamports: 1000,
+                space: 0,
+                owner: SYSTEM_PROGRAM_ID,
+            },
+            vec![
+                AccountMeta::new(attacker, true),
+                AccountMeta::new(new_account, false),
+                AccountMeta::new_readonly(decoy, false),
+                AccountMeta::new_readonly(fee_payer, true),
+            ],
+        );
+        let message = VersionedMessage::Legacy(Message::new(&[instruction], Some(&fee_payer)));
+        let mut transaction =
+            TransactionUtil::new_unsigned_versioned_transaction_resolved(message).unwrap();
+
+        let result = validator.validate_transaction(config, &mut transaction, &rpc_client).await;
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("Fee payer cannot be used for 'System Create Account'"));
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_create_account_with_seed_base_equals_from_two_accounts_allowed() {
+        let fee_payer = Pubkey::new_unique(); // Kora, does not participate
+        let from = Pubkey::new_unique();
+        let seed = "seed";
+        let new_account = Pubkey::create_with_seed(&from, seed, &SYSTEM_PROGRAM_ID).unwrap();
+
+        let rpc_client = RpcMockBuilder::new().build();
+        let mut policy = FeePayerPolicy::default();
+        policy.system.allow_create_account = false;
+        setup_config_with_policy(policy);
+
+        let config = get_config().unwrap();
+        let validator = TransactionValidator::new(config, fee_payer).unwrap();
+
+        // base == from, so the runtime accepts two accounts (no separate base meta). Kora is
+        // neither payer, base, nor the created account, so validation must pass.
+        let instruction = Instruction::new_with_bincode(
+            SYSTEM_PROGRAM_ID,
+            &solana_system_interface::instruction::SystemInstruction::CreateAccountWithSeed {
+                base: from,
+                seed: seed.to_string(),
+                lamports: 1000,
+                space: 0,
+                owner: SYSTEM_PROGRAM_ID,
+            },
+            vec![AccountMeta::new(from, true), AccountMeta::new(new_account, false)],
+        );
+        let message = VersionedMessage::Legacy(Message::new(&[instruction], Some(&fee_payer)));
+        let mut transaction =
+            TransactionUtil::new_unsigned_versioned_transaction_resolved(message).unwrap();
+
+        let result = validator.validate_transaction(config, &mut transaction, &rpc_client).await;
+        assert!(result.is_ok(), "expected Ok, got {:?}", result);
     }
 
     #[tokio::test]

--- a/crates/lib/src/validator/transaction_validator.rs
+++ b/crates/lib/src/validator/transaction_validator.rs
@@ -327,18 +327,25 @@ impl TransactionValidator {
             self.fee_payer_policy.system.allow_allocate, "System Allocate");
 
         validate_system!(self, system_instructions, SystemCreateAccount,
-        ParsedSystemInstructionData::SystemCreateAccount { payer, owner, .. } => payer,
-        self.fee_payer_policy.system.allow_create_account, "System Create Account", {
-            self.validate_create_account_owner(owner)?;
-        });
+            ParsedSystemInstructionData::SystemCreateAccount { payer, .. } => payer,
+            self.fee_payer_policy.system.allow_create_account, "System Create Account");
 
         // Prefund lets the fee payer be the account created (bricked), not just the funder above.
-        // Re-run the same gate keyed on new_account.
+        // Re-run the same policy gate keyed on new_account.
         validate_system!(self, system_instructions, SystemCreateAccount,
-        ParsedSystemInstructionData::SystemCreateAccount { new_account, owner, .. } => new_account,
-        self.fee_payer_policy.system.allow_create_account, "System Create Account", {
-            self.validate_create_account_owner(owner)?;
-        });
+            ParsedSystemInstructionData::SystemCreateAccount { new_account, .. } => new_account,
+            self.fee_payer_policy.system.allow_create_account, "System Create Account");
+
+        // Owner allowlist/blocklist holds for every CreateAccount owner in a Kora-signed tx, not
+        // only when Kora is the funding payer or the created account.
+        for instruction in system_instructions
+            .get(&ParsedSystemInstructionType::SystemCreateAccount)
+            .unwrap_or(&vec![])
+        {
+            if let ParsedSystemInstructionData::SystemCreateAccount { owner, .. } = instruction {
+                self.validate_create_account_owner(owner)?;
+            }
+        }
 
         validate_system!(self, system_instructions, SystemInitializeNonceAccount,
             ParsedSystemInstructionData::SystemInitializeNonceAccount { nonce_authority, .. } => nonce_authority,
@@ -3411,6 +3418,45 @@ mod tests {
             .validate_transaction(config, &mut transaction, &rpc_client)
             .await
             .is_ok());
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_create_account_with_seed_owner_checked_when_kora_is_not_create_payer() {
+        use solana_system_interface::instruction::create_account_with_seed;
+
+        let fee_payer = Pubkey::new_unique(); // Kora, the sponsor / signer
+        let attacker = Pubkey::new_unique(); // the CreateAccountWithSeed `from`/payer, not Kora
+        let base = Pubkey::new_unique();
+        let new_account = Pubkey::new_unique();
+        let off_policy_owner = Pubkey::new_unique();
+
+        let rpc_client = RpcMockBuilder::new().build();
+        let mut policy = FeePayerPolicy::default();
+        policy.system.allow_create_account = true;
+        setup_config_with_policy(policy);
+
+        let config = get_config().unwrap();
+        let validator = TransactionValidator::new(config, fee_payer).unwrap();
+
+        // Kora sponsors a CreateAccountWithSeed funded by the attacker. The owner must still be
+        // checked even though Kora is not the create payer.
+        let instruction = create_account_with_seed(
+            &attacker,
+            &new_account,
+            &base,
+            "seed",
+            1000,
+            100,
+            &off_policy_owner,
+        );
+        let message = VersionedMessage::Legacy(Message::new(&[instruction], Some(&fee_payer)));
+        let mut transaction =
+            TransactionUtil::new_unsigned_versioned_transaction_resolved(message).unwrap();
+
+        let result = validator.validate_transaction(config, &mut transaction, &rpc_client).await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("not in the allowed programs list"));
     }
 
     #[tokio::test]

--- a/crates/lib/src/validator/transaction_validator.rs
+++ b/crates/lib/src/validator/transaction_validator.rs
@@ -889,7 +889,9 @@ impl TransactionValidator {
             }
 
             if let Some(extension_type) = instruction.extension_type {
-                if config.validation.token_2022.is_mint_extension_blocked(extension_type) {
+                if config.validation.token_2022.is_mint_extension_blocked(extension_type)
+                    || config.validation.token_2022.is_account_extension_blocked(extension_type)
+                {
                     return Err(KoraError::InvalidTransaction(format!(
                         "Token2022 instruction '{}' is not allowed because extension '{extension_type:?}' is blocked",
                         instruction.instruction_name
@@ -5623,6 +5625,131 @@ mod tests {
             matches!(result, Err(KoraError::InvalidTransaction(ref msg)) if msg.contains("extension 'MetadataPointer' is blocked")),
             "Expected blocked metadata pointer extension rejection, got: {result:?}"
         );
+    }
+
+    async fn assert_blocked_token2022_extension_rejected(
+        instruction: solana_sdk::instruction::Instruction,
+        block_account_extensions: Vec<String>,
+        block_mint_extensions: Vec<String>,
+        expected_extension: &str,
+    ) {
+        let fee_payer = Keypair::new();
+        let rpc_client = RpcMockBuilder::new().build();
+        let mut config = ConfigMockBuilder::new().build();
+        config.validation.allowed_programs =
+            ProgramsConfig::Allowlist(vec![spl_token_2022_interface::id().to_string()]);
+        config.validation.token_2022.blocked_account_extensions = block_account_extensions;
+        config.validation.token_2022.blocked_mint_extensions = block_mint_extensions;
+        config.validation.token_2022.initialize().unwrap();
+
+        let validator = TransactionValidator::new(&config, fee_payer.pubkey()).unwrap();
+
+        // Fee payer is deliberately not one of the instruction accounts, so the rejection must
+        // come from the blocked-extension check rather than the fee-payer-presence check.
+        let message =
+            VersionedMessage::Legacy(Message::new(&[instruction], Some(&fee_payer.pubkey())));
+        let mut transaction =
+            TransactionUtil::new_unsigned_versioned_transaction_resolved(message).unwrap();
+
+        let result = validator.validate_transaction(&config, &mut transaction, &rpc_client).await;
+        let expected = format!("extension '{expected_extension}' is blocked");
+        assert!(
+            matches!(result, Err(KoraError::InvalidTransaction(ref msg)) if msg.contains(&expected)),
+            "Expected blocked {expected_extension} rejection, got: {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_token2022_memo_transfer_rejects_blocked_account_extension() {
+        let instruction =
+            spl_token_2022_interface::extension::memo_transfer::instruction::enable_required_transfer_memos(
+                &spl_token_2022_interface::id(),
+                &Pubkey::new_unique(),
+                &Pubkey::new_unique(),
+                &[],
+            )
+            .unwrap();
+        assert_blocked_token2022_extension_rejected(
+            instruction,
+            vec!["memo_transfer".to_string()],
+            vec![],
+            "MemoTransfer",
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_token2022_cpi_guard_rejects_blocked_account_extension() {
+        let instruction =
+            spl_token_2022_interface::extension::cpi_guard::instruction::enable_cpi_guard(
+                &spl_token_2022_interface::id(),
+                &Pubkey::new_unique(),
+                &Pubkey::new_unique(),
+                &[],
+            )
+            .unwrap();
+        assert_blocked_token2022_extension_rejected(
+            instruction,
+            vec!["cpi_guard".to_string()],
+            vec![],
+            "CpiGuard",
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_token2022_immutable_owner_rejects_blocked_account_extension() {
+        let instruction = spl_token_2022_interface::instruction::initialize_immutable_owner(
+            &spl_token_2022_interface::id(),
+            &Pubkey::new_unique(),
+        )
+        .unwrap();
+        assert_blocked_token2022_extension_rejected(
+            instruction,
+            vec!["immutable_owner".to_string()],
+            vec![],
+            "ImmutableOwner",
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_token2022_non_transferable_rejects_blocked_mint_extension() {
+        let instruction = spl_token_2022_interface::instruction::initialize_non_transferable_mint(
+            &spl_token_2022_interface::id(),
+            &Pubkey::new_unique(),
+        )
+        .unwrap();
+        assert_blocked_token2022_extension_rejected(
+            instruction,
+            vec![],
+            vec!["non_transferable".to_string()],
+            "NonTransferable",
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_token2022_default_account_state_rejects_blocked_mint_extension() {
+        let instruction =
+            spl_token_2022_interface::extension::default_account_state::instruction::initialize_default_account_state(
+                &spl_token_2022_interface::id(),
+                &Pubkey::new_unique(),
+                &spl_token_2022_interface::state::AccountState::Frozen,
+            )
+            .unwrap();
+        assert_blocked_token2022_extension_rejected(
+            instruction,
+            vec!["default_account_state".to_string()],
+            vec![],
+            "DefaultAccountState",
+        )
+        .await;
     }
 
     #[tokio::test]

--- a/crates/lib/src/validator/transaction_validator.rs
+++ b/crates/lib/src/validator/transaction_validator.rs
@@ -368,7 +368,7 @@ impl TransactionValidator {
                 "SPL Token Burn", "Token2022 Token Burn");
 
             validate_spl!(self, spl_instructions, SplTokenCloseAccount,
-                ParsedSPLInstructionData::SplTokenCloseAccount { owner, multisig_signers, is_2022 } => { owner, multisig_signers, is_2022 },
+                ParsedSPLInstructionData::SplTokenCloseAccount { owner, multisig_signers, is_2022, .. } => { owner, multisig_signers, is_2022 },
                 self.fee_payer_policy.spl_token.allow_close_account,
                 self.fee_payer_policy.token_2022.allow_close_account,
                 "SPL Token Close Account", "Token2022 Token Close Account");
@@ -2502,6 +2502,48 @@ mod tests {
 
     #[tokio::test]
     #[serial]
+    async fn test_close_account_rent_above_max_allowed_lamports_rejected() {
+        let fee_payer = Pubkey::new_unique();
+        let closed_account = Pubkey::new_unique();
+        let recipient = Pubkey::new_unique();
+        let rent_account = AccountMockBuilder::new().with_lamports(2_000_000).build();
+
+        let mut policy = FeePayerPolicy::default();
+        policy.token_2022.allow_close_account = true;
+        let config = ConfigMockBuilder::new()
+            .with_price_source(PriceSource::Mock)
+            .with_allowed_programs(vec![spl_token_2022_interface::id().to_string()])
+            .with_max_allowed_lamports(1_000_000)
+            .with_fee_payer_policy(policy)
+            .build();
+        setup_both_configs(config);
+
+        let rpc_client = RpcMockBuilder::new().with_account_info(&rent_account).build();
+        let config = get_config().unwrap();
+        let validator = TransactionValidator::new(config, fee_payer).unwrap();
+
+        let close_ix = spl_token_2022_interface::instruction::close_account(
+            &spl_token_2022_interface::id(),
+            &closed_account,
+            &recipient,
+            &fee_payer,
+            &[],
+        )
+        .unwrap();
+        let message = VersionedMessage::Legacy(Message::new(&[close_ix], Some(&fee_payer)));
+        let mut transaction =
+            TransactionUtil::new_unsigned_versioned_transaction_resolved(message).unwrap();
+
+        let result = validator.validate_transaction(config, &mut transaction, &rpc_client).await;
+        assert!(matches!(
+            result,
+            Err(KoraError::InvalidTransaction(message))
+                if message.contains("Total transfer amount 2000000 exceeds maximum allowed 1000000")
+        ));
+    }
+
+    #[tokio::test]
+    #[serial]
     async fn test_calculate_total_outflow() {
         let fee_payer = Pubkey::new_unique();
         let config = ConfigMockBuilder::new()
@@ -2768,7 +2810,8 @@ mod tests {
 
         // Test with allow_close_account = true
 
-        let rpc_client = RpcMockBuilder::new().build();
+        let closed_account = AccountMockBuilder::new().with_lamports(5_000).build();
+        let rpc_client = RpcMockBuilder::new().with_account_info(&closed_account).build();
         let mut policy = FeePayerPolicy::default();
         policy.spl_token.allow_close_account = true;
         setup_spl_config_with_policy(policy);
@@ -2788,7 +2831,7 @@ mod tests {
         let message = VersionedMessage::Legacy(Message::new(&[close_ix], Some(&fee_payer)));
         let mut transaction =
             TransactionUtil::new_unsigned_versioned_transaction_resolved(message).unwrap();
-        // Should pass because allow_close_account is true by default
+        // Should pass because allow_close_account is true and the rent is within max_allowed_lamports
         assert!(validator
             .validate_transaction(config, &mut transaction, &rpc_client)
             .await

--- a/crates/lib/src/validator/transaction_validator.rs
+++ b/crates/lib/src/validator/transaction_validator.rs
@@ -306,21 +306,27 @@ impl TransactionValidator {
             self.fee_payer_policy.system.allow_transfer, "System Transfer");
 
         validate_system!(self, system_instructions, SystemAssign,
-        ParsedSystemInstructionData::SystemAssign { authority, owner } => authority,
-        self.fee_payer_policy.system.allow_assign, "System Assign", {
-            if !self.allow_all_programs && !self.allowed_programs.contains(owner) {
-                return Err(KoraError::InvalidTransaction(format!(
-                    "Assign owner program {} is not in the allowed programs list",
-                    owner
-                )));
+            ParsedSystemInstructionData::SystemAssign { authority, .. } => authority,
+            self.fee_payer_policy.system.allow_assign, "System Assign");
+
+        // The owner allowlist/disallowed check holds for every Assign owner in a Kora-signed tx,
+        // not only when the fee payer is the reassigned account (parity with CreateAccount).
+        for instruction in
+            system_instructions.get(&ParsedSystemInstructionType::SystemAssign).unwrap_or(&vec![])
+        {
+            if let ParsedSystemInstructionData::SystemAssign { owner, .. } = instruction {
+                if !self.allow_all_programs && !self.allowed_programs.contains(owner) {
+                    return Err(KoraError::InvalidTransaction(format!(
+                        "Assign owner program {owner} is not in the allowed programs list"
+                    )));
+                }
+                if self.disallowed_accounts.contains(owner) {
+                    return Err(KoraError::InvalidTransaction(format!(
+                        "Assign owner program {owner} is in the disallowed accounts list"
+                    )));
+                }
             }
-            if self.disallowed_accounts.contains(owner) {
-                return Err(KoraError::InvalidTransaction(format!(
-                    "Assign owner program {} is in the disallowed accounts list",
-                    owner
-                )));
-            }
-        });
+        }
 
         validate_system!(self, system_instructions, SystemAllocate,
             ParsedSystemInstructionData::SystemAllocate { account } => account,
@@ -1896,6 +1902,50 @@ mod tests {
             .is_err());
 
         let instruction = assign_with_seed(&fee_payer, &fee_payer, "seed", &off_policy_owner);
+        let message = VersionedMessage::Legacy(Message::new(&[instruction], Some(&fee_payer)));
+        let mut transaction =
+            TransactionUtil::new_unsigned_versioned_transaction_resolved(message).unwrap();
+        assert!(validator
+            .validate_transaction(config, &mut transaction, &rpc_client)
+            .await
+            .is_err());
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_assign_owner_checked_when_reassigned_account_is_not_fee_payer() {
+        let fee_payer = Pubkey::new_unique();
+        let other_account = Pubkey::new_unique(); // reassigned account, not Kora
+        let off_policy_owner = Pubkey::new_unique();
+        let rpc_client = RpcMockBuilder::new().build();
+
+        // allow_assign is true and the fee payer is not the reassigned account, but the owner
+        // is outside the allowlist, so Kora must still refuse to sponsor the assignment.
+        let mut policy = FeePayerPolicy::default();
+        policy.system.allow_assign = true;
+        setup_config_with_policy(policy.clone());
+        let config = get_config().unwrap();
+        let validator = TransactionValidator::new(config, fee_payer).unwrap();
+
+        let instruction = assign(&other_account, &off_policy_owner);
+        let message = VersionedMessage::Legacy(Message::new(&[instruction], Some(&fee_payer)));
+        let mut transaction =
+            TransactionUtil::new_unsigned_versioned_transaction_resolved(message).unwrap();
+        assert!(validator
+            .validate_transaction(config, &mut transaction, &rpc_client)
+            .await
+            .is_err());
+
+        // Same for an owner in disallowed_accounts, even when it is allowlisted.
+        setup_config_with_policy_and_disallowed(
+            policy,
+            vec![SYSTEM_PROGRAM_ID.to_string(), off_policy_owner.to_string()],
+            vec![off_policy_owner.to_string()],
+        );
+        let config = get_config().unwrap();
+        let validator = TransactionValidator::new(config, fee_payer).unwrap();
+
+        let instruction = assign(&other_account, &off_policy_owner);
         let message = VersionedMessage::Legacy(Message::new(&[instruction], Some(&fee_payer)));
         let mut transaction =
             TransactionUtil::new_unsigned_versioned_transaction_resolved(message).unwrap();

--- a/tests/fee_payer_policy/fee_payer_policy_violations.rs
+++ b/tests/fee_payer_policy/fee_payer_policy_violations.rs
@@ -284,10 +284,12 @@ async fn test_close_account_policy_violation() {
         .await
         .expect("Failed to create token account");
 
+    // Close back to the fee payer (outflow-neutral) so this isolates the allow_close_account
+    // policy check; a close to a third party would trip max_allowed_lamports on the rent first.
     let close_account_instruction = token_instruction::close_account(
         &spl_token_interface::id(),
         &fee_payer_token_account.pubkey(),
-        &setup.recipient_pubkey,
+        &setup.fee_payer_keypair.pubkey(),
         &setup.fee_payer_keypair.pubkey(),
         &[&setup.fee_payer_keypair.pubkey()],
     )


### PR DESCRIPTION
Hardens several transaction-validation and fee-accounting paths. Each commit is a self-contained, individually reviewable fix.

Coverage:
- V0 lookup-table address resolution ordering and index preservation (incl. Lighthouse append)
- CloseAccount and ExtendProgram rent counted in fee-payer outflow accounting
- System Assign and CreateAccount owner-allowlist / disallowed-account enforcement
- CreateAccountWithSeed base-signer gating (base read from instruction data)
- Usage-limit keying by source token-account owner and the request-selected signer
- Faithful reconstruction of inner SPL CPIs so fee-payer policy gates run
- Token-2022 extension-init blocklist enforcement (mint and account extensions)

See individual commit messages for the specific defect and fix in each area.