### PR TITLE
ci: baseline inactive rkyv advisory

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -8,7 +8,7 @@ ignore = [
     "RUSTSEC-2026-0098",
     # rustls-webpki 0.101.x is pinned by the transitive rustls 0.21 TLS stack.
     "RUSTSEC-2026-0099",
-    # crossbeam-epoch reached via solana-client -> rayon -> crossbeam-deque; no fix without
-    # a solana-client bump. fmt::Pointer edge case on an already-invalid pointer.
-    "RUSTSEC-2026-0204",
+    # rkyv is an inactive optional dependency of rust_decimal; Kora does not enable its
+    # rkyv features.
+    "RUSTSEC-2026-0235",
 ]


### PR DESCRIPTION
## Summary
- baseline `RUSTSEC-2026-0235`, which `cargo audit` finds through `rust_decimal` lockfile metadata even though Kora does not enable its optional `rkyv` features
- document why the advisory does not affect the active dependency graph
- remove the obsolete `RUSTSEC-2026-0204` exception now that `crossbeam-epoch` is patched at 0.9.20

Upstream tracking: https://github.com/paupino/rust-decimal/issues/818

## Test Plan
- `cargo audit`
- `cargo tree -i rkyv@0.7.46` (no active reverse dependencies)
