### PR TITLE
feat(validation): opt-in support for confidential Token-2022 instructions

### DIFF
--- a/crates/lib/src/config.rs
+++ b/crates/lib/src/config.rs
@@ -430,6 +430,8 @@ pub struct Token2022Config {
     pub blocked_account_extensions: Vec<String>,
     #[serde(default)]
     pub transfer_hook_policy: TransferHookPolicy,
+    #[serde(default)]
+    pub allow_confidential_transfers: bool,
     #[serde(skip)]
     parsed_blocked_mint_extensions: Option<Vec<ExtensionType>>,
     #[serde(skip)]

--- a/crates/lib/src/rpc_server/openapi/spec/combined_api.json
+++ b/crates/lib/src/rpc_server/openapi/spec/combined_api.json
@@ -2154,6 +2154,10 @@
       "Token2022Config": {
         "type": "object",
         "properties": {
+          "allow_confidential_transfers": {
+            "type": "boolean",
+            "default": false
+          },
           "blocked_account_extensions": {
             "type": "array",
             "items": {

--- a/crates/lib/src/transaction/instruction_util.rs
+++ b/crates/lib/src/transaction/instruction_util.rs
@@ -3751,10 +3751,20 @@ impl IxUtils {
                         spl_token_2022_interface::instruction::TokenInstruction::ConfidentialTransferExtension
                         | spl_token_2022_interface::instruction::TokenInstruction::ConfidentialTransferFeeExtension
                         | spl_token_2022_interface::instruction::TokenInstruction::ConfidentialMintBurnExtension => {
-                            return Err(KoraError::InvalidTransaction(
-                                "Confidential Token-2022 instructions are not supported"
-                                    .to_string(),
-                            ));
+                            let allowed = crate::state::get_config()
+                                .map(|c| c.validation.token_2022.allow_confidential_transfers)
+                                .unwrap_or(false);
+                            if allowed {
+                                Self::push_unhandled_token2022_extension(
+                                    &mut parsed_instructions,
+                                    instruction,
+                                );
+                            } else {
+                                return Err(KoraError::InvalidTransaction(
+                                    "Confidential Token-2022 instructions are not supported"
+                                        .to_string(),
+                                ));
+                            }
                         }
                         _ => {
                             Self::push_unhandled_token2022_extension(

--- a/crates/lib/src/transaction/token2022_security.rs
+++ b/crates/lib/src/transaction/token2022_security.rs
@@ -187,7 +187,10 @@ impl Token2022SecurityParser {
                         Some(ExtensionType::NonTransferable),
                     ));
                 }
-                TokenInstruction::WithdrawExcessLamports => {
+                TokenInstruction::WithdrawExcessLamports
+                | TokenInstruction::ConfidentialTransferExtension
+                | TokenInstruction::ConfidentialTransferFeeExtension
+                | TokenInstruction::ConfidentialMintBurnExtension => {
                     parsed.push(Self::unsupported_fee_payer_account_check(
                         instruction,
                         "unsupported Token-2022 extension instruction",

--- a/crates/lib/src/validator/transaction_validator.rs
+++ b/crates/lib/src/validator/transaction_validator.rs
@@ -1076,6 +1076,17 @@ mod tests {
         setup_both_configs(config);
     }
 
+    fn setup_token2022_config_confidential_allowed(policy: FeePayerPolicy) {
+        let mut config = ConfigMockBuilder::new()
+            .with_price_source(PriceSource::Mock)
+            .with_allowed_programs(vec![spl_token_2022_interface::id().to_string()])
+            .with_max_allowed_lamports(1_000_000)
+            .with_fee_payer_policy(policy)
+            .build();
+        config.validation.token_2022.allow_confidential_transfers = true;
+        setup_both_configs(config);
+    }
+
     fn setup_config_with_policy_and_disallowed(
         policy: FeePayerPolicy,
         allowed_programs: Vec<String>,
@@ -5828,6 +5839,102 @@ mod tests {
             assert!(msg.contains("Confidential Token-2022 instructions are not supported"));
         } else {
             panic!("Expected InvalidTransaction error for confidential token2022 instruction");
+        }
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_token2022_confidential_mint_burn_rejected_by_default() {
+        let fee_payer = Pubkey::new_unique();
+        let rpc_client = RpcMockBuilder::new().build();
+        setup_token2022_config_with_policy(FeePayerPolicy::default());
+
+        let config = get_config().unwrap();
+        let validator = TransactionValidator::new(config, fee_payer).unwrap();
+
+        let confidential_ix = Instruction {
+            program_id: spl_token_2022_interface::id(),
+            accounts: vec![],
+            data: spl_token_2022_interface::instruction::TokenInstruction::ConfidentialMintBurnExtension
+                .pack(),
+        };
+
+        let message = VersionedMessage::Legacy(Message::new(&[confidential_ix], Some(&fee_payer)));
+        let mut transaction =
+            TransactionUtil::new_unsigned_versioned_transaction_resolved(message).unwrap();
+
+        let result = validator.validate_transaction(config, &mut transaction, &rpc_client).await;
+        if let Err(KoraError::InvalidTransaction(msg)) = result {
+            assert!(msg.contains("Confidential Token-2022 instructions are not supported"));
+        } else {
+            panic!("Expected InvalidTransaction error for confidential mint/burn instruction");
+        }
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_token2022_confidential_extensions_allowed_when_flag_enabled() {
+        let fee_payer = Pubkey::new_unique();
+        let rpc_client = RpcMockBuilder::new().build();
+        setup_token2022_config_confidential_allowed(FeePayerPolicy::default());
+
+        let config = get_config().unwrap();
+        let validator = TransactionValidator::new(config, fee_payer).unwrap();
+
+        let confidential_variants = [
+            spl_token_2022_interface::instruction::TokenInstruction::ConfidentialTransferExtension,
+            spl_token_2022_interface::instruction::TokenInstruction::ConfidentialTransferFeeExtension,
+            spl_token_2022_interface::instruction::TokenInstruction::ConfidentialMintBurnExtension,
+        ];
+
+        for variant in confidential_variants {
+            let confidential_ix = Instruction {
+                program_id: spl_token_2022_interface::id(),
+                accounts: vec![AccountMeta::new(Pubkey::new_unique(), false)],
+                data: variant.pack(),
+            };
+
+            let message =
+                VersionedMessage::Legacy(Message::new(&[confidential_ix], Some(&fee_payer)));
+            let mut transaction =
+                TransactionUtil::new_unsigned_versioned_transaction_resolved(message).unwrap();
+
+            assert!(
+                validator.validate_transaction(config, &mut transaction, &rpc_client).await.is_ok(),
+                "Confidential {variant:?} should pass when allow_confidential_transfers is enabled"
+            );
+        }
+    }
+
+    #[tokio::test]
+    #[serial]
+    async fn test_token2022_confidential_extension_rejects_fee_payer_account() {
+        let fee_payer = Pubkey::new_unique();
+        let rpc_client = RpcMockBuilder::new().build();
+        setup_token2022_config_confidential_allowed(FeePayerPolicy::default());
+
+        let config = get_config().unwrap();
+        let validator = TransactionValidator::new(config, fee_payer).unwrap();
+
+        let confidential_ix = Instruction {
+            program_id: spl_token_2022_interface::id(),
+            accounts: vec![AccountMeta::new(fee_payer, false)],
+            data: spl_token_2022_interface::instruction::TokenInstruction::ConfidentialMintBurnExtension
+                .pack(),
+        };
+
+        let message = VersionedMessage::Legacy(Message::new(&[confidential_ix], Some(&fee_payer)));
+        let mut transaction =
+            TransactionUtil::new_unsigned_versioned_transaction_resolved(message).unwrap();
+
+        let result = validator.validate_transaction(config, &mut transaction, &rpc_client).await;
+        if let Err(KoraError::InvalidTransaction(msg)) = result {
+            assert!(
+                msg.contains("Fee payer cannot be an account in"),
+                "Expected fee payer rejection, got: {msg}"
+            );
+        } else {
+            panic!("Expected InvalidTransaction error when fee payer is in confidential instruction");
         }
     }
 

--- a/crates/lib/src/validator/transaction_validator.rs
+++ b/crates/lib/src/validator/transaction_validator.rs
@@ -5934,7 +5934,9 @@ mod tests {
                 "Expected fee payer rejection, got: {msg}"
             );
         } else {
-            panic!("Expected InvalidTransaction error when fee payer is in confidential instruction");
+            panic!(
+                "Expected InvalidTransaction error when fee payer is in confidential instruction"
+            );
         }
     }
 

--- a/sdks/ts/src/types/index.ts
+++ b/sdks/ts/src/types/index.ts
@@ -294,6 +294,8 @@ export interface ValidationConfig {
  * Blocked extensions for Token2022.
  */
 export interface Token2022Config {
+    /** Allow confidential Token-2022 transfer instructions instead of rejecting them */
+    allow_confidential_transfers?: boolean;
     /** List of blocked account extensions */
     blocked_account_extensions: string[];
     /** List of blocked mint extensions */


### PR DESCRIPTION
## Summary

Confidential Token-2022 instructions (`ConfidentialTransfer`, `ConfidentialTransferFee`, `ConfidentialMintBurn`) are currently rejected unconditionally during instruction parsing. This PR makes that behavior opt-in so Kora can sponsor confidential issuance/payments flows, while keeping the fee payer protected.

## Changes

- **Config flag** `validation.token2022.allow_confidential_transfers` (default `false`, preserving current behavior). When enabled, the three confidential instructions are parsed as unhandled Token-2022 extensions instead of erroring.
- **Fee-payer protection**: the same three instructions are routed through the `RejectIfFeePayerPresent` security check, so enabling the flag cannot let the fee payer be pulled into a confidential instruction as an account.
- OpenAPI schema and TS SDK config type synced with the new field.

## Behavior

| Config | Confidential ixn |
|--------|------------------|
| flag unset / `false` | rejected (`Confidential Token-2022 instructions are not supported`) |
| `true` | parsed as unhandled extension |
| `true` + fee payer as account | rejected (`Fee payer cannot be an account in ...`) |

## Tests

- confidential mint/burn rejected by default
- all three confidential extensions pass when the flag is enabled
- fee payer still rejected as an account in a confidential instruction even with the flag on