### PR TITLE
chore: release sdk 3

### DIFF
--- a/sdks/ts/package.json
+++ b/sdks/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@solana/kora",
-  "version": "0.3.0-beta.2",
+  "version": "0.3.0-beta.3",
   "description": "TypeScript SDK for Kora RPC",
   "main": "dist/src/index.js",
   "type": "module",


### PR DESCRIPTION
Release includes latest kit & kit plugin deps so this works w/ latest kit stack.