### PR TITLE
test(usage-limit): stop Redis tests from flushing the shared DB

### DIFF
--- a/crates/lib/src/usage_limit/usage_store.rs
+++ b/crates/lib/src/usage_limit/usage_store.rs
@@ -523,14 +523,18 @@ mod tests {
 
         let cfg = Config::from_url(redis_url);
         let pool = cfg.create_pool(Some(Runtime::Tokio1)).unwrap();
+        let key = "test_redis_check_and_increment:key";
+        let mut conn = pool.get().await.unwrap();
+        let _: () = conn.del(key).await.unwrap();
         let store = RedisUsageStore::new(pool);
-        store.clear().await.unwrap();
 
-        assert!(store.check_and_increment("key", 1, 2, None).await.unwrap());
-        assert!(store.check_and_increment("key", 1, 2, None).await.unwrap());
+        assert!(store.check_and_increment(key, 1, 2, None).await.unwrap());
+        assert!(store.check_and_increment(key, 1, 2, None).await.unwrap());
 
-        assert!(!store.check_and_increment("key", 1, 2, None).await.unwrap());
-        assert_eq!(store.get("key").await.unwrap(), 2);
+        assert!(!store.check_and_increment(key, 1, 2, None).await.unwrap());
+        assert_eq!(store.get(key).await.unwrap(), 2);
+
+        let _: () = conn.del(key).await.unwrap();
     }
 
     // Run with: KORA_REDIS_URL="redis://127.0.0.1:6379" cargo test -p kora-lib test_redis -- --include-ignored
@@ -542,17 +546,22 @@ mod tests {
 
         let cfg = Config::from_url(redis_url);
         let pool = cfg.create_pool(Some(Runtime::Tokio1)).unwrap();
+        let key1 = "test_redis_check_and_increment_many:rkey1";
+        let key2 = "test_redis_check_and_increment_many:rkey2";
+        let mut conn = pool.get().await.unwrap();
+        let _: () = conn.del(&[key1, key2]).await.unwrap();
         let store = RedisUsageStore::new(pool);
-        store.clear().await.unwrap();
 
-        let entries = vec![("rkey1".to_string(), 1, 5, None), ("rkey2".to_string(), 1, 1, None)];
+        let entries = vec![(key1.to_string(), 1, 5, None), (key2.to_string(), 1, 1, None)];
 
         assert!(store.check_and_increment_many(&entries).await.unwrap());
-        assert_eq!(store.get("rkey1").await.unwrap(), 1);
-        assert_eq!(store.get("rkey2").await.unwrap(), 1);
+        assert_eq!(store.get(key1).await.unwrap(), 1);
+        assert_eq!(store.get(key2).await.unwrap(), 1);
 
         assert!(!store.check_and_increment_many(&entries).await.unwrap());
-        assert_eq!(store.get("rkey1").await.unwrap(), 1);
-        assert_eq!(store.get("rkey2").await.unwrap(), 1);
+        assert_eq!(store.get(key1).await.unwrap(), 1);
+        assert_eq!(store.get(key2).await.unwrap(), 1);
+
+        let _: () = conn.del(&[key1, key2]).await.unwrap();
     }
 }


### PR DESCRIPTION
## Summary
- The `Rust Unit Tests / Run Redis integration tests` step runs all four `test_redis*` tests in parallel against a single shared Redis DB. The two usage-store tests called `RedisUsageStore::clear()`, which issues `FLUSHDB` and wipes the other tests' keys mid-flight.
- This is the flake seen in [run 30920239228](https://github.com/solana-foundation/kora/actions/runs/30920239228/job/92028631804): `test_redis_check_and_increment` had its counter reset so the third increment was unexpectedly allowed, and `test_redis_get_multiple_accounts_partial_cache_miss` lost its cached account (`AccountNotFound`) — both at the same instant, while the two tests that issued the `FLUSHDB` passed.
- Replace `clear()` in the usage-store tests with per-test namespaced keys and targeted `DEL`s, the same pattern the cache Redis tests already use. No production code changes; `UsageStore::clear()` itself is untouched (still used by `UsageTracker`).

## Test Plan
- `KORA_REDIS_URL=redis://localhost:6379 cargo test --workspace --lib -- --include-ignored test_redis` against `redis:7` (same image as CI): 40 consecutive green runs.
- The pre-fix race needs CI-grade latency to open (0 repros in 500 local runs), but the mechanism is deterministic from the CI trace above.
- `cargo test --workspace --lib` (910 passed), `cargo fmt --check`, `cargo clippy -- -D warnings` all clean.