### PR TITLE
ci: run fuzz targets in CI

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -44,6 +44,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: nightly-2026-07-13
+          targets: x86_64-unknown-linux-gnu
       - uses: taiki-e/install-action@v2.82.0
         with:
           tool: cargo-fuzz
@@ -51,12 +52,12 @@ jobs:
         with:
           workspaces: fuzz
       - name: Build fuzz targets
-        run: cargo fuzz build
+        run: cargo fuzz build --target x86_64-unknown-linux-gnu
       - name: Smoke each target
         run: |
           for target in parse_transaction decode_b64_transaction; do
             echo "::group::fuzz $target"
-            cargo fuzz run "$target" -- -max_total_time=60
+            cargo fuzz run "$target" --target x86_64-unknown-linux-gnu -- -max_total_time=60
             echo "::endgroup::"
           done
       - name: Upload crash artifacts
@@ -83,6 +84,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@master
         with:
           toolchain: nightly-2026-07-13
+          targets: x86_64-unknown-linux-gnu
       - uses: taiki-e/install-action@v2.82.0
         with:
           tool: cargo-fuzz
@@ -90,7 +92,7 @@ jobs:
         with:
           workspaces: fuzz
       - name: Fuzz ${{ matrix.target }}
-        run: cargo fuzz run ${{ matrix.target }} -- -max_total_time=600
+        run: cargo fuzz run ${{ matrix.target }} --target x86_64-unknown-linux-gnu -- -max_total_time=600
       - name: Upload corpus and crashes
         if: always()
         uses: actions/upload-artifact@v7

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,0 +1,102 @@
+name: Fuzz
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "crates/**"
+      - "fuzz/**"
+      - "Cargo.*"
+      - "rust-toolchain.toml"
+      - ".github/workflows/fuzz.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "crates/**"
+      - "fuzz/**"
+      - "Cargo.*"
+      - "rust-toolchain.toml"
+      - ".github/workflows/fuzz.yml"
+  schedule:
+    - cron: "0 7 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: fuzz-${{ github.ref }}-${{ github.event_name }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  smoke:
+    name: Fuzz smoke (60s)
+    if: github.event_name == 'pull_request' || github.event_name == 'push'
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: nightly-2026-07-13
+      - uses: taiki-e/install-action@v2.82.0
+        with:
+          tool: cargo-fuzz
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: fuzz
+      - name: Build fuzz targets
+        run: cargo fuzz build
+      - name: Smoke each target
+        run: |
+          for target in parse_transaction decode_b64_transaction; do
+            echo "::group::fuzz $target"
+            cargo fuzz run "$target" -- -max_total_time=60
+            echo "::endgroup::"
+          done
+      - name: Upload crash artifacts
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: fuzz-crash-artifacts
+          path: fuzz/artifacts/
+          if-no-files-found: ignore
+
+  deep:
+    name: Fuzz deep run (10m)
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [parse_transaction, decode_b64_transaction]
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: nightly-2026-07-13
+      - uses: taiki-e/install-action@v2.82.0
+        with:
+          tool: cargo-fuzz
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: fuzz
+      - name: Fuzz ${{ matrix.target }}
+        run: cargo fuzz run ${{ matrix.target }} -- -max_total_time=600
+      - name: Upload corpus and crashes
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: fuzz-${{ matrix.target }}
+          path: |
+            fuzz/corpus/${{ matrix.target }}/
+            fuzz/artifacts/${{ matrix.target }}/
+          if-no-files-found: ignore

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -25,6 +25,13 @@ just fuzz-list
 
 A crash writes a reproducer to `fuzz/artifacts/<target>/`; re-run it with `cargo fuzz run <target> fuzz/artifacts/<target>/<crash-file>`.
 
+## CI
+
+`.github/workflows/fuzz.yml` runs two jobs:
+
+- **smoke** (every PR/push touching `crates/**` or `fuzz/**`): `cargo fuzz build` + a 60s run per target. Fails on a build break or a crash; uploads any reproducer as an artifact.
+- **deep** (nightly cron + manual `workflow_dispatch`): 10 min per target, uploads the corpus and any crashes as artifacts.
+
 ## Property tests
 
 Structural invariants (e.g. fee-payer drain safety across the policy matrix) live as `proptest` cases in the `kora-lib` unit tests, not here — see `crates/lib/src/validator/transaction_validator.rs` (`mod fee_payer_policy_props`). Run with `cargo test -p kora-lib --lib fee_payer_policy_props`.


### PR DESCRIPTION
## Summary
Adds `.github/workflows/fuzz.yml` so the cargo-fuzz targets run automatically instead of only locally.

- **smoke** (every PR/push touching `crates/**`, `fuzz/**`, `Cargo.*`, or the workflow): `cargo fuzz build` + a 60s run per target (`parse_transaction`, `decode_b64_transaction`). Fails on a build break **or** a crash, and uploads any reproducer as an artifact.
- **deep** (nightly cron `0 7 * * *` + manual `workflow_dispatch`): 10 min per target via a matrix, uploads the corpus and any crash artifacts.
- Uses the repo's existing conventions: `dtolnay/rust-toolchain@master` pinned to `nightly-2026-07-13` (cargo-fuzz needs nightly), `taiki-e/install-action` for a prebuilt cargo-fuzz binary, and `Swatinem/rust-cache` scoped to the `fuzz` workspace.

The `cargo fuzz build` step doubles as a guard that nothing currently has: if a kora-lib parser/validator API change breaks the fuzz harness, CI now catches it (unit tests don't compile the fuzz crate).

## Why a bounded PR smoke + nightly split
A short bounded PR run catches obvious regressions cheaply; deep bug-finding runs on the nightly schedule, off the PR critical path, so a latent crash surfaces as a nightly artifact rather than blocking an unrelated PR.

## Test Plan
- `actionlint` passes clean.
- The workflow's path filter includes `.github/workflows/fuzz.yml`, so the **smoke job runs on this PR** and self-validates the build + 60s run end to end. (First run builds cold under the sanitizer — hence the 45-min smoke timeout; steady-state is fast via rust-cache.)
- Locally: `cargo fuzz build` + `cargo fuzz run <target> -- -max_total_time=60` both succeed with no crashes.

## Follow-ups (not here)
- Commit/persist a seed corpus so runs accumulate coverage across nightlies (currently each run starts cold; the nightly uploads its discovered corpus as an artifact).

Closes TOO-625