### PR TITLE
fix(deps): bump h2 to 0.4.16 for RUSTSEC-2026-0258

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -11,4 +11,8 @@ ignore = [
     # rkyv is an inactive optional dependency of rust_decimal; Kora does not enable its
     # rkyv features.
     "RUSTSEC-2026-0235",
+    # h2 0.3.x has no patched release and is pinned by hyper 0.14 (jsonrpsee 0.16) and by
+    # the optional hyper-014 path in aws-smithy-http-client. h2 0.4.x is on the patched
+    # 0.4.16; drop this once jsonrpsee moves to hyper 1.x.
+    "RUSTSEC-2026-0258",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -613,7 +613,7 @@ dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "h2 0.3.27",
- "h2 0.4.14",
+ "h2 0.4.16",
  "http 0.2.12",
  "http 1.3.1",
  "http-body 0.4.6",
@@ -2647,9 +2647,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.14"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2905,7 +2905,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2 0.4.14",
+ "h2 0.4.16",
  "http 1.3.1",
  "http-body 1.0.1",
  "httparse",
@@ -5038,7 +5038,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.4.14",
+ "h2 0.4.16",
  "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",


### PR DESCRIPTION
## Summary
- The nightly `Security` workflow started failing on `main` after RUSTSEC-2026-0258 was published on 2026-08-17: h2 below 0.4.16 accepts and queues empty DATA frames without limit, which can grow memory without bound or panic on length overflow.
- Bumps h2 0.4.14 to the patched 0.4.16 in `Cargo.lock`. This is the copy Kora actually serves traffic with (hyper 1.x via reqwest/aws-sdk).
- Adds `RUSTSEC-2026-0258` to `.cargo/audit.toml` for the second, unfixable copy: h2 0.3.27. The 0.3.x line has no patched release (the advisory lists `>= 0.4.16` only), and it is pinned by hyper 0.14 through jsonrpsee 0.16 plus the optional `hyper-014` path in `aws-smithy-http-client`. Removing it means moving jsonrpsee off hyper 0.14, which is a server refactor (jsonrpsee 0.16 `server::logger::Body` is used across `rpc_server/` and `metrics/`) and does not belong in an advisory fix.

## Test Plan
- `cargo audit` exits 0 locally.
- Before the ignore, `cargo audit` reports only h2 0.3.27, confirming the 0.4.x bump resolved the reachable copy.
- `cargo metadata --locked` succeeds, so the lockfile is consistent.
- `cargo check --locked --workspace --all-targets` succeeds.

## Follow-up
- Upgrade jsonrpsee from 0.16 to a hyper 1.x release, then drop the `RUSTSEC-2026-0258` ignore.