### PR TITLE
chore: release v2.2.0-beta.8

### DIFF
--- a/.github/cliff.toml
+++ b/.github/cliff.toml
@@ -18,9 +18,17 @@ body = """
 trim = true
 
 [git]
+tag_pattern = "^v[0-9]"
 conventional_commits = true
 filter_unconventional = true
+commit_preprocessors = [
+  # Strip issue IDs from changelog entries; they live in historical commit subjects only.
+  { pattern = "\\s*\\(KORA-[0-9/]+\\)", replace = "" },
+]
 commit_parsers = [
+  # Skip housekeeping and non-library scopes regardless of type: dependency bumps and CI/build
+  # tweaks land as fix(deps)/fix(ci), and kora-deploy/examples aren't kora-lib/kora-cli changes.
+  { message = "^\\w+\\((deps(-dev)?|ci|build|kora-deploy|devnet-deploy-paymaster|examples)\\)", skip = true },
   { message = "^feat", group = "Features" },
   { message = "^fix", group = "Bug Fixes" },
   { message = "^perf", group = "Performance" },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,56 +7,17 @@
 
 - bundle-aware fee estimation for cross-leg ATA creation (#606)
 
-- restore pnpm vulnerability audit (#612)
-
 - make multi-rule limit enforcement all-or-nothing (#571)
 
 - align fee estimation and config validation with runtime behavior (#603)
 
 - startup and config hardening (auth flags, usage-limit rules, signer pool, transfer-hook warning) (#602)
 
-
-### Features
-
-- reject unknown keys in kora.toml via deny_unknown_fields (#609)
-
-- batch-fetch and cache address lookup tables for V0 transactions (#565)
-
-## kora-deploy-v0.1.0 - 2026-07-09
-
-
-### Bug Fixes
-
-- bump crossbeam-epoch to 0.9.20 to resolve RUSTSEC-2026-0204 (#598)
-
 - support mint-level setAuthority in CPI inner instruction reconstruction (#589)
-
-
-### Features
-
-- support p-token batch and lamport instructions (#591)
-
-- add registry-gated program upgrades (#592)
-
-
-### Testing
-
-- fix flaky unit tests (config-mock and metrics-registry races) (#600)
-
-## ts-sdk-v0.3.0-beta.2 - 2026-06-30
-
-
-### Bug Fixes
 
 - move @solana/kit integration to a /kit subpath so the main entry bundles (#581)
 
-- bump quinn-proto to 0.11.15 for RUSTSEC-2026-0185 (#576)
-
 - pin Docker builder to bookworm to match runtime glibc (#575)
-
-- bump builder to rust 1.91 (#574)
-
-- bump builder to rust 1.89 (#573)
 
 - exit with status 1 on config validation failure (#567)
 
@@ -71,12 +32,6 @@
 - harden deploy_authority against further fee-payer drains (#542)
 
 - guard fee-payer-funded CreateAccount to loader-owned accounts (#541)
-
-- base64+data_slice reaper RPC + smoke-test.sh --bin (#537)
-
-- exec-form ENTRYPOINT + deploy_target input (#536)
-
-- build reaper image via cargo install --git (#535)
 
 - skip empty key vars (#469)
 
@@ -100,15 +55,15 @@
 
 - derive Token-2022 payment ATAs with correct program id (#443)
 
-- increase probe lease to 60s to cover worst-case signing (KORA-25) (#441)
+- increase probe lease to 60s to cover worst-case signing (#441)
 
-- simulate bundle sequentially before signing when sig_verify=false (KORA-21) (#439)
+- simulate bundle sequentially before signing when sig_verify=false (#439)
 
-- warn on unvalidated programs in allowed_programs (KORA-14/15/16) (#433)
+- warn on unvalidated programs in allowed_programs (#433)
 
-- verify payment owner is a signer before quota attribution (KORA-19) (#440)
+- verify payment owner is a signer before quota attribution (#440)
 
-- track nonce withdrawal outflow when fee payer is authority (KORA-12) (#435)
+- track nonce withdrawal outflow when fee payer is authority (#435)
 
 - reject token decimals > 19 to prevent overflow in fee calculation (#432)
 
@@ -126,16 +81,16 @@
 
 - bypass cache for payment-critical account reads (#418)
 
-- pin crates.io auth action to valid commit (#410)
-
-- wire trusted publishing token into cargo publish (#409)
-
 
 ### Features
 
-- support CreateAccountAllowPrefund instruction (#578)
+- reject unknown keys in kora.toml via deny_unknown_fields (#609)
 
-- add devnet paymaster Databricks dashboard (#564)
+- batch-fetch and cache address lookup tables for V0 transactions (#565)
+
+- support p-token batch and lamport instructions (#591)
+
+- support CreateAccountAllowPrefund instruction (#578)
 
 - expose HTTP timeout configuration for remote signer providers (#530)
 
@@ -143,13 +98,7 @@
 
 - extend CreateAccount pairing guard to loader-v4 (#549)
 
-- reap orphan loader-v3 buffers (#548)
-
-- add devnet deployer verification suite (#544)
-
 - structured numeric RPC error codes (#424)
-
-- add inactive-program reaper (#534)
 
 - cross-cluster mint validation (#464)
 
@@ -172,12 +121,9 @@
 - add docker compose for 1-click facilitator deploy (#414)
 
 
-### Refactoring
-
-- extract deploy lib, add kora-deploy CLI (#539)
-
-
 ### Testing
+
+- fix flaky unit tests (config-mock and metrics-registry races) (#600)
 
 - speed up integration runner, measure integration coverage, extend CI matrix (#557)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,188 @@
+## 2.2.0-beta.8 - 2026-07-29
+
+
+### Bug Fixes
+
+- security hardening for transaction validation and fee-payer accounting (#620)
+
+- bundle-aware fee estimation for cross-leg ATA creation (#606)
+
+- restore pnpm vulnerability audit (#612)
+
+- make multi-rule limit enforcement all-or-nothing (#571)
+
+- align fee estimation and config validation with runtime behavior (#603)
+
+- startup and config hardening (auth flags, usage-limit rules, signer pool, transfer-hook warning) (#602)
+
+
+### Features
+
+- reject unknown keys in kora.toml via deny_unknown_fields (#609)
+
+- batch-fetch and cache address lookup tables for V0 transactions (#565)
+
+## kora-deploy-v0.1.0 - 2026-07-09
+
+
+### Bug Fixes
+
+- bump crossbeam-epoch to 0.9.20 to resolve RUSTSEC-2026-0204 (#598)
+
+- support mint-level setAuthority in CPI inner instruction reconstruction (#589)
+
+
+### Features
+
+- support p-token batch and lamport instructions (#591)
+
+- add registry-gated program upgrades (#592)
+
+
+### Testing
+
+- fix flaky unit tests (config-mock and metrics-registry races) (#600)
+
+## ts-sdk-v0.3.0-beta.2 - 2026-06-30
+
+
+### Bug Fixes
+
+- move @solana/kit integration to a /kit subpath so the main entry bundles (#581)
+
+- bump quinn-proto to 0.11.15 for RUSTSEC-2026-0185 (#576)
+
+- pin Docker builder to bookworm to match runtime glibc (#575)
+
+- bump builder to rust 1.91 (#574)
+
+- bump builder to rust 1.89 (#573)
+
+- exit with status 1 on config validation failure (#567)
+
+- atomic usage limit enforcement across concurrent requests (#463)
+
+- cache payment-side token prices and add oracle HTTP timeouts (#529)
+
+- redact http url path and query in error messages (#552)
+
+- count programdata in the loader CreateAccount pairing check (#543)
+
+- harden deploy_authority against further fee-payer drains (#542)
+
+- guard fee-payer-funded CreateAccount to loader-owned accounts (#541)
+
+- base64+data_slice reaper RPC + smoke-test.sh --bin (#537)
+
+- exec-form ENTRYPOINT + deploy_target input (#536)
+
+- build reaper image via cargo install --git (#535)
+
+- skip empty key vars (#469)
+
+- support SyncNative in CPI inner instruction reconstruction (#468)
+
+- enforce fee-payer policy for multisig co-signers (#456)
+
+- allow empty allowed_tokens under Free pricing + unblock devnet-deploy-paymaster example (#452)
+
+- validate extension security metadata (#447)
+
+- classify transfercheckedwithfee as transfer (#446)
+
+- harden Token-2022 extension catch-all and parse failures (#434)
+
+- account for alt close outflow (#445)
+
+- separate probe reservation from selection (#442)
+
+- enforce strict fixed pricing when token quote floors to zero (#444)
+
+- derive Token-2022 payment ATAs with correct program id (#443)
+
+- increase probe lease to 60s to cover worst-case signing (KORA-25) (#441)
+
+- simulate bundle sequentially before signing when sig_verify=false (KORA-21) (#439)
+
+- warn on unvalidated programs in allowed_programs (KORA-14/15/16) (#433)
+
+- verify payment owner is a signer before quota attribution (KORA-19) (#440)
+
+- track nonce withdrawal outflow when fee payer is authority (KORA-12) (#435)
+
+- reject token decimals > 19 to prevent overflow in fee calculation (#432)
+
+- validate CreateAccount owner program against allowed list (#431)
+
+- harden fee payer protection against ATA rent drain and net-zero payment exploits (#428)
+
+- validate signed txs with sequential simulation (#425)
+
+- enforce transfer-hook checks in free pricing (#423)
+
+- correct token2022 permanent delegate warning scope (#420)
+
+- enforce fee payer policy for ALT instructions (#419)
+
+- bypass cache for payment-critical account reads (#418)
+
+- pin crates.io auth action to valid commit (#410)
+
+- wire trusted publishing token into cargo publish (#409)
+
+
+### Features
+
+- support CreateAccountAllowPrefund instruction (#578)
+
+- add devnet paymaster Databricks dashboard (#564)
+
+- expose HTTP timeout configuration for remote signer providers (#530)
+
+- replace vec pubkey with hashset (#551)
+
+- extend CreateAccount pairing guard to loader-v4 (#549)
+
+- reap orphan loader-v3 buffers (#548)
+
+- add devnet deployer verification suite (#544)
+
+- structured numeric RPC error codes (#424)
+
+- add inactive-program reaper (#534)
+
+- cross-cluster mint validation (#464)
+
+- add BPF Loader Upgradeable (loader-v3) policy + plugin coverage (#453)
+
+- add DeployAuthority plugin for devnet-deploy paymasters (#451)
+
+- add loader-v4 fee-payer policy for program deployment (#449)
+
+- add must_call_programs validation rule (#422)
+
+- block compute-only transactions (#421)
+
+- sync solana-keychain to 1.0.1 and add new signer adapters (#416)
+
+- implement graceful retry and timeout for remote signers (#412)
+
+- add health monitoring and automatic failover for signer pool (#399)
+
+- add docker compose for 1-click facilitator deploy (#414)
+
+
+### Refactoring
+
+- extract deploy lib, add kora-deploy CLI (#539)
+
+
+### Testing
+
+- speed up integration runner, measure integration coverage, extend CI matrix (#557)
+
+- add loader-v3 deploy lifecycle integration test + open up plugin-guarded ops (#459)
+
 ## 2.2.0-beta.7 - 2026-03-27
 
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3530,7 +3530,7 @@ dependencies = [
 
 [[package]]
 name = "kora-cli"
-version = "2.2.0-beta.7"
+version = "2.2.0-beta.8"
 dependencies = [
  "clap",
  "dotenv",
@@ -3566,7 +3566,7 @@ dependencies = [
 
 [[package]]
 name = "kora-lib"
-version = "2.2.0-beta.7"
+version = "2.2.0-beta.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -8085,7 +8085,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "tests"
-version = "2.2.0-beta.7"
+version = "2.2.0-beta.8"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,13 +14,13 @@ all = { level = "deny", priority = -1 }
 module_inception = { level = "allow", priority = 0 }
 
 [workspace.package]
-version = "2.2.0-beta.7"
+version = "2.2.0-beta.8"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/solana-foundation/kora"
 
 [workspace.dependencies]
-kora-lib = { path = "crates/lib", version = "2.2.0-beta.7" }
+kora-lib = { path = "crates/lib", version = "2.2.0-beta.8" }
 kora-deploy = { path = "crates/kora-deploy", version = "0.2.0" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kora-cli"
-version = "2.2.0-beta.7"
+version = "2.2.0-beta.8"
 edition = "2021"
 description = "CLI for Kora gasless relayer"
 license = "MIT"

--- a/crates/lib/Cargo.toml
+++ b/crates/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kora-lib"
-version = "2.2.0-beta.7"
+version = "2.2.0-beta.8"
 edition = "2021"
 license = "MIT"
 description = "Core library for Kora gasless relayer"


### PR DESCRIPTION
Release **v2.2.0-beta.8** (Rust crates: kora-lib + kora-cli).

First tagged release since `v2.2.0-beta.7` (2026-03-27), so this captures ~163 commits of accumulated `main` — including the recent transaction-validation and fee-payer-accounting security hardening (#620), bundle-aware fee estimation (#606), V0 ALT batch-caching (#565), and `deny_unknown_fields` config validation (#609). See CHANGELOG.md for the full list.

- Bumps `kora-lib`, `kora-cli`, and the workspace version to `2.2.0-beta.8`.
- `kora-deploy` (0.2.0) and `devnet-deploy-paymaster` are intentionally left on their own version lines (only kora-lib + kora-cli are synchronized-versioned).
- Publish happens after merge via the 'Publish Rust Crates' workflow.