### PR TITLE
feat: add max_priority_fee_lamports validation config

### DIFF
--- a/.claude/skills/kora-operator/references/configuration.md
+++ b/.claude/skills/kora-operator/references/configuration.md
@@ -178,6 +178,8 @@ When enabled, the returned transaction message may be modified (balance assertio
 ```toml
 [validation]
 max_allowed_lamports = 1000000     # Max transaction value in lamports
+# max_priority_fee_lamports = 100000 # Max priority fee in lamports (unset = unlimited, 0 = none).
+                                     # Covers ComputeBudget instructions and the v1 transaction config.
 max_signatures = 10                # Max signatures per transaction
 price_source = "Mock"              # "Mock" or "Jupiter" (requires JUPITER_API_KEY)
 allow_durable_transactions = false # Allow durable nonce transactions (security risk!)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3992,6 +3992,7 @@ dependencies = [
  "solana-address-lookup-table-interface",
  "solana-client",
  "solana-commitment-config",
+ "solana-compute-budget",
  "solana-compute-budget-interface",
  "solana-keychain",
  "solana-loader-v3-interface 6.1.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ solana-loader-v3-interface = { version = "6.1.0", features = ["bincode", "serde"
 solana-loader-v4-interface = { version = "3.1.0", features = ["bincode", "serde"] }
 solana-program = ">=4.0.0,<4.1"
 solana-program-pack = "3.1.0"
-solana-compute-budget-interface = "3.0.0"
+solana-compute-budget-interface = { version = "3.0.0", features = ["borsh"] }
 solana-client = "4.2.1"
 solana-nonce = "3.0.0"
 bs58 = "0.5.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ solana-loader-v4-interface = { version = "3.1.0", features = ["bincode", "serde"
 solana-program = ">=4.0.0,<4.1"
 solana-program-pack = "3.1.0"
 solana-compute-budget-interface = { version = "3.0.0", features = ["borsh"] }
+solana-compute-budget = { version = "4.2.1", features = ["agave-unstable-api"] }
 solana-client = "4.2.1"
 solana-nonce = "3.0.0"
 bs58 = "0.5.1"

--- a/crates/lib/Cargo.toml
+++ b/crates/lib/Cargo.toml
@@ -31,6 +31,7 @@ solana-system-interface = { workspace = true }
 solana-program = { workspace = true }
 solana-program-pack = { workspace = true }
 solana-compute-budget-interface = { workspace = true }
+solana-compute-budget = { workspace = true }
 solana-transaction-status-client-types = { workspace = true }
 solana-transaction-status = { workspace = true }
 solana-address-lookup-table-interface = { workspace = true }

--- a/crates/lib/src/config.rs
+++ b/crates/lib/src/config.rs
@@ -189,10 +189,8 @@ impl ProgramsConfig {
 #[serde(deny_unknown_fields)]
 pub struct ValidationConfig {
     pub max_allowed_lamports: u64,
-    /// Maximum priority fee in lamports a transaction may request. Unset = unlimited.
-    /// 0 = priority fees not allowed. Applies to ComputeBudget instructions (legacy/v0)
-    /// and the v1 transaction config; when a compute unit price is set without an
-    /// explicit compute unit limit, the 1.4M CU protocol maximum is assumed.
+    /// Maximum priority fee in lamports a transaction may request.
+    /// Unset = unlimited, 0 = not allowed.
     #[serde(default)]
     pub max_priority_fee_lamports: Option<u64>,
     pub max_signatures: u64,

--- a/crates/lib/src/config.rs
+++ b/crates/lib/src/config.rs
@@ -189,6 +189,12 @@ impl ProgramsConfig {
 #[serde(deny_unknown_fields)]
 pub struct ValidationConfig {
     pub max_allowed_lamports: u64,
+    /// Maximum priority fee in lamports a transaction may request. Unset = unlimited.
+    /// 0 = priority fees not allowed. Applies to ComputeBudget instructions (legacy/v0)
+    /// and the v1 transaction config; when a compute unit price is set without an
+    /// explicit compute unit limit, the 1.4M CU protocol maximum is assumed.
+    #[serde(default)]
+    pub max_priority_fee_lamports: Option<u64>,
     pub max_signatures: u64,
     pub allowed_programs: ProgramsConfig,
     pub allowed_tokens: Vec<String>,

--- a/crates/lib/src/constant.rs
+++ b/crates/lib/src/constant.rs
@@ -8,8 +8,6 @@ pub const ESTIMATED_LAMPORTS_FOR_PAYMENT_INSTRUCTION: u64 = 50;
 pub const MIN_BALANCE_FOR_RENT_EXEMPTION: u64 = 2_039_280;
 pub const DEFAULT_INTEREST_MULTIPLIER: u128 = 100 * 24 * 60 * 60 / 10000 / (365 * 24 * 60 * 60);
 pub const MAX_TRANSACTION_SIZE: usize = 1232;
-pub const MAX_COMPUTE_UNIT_LIMIT: u32 = 1_400_000;
-pub const MICRO_LAMPORTS_PER_LAMPORT: u64 = 1_000_000;
 
 // HTTP Headers
 pub const X_RECAPTCHA_TOKEN: &str = "x-recaptcha-token";

--- a/crates/lib/src/constant.rs
+++ b/crates/lib/src/constant.rs
@@ -8,6 +8,8 @@ pub const ESTIMATED_LAMPORTS_FOR_PAYMENT_INSTRUCTION: u64 = 50;
 pub const MIN_BALANCE_FOR_RENT_EXEMPTION: u64 = 2_039_280;
 pub const DEFAULT_INTEREST_MULTIPLIER: u128 = 100 * 24 * 60 * 60 / 10000 / (365 * 24 * 60 * 60);
 pub const MAX_TRANSACTION_SIZE: usize = 1232;
+pub const MAX_COMPUTE_UNIT_LIMIT: u32 = 1_400_000;
+pub const MICRO_LAMPORTS_PER_LAMPORT: u64 = 1_000_000;
 
 // HTTP Headers
 pub const X_RECAPTCHA_TOKEN: &str = "x-recaptcha-token";

--- a/crates/lib/src/fee/fee.rs
+++ b/crates/lib/src/fee/fee.rs
@@ -810,17 +810,21 @@ impl TransactionFeeUtil {
     /// is set without an explicit limit, the 1.4M CU protocol maximum is assumed
     /// (an upper bound, so a configured cap can only over-reject, never let a
     /// higher fee through).
-    pub fn get_requested_priority_fee(message: &VersionedMessage) -> u64 {
+    ///
+    /// `account_keys` must be the fully resolved key list (static plus lookup-table
+    /// loaded, in canonical order): the runtime resolves ComputeBudget program ids
+    /// against loaded keys too, so a static-only lookup would miss an ALT-loaded
+    /// ComputeBudget program and undercount the fee.
+    pub fn get_requested_priority_fee(message: &VersionedMessage, account_keys: &[Pubkey]) -> u64 {
         if let VersionedMessage::V1(v1_message) = message {
             return v1_message.config.priority_fee.unwrap_or(0);
         }
 
         let compute_budget_program_id = solana_compute_budget_interface::id();
-        let static_keys = message.static_account_keys();
         let mut compute_unit_price: Option<u64> = None;
         let mut compute_unit_limit: Option<u32> = None;
         for instruction in message.instructions() {
-            if static_keys.get(instruction.program_id_index as usize)
+            if account_keys.get(instruction.program_id_index as usize)
                 != Some(&compute_budget_program_id)
             {
                 continue;
@@ -876,7 +880,9 @@ mod tests {
     use solana_address_lookup_table_interface::{
         instruction as alt_instruction, program::ID as ADDRESS_LOOKUP_TABLE_PROGRAM_ID,
     };
-    use solana_message::{v0, v1, Message, VersionedMessage};
+    use solana_message::{
+        compiled_instruction::CompiledInstruction, v0, v1, Message, VersionedMessage,
+    };
     use solana_sdk::{
         account::Account,
         hash::Hash,
@@ -2524,7 +2530,10 @@ mod tests {
             transfer(&payer, &recipient, 1_000),
         ]);
 
-        assert_eq!(TransactionFeeUtil::get_requested_priority_fee(&message), 7_500);
+        assert_eq!(
+            TransactionFeeUtil::get_requested_priority_fee(&message, message.static_account_keys()),
+            7_500
+        );
     }
 
     #[test]
@@ -2537,7 +2546,10 @@ mod tests {
             transfer(&payer, &recipient, 1_000),
         ]);
 
-        assert_eq!(TransactionFeeUtil::get_requested_priority_fee(&message), 1);
+        assert_eq!(
+            TransactionFeeUtil::get_requested_priority_fee(&message, message.static_account_keys()),
+            1
+        );
     }
 
     #[test]
@@ -2550,7 +2562,7 @@ mod tests {
         ]);
 
         assert_eq!(
-            TransactionFeeUtil::get_requested_priority_fee(&message),
+            TransactionFeeUtil::get_requested_priority_fee(&message, message.static_account_keys()),
             2_000 * MAX_COMPUTE_UNIT_LIMIT as u64 / MICRO_LAMPORTS_PER_LAMPORT
         );
     }
@@ -2562,14 +2574,26 @@ mod tests {
 
         let no_compute_budget =
             legacy_message_with_instructions(&[transfer(&payer, &recipient, 1_000)]);
-        assert_eq!(TransactionFeeUtil::get_requested_priority_fee(&no_compute_budget), 0);
+        assert_eq!(
+            TransactionFeeUtil::get_requested_priority_fee(
+                &no_compute_budget,
+                no_compute_budget.static_account_keys()
+            ),
+            0
+        );
 
         let zero_price = legacy_message_with_instructions(&[
             ComputeBudgetInstruction::set_compute_unit_limit(300_000),
             ComputeBudgetInstruction::set_compute_unit_price(0),
             transfer(&payer, &recipient, 1_000),
         ]);
-        assert_eq!(TransactionFeeUtil::get_requested_priority_fee(&zero_price), 0);
+        assert_eq!(
+            TransactionFeeUtil::get_requested_priority_fee(
+                &zero_price,
+                zero_price.static_account_keys()
+            ),
+            0
+        );
     }
 
     #[test]
@@ -2577,10 +2601,16 @@ mod tests {
         let message = v1_message_with_config(
             v1::TransactionConfig::empty().with_priority_fee(1_234).with_compute_unit_limit(200),
         );
-        assert_eq!(TransactionFeeUtil::get_requested_priority_fee(&message), 1_234);
+        assert_eq!(
+            TransactionFeeUtil::get_requested_priority_fee(&message, message.static_account_keys()),
+            1_234
+        );
 
         let no_fee = v1_message_with_config(v1::TransactionConfig::empty());
-        assert_eq!(TransactionFeeUtil::get_requested_priority_fee(&no_fee), 0);
+        assert_eq!(
+            TransactionFeeUtil::get_requested_priority_fee(&no_fee, no_fee.static_account_keys()),
+            0
+        );
     }
 
     #[test]
@@ -2599,9 +2629,47 @@ mod tests {
 
         // The runtime treats ComputeBudget instructions in V1 transactions as
         // no-ops; only the config field carries the priority fee.
+        let message = VersionedMessage::V1(message);
         assert_eq!(
-            TransactionFeeUtil::get_requested_priority_fee(&VersionedMessage::V1(message)),
+            TransactionFeeUtil::get_requested_priority_fee(&message, message.static_account_keys()),
             0
+        );
+    }
+
+    #[test]
+    fn test_get_requested_priority_fee_v0_with_alt_loaded_compute_budget() {
+        let payer = Pubkey::new_unique();
+        let limit_data = ComputeBudgetInstruction::set_compute_unit_limit(300_000).data;
+        let price_data = ComputeBudgetInstruction::set_compute_unit_price(2_000).data;
+
+        // The ComputeBudget program id lives past the static keys (loaded from a
+        // lookup table); the runtime still processes these instructions, so the
+        // extraction must resolve program ids against the full resolved key list.
+        let message = VersionedMessage::V0(v0::Message {
+            header: solana_message::MessageHeader {
+                num_required_signatures: 1,
+                num_readonly_signed_accounts: 0,
+                num_readonly_unsigned_accounts: 0,
+            },
+            account_keys: vec![payer],
+            recent_blockhash: Hash::new_unique(),
+            instructions: vec![
+                CompiledInstruction { program_id_index: 1, accounts: vec![], data: limit_data },
+                CompiledInstruction { program_id_index: 1, accounts: vec![], data: price_data },
+            ],
+            address_table_lookups: vec![solana_message::v0::MessageAddressTableLookup {
+                account_key: Pubkey::new_unique(),
+                writable_indexes: vec![],
+                readonly_indexes: vec![0],
+            }],
+        });
+        let resolved_keys = vec![payer, solana_compute_budget_interface::id()];
+
+        assert_eq!(
+            TransactionFeeUtil::get_requested_priority_fee(&message, &resolved_keys),
+            600,
+            "300_000 CU * 2_000 micro-lamports = 600 lamports must be counted \
+             even when the ComputeBudget program is loaded via a lookup table"
         );
     }
 }

--- a/crates/lib/src/fee/fee.rs
+++ b/crates/lib/src/fee/fee.rs
@@ -5,7 +5,10 @@ use std::{
 
 use crate::{
     config::Config,
-    constant::{ESTIMATED_LAMPORTS_FOR_PAYMENT_INSTRUCTION, LAMPORTS_PER_SIGNATURE},
+    constant::{
+        ESTIMATED_LAMPORTS_FOR_PAYMENT_INSTRUCTION, LAMPORTS_PER_SIGNATURE, MAX_COMPUTE_UNIT_LIMIT,
+        MICRO_LAMPORTS_PER_LAMPORT,
+    },
     error::KoraError,
     fee::price::PriceModel,
     token::{
@@ -29,6 +32,7 @@ use crate::cache::CacheUtil;
 #[cfg(test)]
 use crate::tests::cache_mock::MockCacheUtil as CacheUtil;
 use solana_client::{nonblocking::rpc_client::RpcClient, rpc_client::SerializableMessage};
+use solana_compute_budget_interface::ComputeBudgetInstruction;
 use solana_message::VersionedMessage;
 use solana_program_pack::Pack;
 use solana_sdk::pubkey::Pubkey;
@@ -799,6 +803,49 @@ impl TransactionFeeUtil {
             }
         }
         .map_err(|e| KoraError::RpcError(e.to_string()))
+    }
+
+    /// Priority fee in lamports the transaction requests: the config field for V1,
+    /// or ComputeBudget price times limit for legacy/V0. When a compute unit price
+    /// is set without an explicit limit, the 1.4M CU protocol maximum is assumed
+    /// (an upper bound, so a configured cap can only over-reject, never let a
+    /// higher fee through).
+    pub fn get_requested_priority_fee(message: &VersionedMessage) -> u64 {
+        if let VersionedMessage::V1(v1_message) = message {
+            return v1_message.config.priority_fee.unwrap_or(0);
+        }
+
+        let compute_budget_program_id = solana_compute_budget_interface::id();
+        let static_keys = message.static_account_keys();
+        let mut compute_unit_price: Option<u64> = None;
+        let mut compute_unit_limit: Option<u32> = None;
+        for instruction in message.instructions() {
+            if static_keys.get(instruction.program_id_index as usize)
+                != Some(&compute_budget_program_id)
+            {
+                continue;
+            }
+            match borsh::from_slice(&instruction.data) {
+                Ok(ComputeBudgetInstruction::SetComputeUnitPrice(micro_lamports)) => {
+                    compute_unit_price.get_or_insert(micro_lamports);
+                }
+                Ok(ComputeBudgetInstruction::SetComputeUnitLimit(units)) => {
+                    compute_unit_limit.get_or_insert(units);
+                }
+                _ => {}
+            }
+        }
+
+        let Some(price) = compute_unit_price.filter(|price| *price > 0) else {
+            return 0;
+        };
+        let limit =
+            compute_unit_limit.unwrap_or(MAX_COMPUTE_UNIT_LIMIT).min(MAX_COMPUTE_UNIT_LIMIT);
+        (price as u128)
+            .saturating_mul(limit as u128)
+            .div_ceil(MICRO_LAMPORTS_PER_LAMPORT as u128)
+            .try_into()
+            .unwrap_or(u64::MAX)
     }
 }
 
@@ -2447,5 +2494,114 @@ mod tests {
             .unwrap();
 
         assert_eq!(result, 9000, "Should return mocked base fee for V1 message");
+    }
+
+    fn legacy_message_with_instructions(instructions: &[Instruction]) -> VersionedMessage {
+        let payer = Pubkey::new_unique();
+        VersionedMessage::Legacy(Message::new(instructions, Some(&payer)))
+    }
+
+    fn v1_message_with_config(config: v1::TransactionConfig) -> VersionedMessage {
+        let payer = Keypair::new();
+        let recipient = Pubkey::new_unique();
+        let mut message = v1::Message::try_compile(
+            &payer.pubkey(),
+            &[transfer(&payer.pubkey(), &recipient, 1_000)],
+            Hash::default(),
+        )
+        .expect("Failed to compile V1 message");
+        message.config = config;
+        VersionedMessage::V1(message)
+    }
+
+    #[test]
+    fn test_get_requested_priority_fee_legacy_price_and_limit() {
+        let payer = Pubkey::new_unique();
+        let recipient = Pubkey::new_unique();
+        let message = legacy_message_with_instructions(&[
+            ComputeBudgetInstruction::set_compute_unit_limit(300_000),
+            ComputeBudgetInstruction::set_compute_unit_price(25_000),
+            transfer(&payer, &recipient, 1_000),
+        ]);
+
+        assert_eq!(TransactionFeeUtil::get_requested_priority_fee(&message), 7_500);
+    }
+
+    #[test]
+    fn test_get_requested_priority_fee_rounds_up() {
+        let payer = Pubkey::new_unique();
+        let recipient = Pubkey::new_unique();
+        let message = legacy_message_with_instructions(&[
+            ComputeBudgetInstruction::set_compute_unit_limit(100),
+            ComputeBudgetInstruction::set_compute_unit_price(1),
+            transfer(&payer, &recipient, 1_000),
+        ]);
+
+        assert_eq!(TransactionFeeUtil::get_requested_priority_fee(&message), 1);
+    }
+
+    #[test]
+    fn test_get_requested_priority_fee_price_without_limit_assumes_max() {
+        let payer = Pubkey::new_unique();
+        let recipient = Pubkey::new_unique();
+        let message = legacy_message_with_instructions(&[
+            ComputeBudgetInstruction::set_compute_unit_price(2_000),
+            transfer(&payer, &recipient, 1_000),
+        ]);
+
+        assert_eq!(
+            TransactionFeeUtil::get_requested_priority_fee(&message),
+            2_000 * MAX_COMPUTE_UNIT_LIMIT as u64 / MICRO_LAMPORTS_PER_LAMPORT
+        );
+    }
+
+    #[test]
+    fn test_get_requested_priority_fee_zero_without_price() {
+        let payer = Pubkey::new_unique();
+        let recipient = Pubkey::new_unique();
+
+        let no_compute_budget =
+            legacy_message_with_instructions(&[transfer(&payer, &recipient, 1_000)]);
+        assert_eq!(TransactionFeeUtil::get_requested_priority_fee(&no_compute_budget), 0);
+
+        let zero_price = legacy_message_with_instructions(&[
+            ComputeBudgetInstruction::set_compute_unit_limit(300_000),
+            ComputeBudgetInstruction::set_compute_unit_price(0),
+            transfer(&payer, &recipient, 1_000),
+        ]);
+        assert_eq!(TransactionFeeUtil::get_requested_priority_fee(&zero_price), 0);
+    }
+
+    #[test]
+    fn test_get_requested_priority_fee_v1_reads_config() {
+        let message = v1_message_with_config(
+            v1::TransactionConfig::empty().with_priority_fee(1_234).with_compute_unit_limit(200),
+        );
+        assert_eq!(TransactionFeeUtil::get_requested_priority_fee(&message), 1_234);
+
+        let no_fee = v1_message_with_config(v1::TransactionConfig::empty());
+        assert_eq!(TransactionFeeUtil::get_requested_priority_fee(&no_fee), 0);
+    }
+
+    #[test]
+    fn test_get_requested_priority_fee_v1_ignores_compute_budget_instructions() {
+        let payer = Keypair::new();
+        let recipient = Pubkey::new_unique();
+        let message = v1::Message::try_compile(
+            &payer.pubkey(),
+            &[
+                ComputeBudgetInstruction::set_compute_unit_price(50_000),
+                transfer(&payer.pubkey(), &recipient, 1_000),
+            ],
+            Hash::default(),
+        )
+        .expect("Failed to compile V1 message");
+
+        // The runtime treats ComputeBudget instructions in V1 transactions as
+        // no-ops; only the config field carries the priority fee.
+        assert_eq!(
+            TransactionFeeUtil::get_requested_priority_fee(&VersionedMessage::V1(message)),
+            0
+        );
     }
 }

--- a/crates/lib/src/fee/fee.rs
+++ b/crates/lib/src/fee/fee.rs
@@ -5,10 +5,7 @@ use std::{
 
 use crate::{
     config::Config,
-    constant::{
-        ESTIMATED_LAMPORTS_FOR_PAYMENT_INSTRUCTION, LAMPORTS_PER_SIGNATURE, MAX_COMPUTE_UNIT_LIMIT,
-        MICRO_LAMPORTS_PER_LAMPORT,
-    },
+    constant::{ESTIMATED_LAMPORTS_FOR_PAYMENT_INSTRUCTION, LAMPORTS_PER_SIGNATURE},
     error::KoraError,
     fee::price::PriceModel,
     token::{
@@ -32,6 +29,7 @@ use crate::cache::CacheUtil;
 #[cfg(test)]
 use crate::tests::cache_mock::MockCacheUtil as CacheUtil;
 use solana_client::{nonblocking::rpc_client::RpcClient, rpc_client::SerializableMessage};
+use solana_compute_budget::compute_budget_limits::{ComputeBudgetLimits, MAX_COMPUTE_UNIT_LIMIT};
 use solana_compute_budget_interface::ComputeBudgetInstruction;
 use solana_message::VersionedMessage;
 use solana_program_pack::Pack;
@@ -806,15 +804,11 @@ impl TransactionFeeUtil {
     }
 
     /// Priority fee in lamports the transaction requests: the config field for V1,
-    /// or ComputeBudget price times limit for legacy/V0. When a compute unit price
-    /// is set without an explicit limit, the 1.4M CU protocol maximum is assumed
-    /// (an upper bound, so a configured cap can only over-reject, never let a
-    /// higher fee through).
+    /// ComputeBudget price times limit for legacy/V0, assuming the maximum compute
+    /// unit limit when none is set (an upper bound, so a cap can only over-reject).
     ///
-    /// `account_keys` must be the fully resolved key list (static plus lookup-table
-    /// loaded, in canonical order): the runtime resolves ComputeBudget program ids
-    /// against loaded keys too, so a static-only lookup would miss an ALT-loaded
-    /// ComputeBudget program and undercount the fee.
+    /// `account_keys` must be the resolved key list: the runtime resolves program
+    /// ids against lookup-table loaded keys too.
     pub fn get_requested_priority_fee(message: &VersionedMessage, account_keys: &[Pubkey]) -> u64 {
         if let VersionedMessage::V1(v1_message) = message {
             return v1_message.config.priority_fee.unwrap_or(0);
@@ -843,13 +837,15 @@ impl TransactionFeeUtil {
         let Some(price) = compute_unit_price.filter(|price| *price > 0) else {
             return 0;
         };
-        let limit =
-            compute_unit_limit.unwrap_or(MAX_COMPUTE_UNIT_LIMIT).min(MAX_COMPUTE_UNIT_LIMIT);
-        (price as u128)
-            .saturating_mul(limit as u128)
-            .div_ceil(MICRO_LAMPORTS_PER_LAMPORT as u128)
-            .try_into()
-            .unwrap_or(u64::MAX)
+
+        ComputeBudgetLimits {
+            compute_unit_price: price,
+            compute_unit_limit: compute_unit_limit
+                .unwrap_or(MAX_COMPUTE_UNIT_LIMIT)
+                .min(MAX_COMPUTE_UNIT_LIMIT),
+            ..Default::default()
+        }
+        .get_prioritization_fee()
     }
 }
 
@@ -871,6 +867,9 @@ mod tests {
             },
             config_mock::{mock_state::get_config, ConfigMockBuilder},
             rpc_mock::RpcMockBuilder,
+            transaction_mock::{
+                create_legacy_message, create_v0_message_with_alt_loaded_program, create_v1_message,
+            },
         },
         token::{
             interface::TokenInterface, spl_token::TokenProgram, spl_token_2022::Token2022Program,
@@ -880,9 +879,7 @@ mod tests {
     use solana_address_lookup_table_interface::{
         instruction as alt_instruction, program::ID as ADDRESS_LOOKUP_TABLE_PROGRAM_ID,
     };
-    use solana_message::{
-        compiled_instruction::CompiledInstruction, v0, v1, Message, VersionedMessage,
-    };
+    use solana_message::{v0, v1, Message, VersionedMessage};
     use solana_sdk::{
         account::Account,
         hash::Hash,
@@ -2502,33 +2499,18 @@ mod tests {
         assert_eq!(result, 9000, "Should return mocked base fee for V1 message");
     }
 
-    fn legacy_message_with_instructions(instructions: &[Instruction]) -> VersionedMessage {
-        let payer = Pubkey::new_unique();
-        VersionedMessage::Legacy(Message::new(instructions, Some(&payer)))
-    }
-
-    fn v1_message_with_config(config: v1::TransactionConfig) -> VersionedMessage {
-        let payer = Keypair::new();
-        let recipient = Pubkey::new_unique();
-        let mut message = v1::Message::try_compile(
-            &payer.pubkey(),
-            &[transfer(&payer.pubkey(), &recipient, 1_000)],
-            Hash::default(),
-        )
-        .expect("Failed to compile V1 message");
-        message.config = config;
-        VersionedMessage::V1(message)
-    }
-
     #[test]
     fn test_get_requested_priority_fee_legacy_price_and_limit() {
         let payer = Pubkey::new_unique();
         let recipient = Pubkey::new_unique();
-        let message = legacy_message_with_instructions(&[
-            ComputeBudgetInstruction::set_compute_unit_limit(300_000),
-            ComputeBudgetInstruction::set_compute_unit_price(25_000),
-            transfer(&payer, &recipient, 1_000),
-        ]);
+        let message = create_legacy_message(
+            &payer,
+            &[
+                ComputeBudgetInstruction::set_compute_unit_limit(300_000),
+                ComputeBudgetInstruction::set_compute_unit_price(25_000),
+                transfer(&payer, &recipient, 1_000),
+            ],
+        );
 
         assert_eq!(
             TransactionFeeUtil::get_requested_priority_fee(&message, message.static_account_keys()),
@@ -2540,11 +2522,14 @@ mod tests {
     fn test_get_requested_priority_fee_rounds_up() {
         let payer = Pubkey::new_unique();
         let recipient = Pubkey::new_unique();
-        let message = legacy_message_with_instructions(&[
-            ComputeBudgetInstruction::set_compute_unit_limit(100),
-            ComputeBudgetInstruction::set_compute_unit_price(1),
-            transfer(&payer, &recipient, 1_000),
-        ]);
+        let message = create_legacy_message(
+            &payer,
+            &[
+                ComputeBudgetInstruction::set_compute_unit_limit(100),
+                ComputeBudgetInstruction::set_compute_unit_price(1),
+                transfer(&payer, &recipient, 1_000),
+            ],
+        );
 
         assert_eq!(
             TransactionFeeUtil::get_requested_priority_fee(&message, message.static_account_keys()),
@@ -2556,14 +2541,18 @@ mod tests {
     fn test_get_requested_priority_fee_price_without_limit_assumes_max() {
         let payer = Pubkey::new_unique();
         let recipient = Pubkey::new_unique();
-        let message = legacy_message_with_instructions(&[
-            ComputeBudgetInstruction::set_compute_unit_price(2_000),
-            transfer(&payer, &recipient, 1_000),
-        ]);
+        let message = create_legacy_message(
+            &payer,
+            &[
+                ComputeBudgetInstruction::set_compute_unit_price(2_000),
+                transfer(&payer, &recipient, 1_000),
+            ],
+        );
 
+        // 2_000 micro-lamports over the assumed 1.4M CU maximum = 2_800 lamports
         assert_eq!(
             TransactionFeeUtil::get_requested_priority_fee(&message, message.static_account_keys()),
-            2_000 * MAX_COMPUTE_UNIT_LIMIT as u64 / MICRO_LAMPORTS_PER_LAMPORT
+            2_800
         );
     }
 
@@ -2573,7 +2562,7 @@ mod tests {
         let recipient = Pubkey::new_unique();
 
         let no_compute_budget =
-            legacy_message_with_instructions(&[transfer(&payer, &recipient, 1_000)]);
+            create_legacy_message(&payer, &[transfer(&payer, &recipient, 1_000)]);
         assert_eq!(
             TransactionFeeUtil::get_requested_priority_fee(
                 &no_compute_budget,
@@ -2582,11 +2571,14 @@ mod tests {
             0
         );
 
-        let zero_price = legacy_message_with_instructions(&[
-            ComputeBudgetInstruction::set_compute_unit_limit(300_000),
-            ComputeBudgetInstruction::set_compute_unit_price(0),
-            transfer(&payer, &recipient, 1_000),
-        ]);
+        let zero_price = create_legacy_message(
+            &payer,
+            &[
+                ComputeBudgetInstruction::set_compute_unit_limit(300_000),
+                ComputeBudgetInstruction::set_compute_unit_price(0),
+                transfer(&payer, &recipient, 1_000),
+            ],
+        );
         assert_eq!(
             TransactionFeeUtil::get_requested_priority_fee(
                 &zero_price,
@@ -2598,7 +2590,8 @@ mod tests {
 
     #[test]
     fn test_get_requested_priority_fee_v1_reads_config() {
-        let message = v1_message_with_config(
+        let message = create_v1_message(
+            &Pubkey::new_unique(),
             v1::TransactionConfig::empty().with_priority_fee(1_234).with_compute_unit_limit(200),
         );
         assert_eq!(
@@ -2606,7 +2599,7 @@ mod tests {
             1_234
         );
 
-        let no_fee = v1_message_with_config(v1::TransactionConfig::empty());
+        let no_fee = create_v1_message(&Pubkey::new_unique(), v1::TransactionConfig::empty());
         assert_eq!(
             TransactionFeeUtil::get_requested_priority_fee(&no_fee, no_fee.static_account_keys()),
             0
@@ -2645,24 +2638,8 @@ mod tests {
         // The ComputeBudget program id lives past the static keys (loaded from a
         // lookup table); the runtime still processes these instructions, so the
         // extraction must resolve program ids against the full resolved key list.
-        let message = VersionedMessage::V0(v0::Message {
-            header: solana_message::MessageHeader {
-                num_required_signatures: 1,
-                num_readonly_signed_accounts: 0,
-                num_readonly_unsigned_accounts: 0,
-            },
-            account_keys: vec![payer],
-            recent_blockhash: Hash::new_unique(),
-            instructions: vec![
-                CompiledInstruction { program_id_index: 1, accounts: vec![], data: limit_data },
-                CompiledInstruction { program_id_index: 1, accounts: vec![], data: price_data },
-            ],
-            address_table_lookups: vec![solana_message::v0::MessageAddressTableLookup {
-                account_key: Pubkey::new_unique(),
-                writable_indexes: vec![],
-                readonly_indexes: vec![0],
-            }],
-        });
+        let message =
+            create_v0_message_with_alt_loaded_program(&payer, vec![limit_data, price_data]);
         let resolved_keys = vec![payer, solana_compute_budget_interface::id()];
 
         assert_eq!(

--- a/crates/lib/src/fee/fee.rs
+++ b/crates/lib/src/fee/fee.rs
@@ -29,7 +29,9 @@ use crate::cache::CacheUtil;
 #[cfg(test)]
 use crate::tests::cache_mock::MockCacheUtil as CacheUtil;
 use solana_client::{nonblocking::rpc_client::RpcClient, rpc_client::SerializableMessage};
-use solana_compute_budget::compute_budget_limits::{ComputeBudgetLimits, MAX_COMPUTE_UNIT_LIMIT};
+use solana_compute_budget::compute_budget_limits::{
+    ComputeBudgetLimits, DEFAULT_INSTRUCTION_COMPUTE_UNIT_LIMIT, MAX_COMPUTE_UNIT_LIMIT,
+};
 use solana_compute_budget_interface::ComputeBudgetInstruction;
 use solana_message::VersionedMessage;
 use solana_program_pack::Pack;
@@ -804,8 +806,13 @@ impl TransactionFeeUtil {
     }
 
     /// Priority fee in lamports the transaction requests: the config field for V1,
-    /// ComputeBudget price times limit for legacy/V0, assuming the maximum compute
-    /// unit limit when none is set (an upper bound, so a cap can only over-reject).
+    /// ComputeBudget price times limit for legacy/V0.
+    ///
+    /// When no SetComputeUnitLimit is present the runtime derives a default limit per
+    /// instruction, charging a builtin less than a program. Deriving it here would take the
+    /// cluster's feature set, so every instruction is billed at the higher per-instruction
+    /// default instead: an upper bound on the runtime's own default, so the cap can only
+    /// over-reject, never under.
     ///
     /// `account_keys` must be the resolved key list: the runtime resolves program
     /// ids against lookup-table loaded keys too.
@@ -817,10 +824,12 @@ impl TransactionFeeUtil {
         let compute_budget_program_id = solana_compute_budget_interface::id();
         let mut compute_unit_price: Option<u64> = None;
         let mut compute_unit_limit: Option<u32> = None;
+        let mut non_compute_budget_instructions: u32 = 0;
         for instruction in message.instructions() {
             if account_keys.get(instruction.program_id_index as usize)
                 != Some(&compute_budget_program_id)
             {
+                non_compute_budget_instructions = non_compute_budget_instructions.saturating_add(1);
                 continue;
             }
             match borsh::from_slice(&instruction.data) {
@@ -838,10 +847,13 @@ impl TransactionFeeUtil {
             return 0;
         };
 
+        let default_compute_unit_limit =
+            non_compute_budget_instructions.saturating_mul(DEFAULT_INSTRUCTION_COMPUTE_UNIT_LIMIT);
+
         ComputeBudgetLimits {
             compute_unit_price: price,
             compute_unit_limit: compute_unit_limit
-                .unwrap_or(MAX_COMPUTE_UNIT_LIMIT)
+                .unwrap_or(default_compute_unit_limit)
                 .min(MAX_COMPUTE_UNIT_LIMIT),
             ..Default::default()
         }
@@ -2538,7 +2550,7 @@ mod tests {
     }
 
     #[test]
-    fn test_get_requested_priority_fee_price_without_limit_assumes_max() {
+    fn test_get_requested_priority_fee_price_without_limit_bills_per_instruction_default() {
         let payer = Pubkey::new_unique();
         let recipient = Pubkey::new_unique();
         let message = create_legacy_message(
@@ -2549,7 +2561,24 @@ mod tests {
             ],
         );
 
-        // 2_000 micro-lamports over the assumed 1.4M CU maximum = 2_800 lamports
+        // The lone transfer defaults to 200_000 CU, so 2_000 micro-lamports over it = 400 lamports.
+        // Billing the 1.4M protocol maximum instead would overstate this sevenfold.
+        assert_eq!(
+            TransactionFeeUtil::get_requested_priority_fee(&message, message.static_account_keys()),
+            400
+        );
+    }
+
+    #[test]
+    fn test_get_requested_priority_fee_default_limit_clamps_to_protocol_maximum() {
+        let payer = Pubkey::new_unique();
+        let recipient = Pubkey::new_unique();
+        let mut instructions = vec![ComputeBudgetInstruction::set_compute_unit_price(2_000)];
+        instructions.extend((0..8).map(|_| transfer(&payer, &recipient, 1_000)));
+        let message = create_legacy_message(&payer, &instructions);
+
+        // 8 instructions x 200_000 = 1.6M CU, over the 1.4M the runtime will grant,
+        // so the fee is 2_000 micro-lamports over 1.4M = 2_800 lamports.
         assert_eq!(
             TransactionFeeUtil::get_requested_priority_fee(&message, message.static_account_keys()),
             2_800

--- a/crates/lib/src/tests/config_mock.rs
+++ b/crates/lib/src/tests/config_mock.rs
@@ -78,6 +78,7 @@ impl ConfigMockBuilder {
             config: Config {
                 validation: ValidationConfig {
                     max_allowed_lamports: 1_000_000_000,
+                    max_priority_fee_lamports: None,
                     max_signatures: 10,
                     allowed_programs: ProgramsConfig::Allowlist(vec![
                         "11111111111111111111111111111111".parse().unwrap(), // System Program
@@ -217,6 +218,11 @@ impl ConfigMockBuilder {
         self
     }
 
+    pub fn with_max_priority_fee_lamports(mut self, max_priority_fee_lamports: u64) -> Self {
+        self.config.validation.max_priority_fee_lamports = Some(max_priority_fee_lamports);
+        self
+    }
+
     pub fn with_max_signatures(mut self, max_signatures: u64) -> Self {
         self.config.validation.max_signatures = max_signatures;
         self
@@ -306,6 +312,7 @@ impl ValidationConfigBuilder {
         Self {
             config: ValidationConfig {
                 max_allowed_lamports: 1_000_000_000,
+                max_priority_fee_lamports: None,
                 max_signatures: 10,
                 allowed_programs: ProgramsConfig::Allowlist(vec![]),
                 allowed_tokens: vec![],

--- a/crates/lib/src/tests/transaction_mock.rs
+++ b/crates/lib/src/tests/transaction_mock.rs
@@ -1,5 +1,5 @@
 use solana_message::{
-    compiled_instruction::CompiledInstruction, v1, Message, MessageHeader, VersionedMessage,
+    compiled_instruction::CompiledInstruction, v0, v1, Message, MessageHeader, VersionedMessage,
 };
 use solana_sdk::{
     hash::Hash,
@@ -83,4 +83,62 @@ pub fn create_mock_v1_transaction_with_max_addresses(fee_payer: &Keypair) -> Ver
     });
 
     VersionedTransaction::try_new(message, &[fee_payer]).unwrap()
+}
+
+pub fn create_legacy_message(fee_payer: &Pubkey, instructions: &[Instruction]) -> VersionedMessage {
+    VersionedMessage::Legacy(Message::new(instructions, Some(fee_payer)))
+}
+
+/// V1 message carrying a transfer instruction and the given transaction config.
+pub fn create_v1_message(fee_payer: &Pubkey, config: v1::TransactionConfig) -> VersionedMessage {
+    let mut message = v1::Message::try_compile(
+        fee_payer,
+        &[transfer(fee_payer, &Pubkey::new_unique(), 1_000)],
+        Hash::new_unique(),
+    )
+    .unwrap();
+    message.config = config;
+    VersionedMessage::V1(message)
+}
+
+/// V0 message whose instructions all invoke a program loaded from a lookup table:
+/// `program_id_index` 1 resolves past the single static key, so callers must supply
+/// the resolved key list themselves (see [`create_resolved_with_loaded_keys`]).
+pub fn create_v0_message_with_alt_loaded_program(
+    fee_payer: &Pubkey,
+    instruction_data: Vec<Vec<u8>>,
+) -> VersionedMessage {
+    VersionedMessage::V0(v0::Message {
+        header: MessageHeader {
+            num_required_signatures: 1,
+            num_readonly_signed_accounts: 0,
+            num_readonly_unsigned_accounts: 0,
+        },
+        account_keys: vec![*fee_payer],
+        recent_blockhash: Hash::new_unique(),
+        instructions: instruction_data
+            .into_iter()
+            .map(|data| CompiledInstruction { program_id_index: 1, accounts: vec![], data })
+            .collect(),
+        address_table_lookups: vec![v0::MessageAddressTableLookup {
+            account_key: Pubkey::new_unique(),
+            writable_indexes: vec![],
+            readonly_indexes: vec![0],
+        }],
+    })
+}
+
+/// Resolved transaction with an explicit resolved key list, for messages whose
+/// program ids live in a lookup table: `from_kora_built_transaction` cannot resolve
+/// those without RPC. `all_instructions` is left empty, so this only suits
+/// validations that read the message and resolved keys.
+pub fn create_resolved_with_loaded_keys(
+    message: VersionedMessage,
+    all_account_keys: Vec<Pubkey>,
+) -> VersionedTransactionResolved {
+    let mut resolved = create_mock_resolved_transaction();
+    resolved.transaction = TransactionUtil::new_unsigned_versioned_transaction(message);
+    resolved.all_account_keys = all_account_keys;
+    resolved.all_instructions = Vec::new();
+    resolved
 }

--- a/crates/lib/src/tests/transaction_mock.rs
+++ b/crates/lib/src/tests/transaction_mock.rs
@@ -91,12 +91,21 @@ pub fn create_legacy_message(fee_payer: &Pubkey, instructions: &[Instruction]) -
 
 /// V1 message carrying a transfer instruction and the given transaction config.
 pub fn create_v1_message(fee_payer: &Pubkey, config: v1::TransactionConfig) -> VersionedMessage {
-    let mut message = v1::Message::try_compile(
+    create_v1_message_with_instructions(
         fee_payer,
         &[transfer(fee_payer, &Pubkey::new_unique(), 1_000)],
-        Hash::new_unique(),
+        config,
     )
-    .unwrap();
+}
+
+/// V1 message carrying the given instructions and transaction config.
+pub fn create_v1_message_with_instructions(
+    fee_payer: &Pubkey,
+    instructions: &[Instruction],
+    config: v1::TransactionConfig,
+) -> VersionedMessage {
+    let mut message =
+        v1::Message::try_compile(fee_payer, instructions, Hash::new_unique()).unwrap();
     message.config = config;
     VersionedMessage::V1(message)
 }

--- a/crates/lib/src/validator/config_validator.rs
+++ b/crates/lib/src/validator/config_validator.rs
@@ -1020,6 +1020,7 @@ mod tests {
         let mut config = Config {
             validation: ValidationConfig {
                 max_allowed_lamports: 1000000000,
+                max_priority_fee_lamports: None,
                 max_signatures: 10,
                 allowed_programs: ProgramsConfig::Allowlist(vec!["program1".to_string()]),
                 allowed_tokens: vec!["token1".to_string()],
@@ -1062,6 +1063,7 @@ mod tests {
         let config = Config {
             validation: ValidationConfig {
                 max_allowed_lamports: 1_000_000,
+                max_priority_fee_lamports: None,
                 max_signatures: 10,
                 allowed_programs: ProgramsConfig::Allowlist(vec![
                     SYSTEM_PROGRAM_ID.to_string(),
@@ -1105,6 +1107,7 @@ mod tests {
     fn validation_config_with_auth() -> ValidationConfig {
         ValidationConfig {
             max_allowed_lamports: 1_000_000,
+            max_priority_fee_lamports: None,
             max_signatures: 10,
             allowed_programs: ProgramsConfig::Allowlist(vec![
                 SYSTEM_PROGRAM_ID.to_string(),
@@ -1198,6 +1201,7 @@ mod tests {
         let config = Config {
             validation: ValidationConfig {
                 max_allowed_lamports: 1_000_000,
+                max_priority_fee_lamports: None,
                 max_signatures: 10,
                 allowed_programs: ProgramsConfig::Allowlist(vec![
                     SYSTEM_PROGRAM_ID.to_string(),
@@ -1248,6 +1252,7 @@ mod tests {
         let config = Config {
             validation: ValidationConfig {
                 max_allowed_lamports: 1_000_000,
+                max_priority_fee_lamports: None,
                 max_signatures: 10,
                 allowed_programs: ProgramsConfig::Allowlist(vec![
                     SYSTEM_PROGRAM_ID.to_string(),
@@ -1299,6 +1304,7 @@ mod tests {
         let config = Config {
             validation: ValidationConfig {
                 max_allowed_lamports: 1_000_000,
+                max_priority_fee_lamports: None,
                 max_signatures: 10,
                 allowed_programs: ProgramsConfig::Allowlist(vec![
                     SYSTEM_PROGRAM_ID.to_string(),
@@ -1344,6 +1350,7 @@ mod tests {
         let config = Config {
             validation: ValidationConfig {
                 max_allowed_lamports: 1_000_000,
+                max_priority_fee_lamports: None,
                 max_signatures: 10,
                 allowed_programs: ProgramsConfig::Allowlist(vec![
                     SYSTEM_PROGRAM_ID.to_string(),
@@ -1391,7 +1398,8 @@ mod tests {
     async fn test_validate_with_result_warnings() {
         let config = Config {
             validation: ValidationConfig {
-                max_allowed_lamports: 0,                             // Should warn
+                max_allowed_lamports: 0, // Should warn
+                max_priority_fee_lamports: None,
                 max_signatures: 0,                                   // Should warn
                 allowed_programs: ProgramsConfig::Allowlist(vec![]), // Should warn
                 allowed_tokens: vec!["4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU".to_string()],
@@ -1564,6 +1572,7 @@ mod tests {
         let config = Config {
             validation: ValidationConfig {
                 max_allowed_lamports: 1_000_000,
+                max_priority_fee_lamports: None,
                 max_signatures: 10,
                 allowed_programs: ProgramsConfig::Allowlist(vec![SYSTEM_PROGRAM_ID.to_string()]),
                 allowed_tokens: vec![],
@@ -1603,6 +1612,7 @@ mod tests {
         let config = Config {
             validation: ValidationConfig {
                 max_allowed_lamports: 1_000_000,
+                max_priority_fee_lamports: None,
                 max_signatures: 10,
                 allowed_programs: ProgramsConfig::Allowlist(vec![SYSTEM_PROGRAM_ID.to_string()]),
                 allowed_tokens: vec![],
@@ -1643,6 +1653,7 @@ mod tests {
         let config = Config {
             validation: ValidationConfig {
                 max_allowed_lamports: 1_000_000,
+                max_priority_fee_lamports: None,
                 max_signatures: 10,
                 allowed_programs: ProgramsConfig::Allowlist(vec![
                     "11111111111111111111111111111112".to_string(),
@@ -1759,6 +1770,7 @@ mod tests {
         let config = Config {
             validation: ValidationConfig {
                 max_allowed_lamports: 1_000_000,
+                max_priority_fee_lamports: None,
                 max_signatures: 10,
                 allowed_programs: ProgramsConfig::Allowlist(vec![SYSTEM_PROGRAM_ID.to_string()]),
                 allowed_tokens: vec![], // Error - no tokens
@@ -1804,6 +1816,7 @@ mod tests {
         let config = Config {
             validation: ValidationConfig {
                 max_allowed_lamports: 1_000_000,
+                max_priority_fee_lamports: None,
                 max_signatures: 10,
                 allowed_programs: ProgramsConfig::Allowlist(vec![SYSTEM_PROGRAM_ID.to_string()]),
                 allowed_tokens: vec!["4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU".to_string()],
@@ -1850,6 +1863,7 @@ mod tests {
         let config = Config {
             validation: ValidationConfig {
                 max_allowed_lamports: 1_000_000,
+                max_priority_fee_lamports: None,
                 max_signatures: 10,
                 allowed_programs: ProgramsConfig::Allowlist(vec![SYSTEM_PROGRAM_ID.to_string()]),
                 allowed_tokens: vec!["4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU".to_string()],
@@ -1902,6 +1916,7 @@ mod tests {
         let config = Config {
             validation: ValidationConfig {
                 max_allowed_lamports: 1_000_000,
+                max_priority_fee_lamports: None,
                 max_signatures: 10,
                 allowed_programs: ProgramsConfig::Allowlist(vec![
                     SYSTEM_PROGRAM_ID.to_string(),
@@ -1953,6 +1968,7 @@ mod tests {
         let config = Config {
             validation: ValidationConfig {
                 max_allowed_lamports: 1_000_000,
+                max_priority_fee_lamports: None,
                 max_signatures: 10,
                 allowed_programs: ProgramsConfig::Allowlist(vec![SYSTEM_PROGRAM_ID.to_string()]), // Missing token programs
                 allowed_tokens: vec!["4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU".to_string()],
@@ -1995,6 +2011,7 @@ mod tests {
         let config = Config {
             validation: ValidationConfig {
                 max_allowed_lamports: 1_000_000,
+                max_priority_fee_lamports: None,
                 max_signatures: 10,
                 allowed_programs: ProgramsConfig::Allowlist(vec![
                     SYSTEM_PROGRAM_ID.to_string(),
@@ -2036,6 +2053,7 @@ mod tests {
         let config = Config {
             validation: ValidationConfig {
                 max_allowed_lamports: 1_000_000,
+                max_priority_fee_lamports: None,
                 max_signatures: 10,
                 allowed_programs: ProgramsConfig::Allowlist(vec![
                     SYSTEM_PROGRAM_ID.to_string(),
@@ -2075,6 +2093,7 @@ mod tests {
         Config {
             validation: ValidationConfig {
                 max_allowed_lamports: 1_000_000,
+                max_priority_fee_lamports: None,
                 max_signatures: 10,
                 allowed_programs: ProgramsConfig::Allowlist(vec![SYSTEM_PROGRAM_ID.to_string()]),
                 allowed_tokens: vec!["4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU".to_string()], // Required to pass basic validation
@@ -2102,6 +2121,7 @@ mod tests {
         Config {
             validation: ValidationConfig {
                 max_allowed_lamports: 1_000_000,
+                max_priority_fee_lamports: None,
                 max_signatures: 10,
                 allowed_programs: ProgramsConfig::Allowlist(vec![]), // No programs
                 allowed_tokens: vec!["4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU".to_string()],
@@ -2170,6 +2190,7 @@ mod tests {
         let config = Config {
             validation: ValidationConfig {
                 max_allowed_lamports: 1_000_000,
+                max_priority_fee_lamports: None,
                 max_signatures: 10,
                 allowed_programs: ProgramsConfig::Allowlist(vec![SYSTEM_PROGRAM_ID.to_string()]),
                 allowed_tokens: vec!["4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU".to_string()],
@@ -2207,6 +2228,7 @@ mod tests {
         let config = Config {
             validation: ValidationConfig {
                 max_allowed_lamports: 1_000_000,
+                max_priority_fee_lamports: None,
                 max_signatures: 10,
                 allowed_programs: ProgramsConfig::Allowlist(vec![SYSTEM_PROGRAM_ID.to_string()]),
                 allowed_tokens: vec!["4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU".to_string()],
@@ -2244,6 +2266,7 @@ mod tests {
         let config = Config {
             validation: ValidationConfig {
                 max_allowed_lamports: 1_000_000,
+                max_priority_fee_lamports: None,
                 max_signatures: 10,
                 allowed_programs: ProgramsConfig::Allowlist(vec![SYSTEM_PROGRAM_ID.to_string()]),
                 allowed_tokens: vec!["4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU".to_string()],
@@ -2280,6 +2303,7 @@ mod tests {
         let config = Config {
             validation: ValidationConfig {
                 max_allowed_lamports: 1_000_000,
+                max_priority_fee_lamports: None,
                 max_signatures: 10,
                 allowed_programs: ProgramsConfig::Allowlist(vec![SYSTEM_PROGRAM_ID.to_string()]),
                 allowed_tokens: vec!["4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU".to_string()],
@@ -2322,6 +2346,7 @@ mod tests {
         let config = Config {
             validation: ValidationConfig {
                 max_allowed_lamports: 1_000_000,
+                max_priority_fee_lamports: None,
                 max_signatures: 10,
                 allowed_programs: ProgramsConfig::Allowlist(vec![SYSTEM_PROGRAM_ID.to_string()]),
                 allowed_tokens: vec!["4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU".to_string()],
@@ -2364,6 +2389,7 @@ mod tests {
         let config = Config {
             validation: ValidationConfig {
                 max_allowed_lamports: 1_000_000,
+                max_priority_fee_lamports: None,
                 max_signatures: 10,
                 allowed_programs: ProgramsConfig::Allowlist(vec![SYSTEM_PROGRAM_ID.to_string()]),
                 allowed_tokens: vec!["4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU".to_string()],
@@ -2480,6 +2506,7 @@ mod tests {
         let config = Config {
             validation: ValidationConfig {
                 max_allowed_lamports: 1_000_000,
+                max_priority_fee_lamports: None,
                 max_signatures: 10,
                 allowed_programs: ProgramsConfig::Allowlist(vec![
                     SYSTEM_PROGRAM_ID.to_string(),
@@ -2876,6 +2903,7 @@ mod tests {
         let config = Config {
             validation: ValidationConfig {
                 max_allowed_lamports: 1_000_000,
+                max_priority_fee_lamports: None,
                 max_signatures: 10,
                 allowed_programs: ProgramsConfig::Allowlist(vec![
                     SYSTEM_PROGRAM_ID.to_string(),
@@ -2918,6 +2946,7 @@ mod tests {
         let config = Config {
             validation: ValidationConfig {
                 max_allowed_lamports: 1_000_000,
+                max_priority_fee_lamports: None,
                 max_signatures: 10,
                 allowed_programs: ProgramsConfig::Allowlist(vec![
                     SYSTEM_PROGRAM_ID.to_string(),
@@ -2961,6 +2990,7 @@ mod tests {
         let config = Config {
             validation: ValidationConfig {
                 max_allowed_lamports: 1_000_000,
+                max_priority_fee_lamports: None,
                 max_signatures: 10,
                 allowed_programs: ProgramsConfig::Allowlist(vec![
                     SYSTEM_PROGRAM_ID.to_string(),
@@ -3003,6 +3033,7 @@ mod tests {
         let config = Config {
             validation: ValidationConfig {
                 max_allowed_lamports: 1_000_000,
+                max_priority_fee_lamports: None,
                 max_signatures: 10,
                 allowed_programs: ProgramsConfig::Allowlist(vec![
                     SYSTEM_PROGRAM_ID.to_string(),
@@ -3052,6 +3083,7 @@ mod tests {
         let config = Config {
             validation: ValidationConfig {
                 max_allowed_lamports: 1_000_000,
+                max_priority_fee_lamports: None,
                 max_signatures: 10,
                 allowed_programs: ProgramsConfig::Allowlist(vec![
                     SYSTEM_PROGRAM_ID.to_string(),
@@ -3103,6 +3135,7 @@ mod tests {
         let config = Config {
             validation: ValidationConfig {
                 max_allowed_lamports: 1_000_000,
+                max_priority_fee_lamports: None,
                 max_signatures: 10,
                 allowed_programs: ProgramsConfig::Allowlist(vec![
                     SYSTEM_PROGRAM_ID.to_string(),
@@ -3285,6 +3318,7 @@ mod tests {
         let config = Config {
             validation: ValidationConfig {
                 max_allowed_lamports: 1_000_000,
+                max_priority_fee_lamports: None,
                 max_signatures: 10,
                 allowed_programs: ProgramsConfig::Allowlist(vec![
                     SYSTEM_PROGRAM_ID.to_string(),

--- a/crates/lib/src/validator/transaction_validator.rs
+++ b/crates/lib/src/validator/transaction_validator.rs
@@ -1059,6 +1059,7 @@ mod tests {
             transaction_mock::{
                 create_legacy_message, create_resolved_with_loaded_keys,
                 create_v0_message_with_alt_loaded_program, create_v1_message,
+                create_v1_message_with_instructions,
             },
         },
         transaction::TransactionUtil,
@@ -1515,6 +1516,59 @@ mod tests {
         let error = validator.validate_priority_fee(&over_cap).unwrap_err();
         assert!(
             error.to_string().contains("Priority fee 15000 exceeds maximum allowed 10000"),
+            "Unexpected error: {error}"
+        );
+    }
+
+    /// The runtime ignores ComputeBudget instructions in a V1 transaction, so the cap must
+    /// read the transaction config alone. Billing the instructions instead would reject a
+    /// transaction whose real priority fee is under the cap.
+    #[test]
+    fn test_validate_priority_fee_v1_ignores_over_cap_compute_budget_instructions() {
+        let fee_payer = Pubkey::new_unique();
+        let recipient = Pubkey::new_unique();
+        let config = ConfigMockBuilder::new().with_max_priority_fee_lamports(10_000).build();
+        let validator = TransactionValidator::new(&config, fee_payer).unwrap();
+
+        // Config asks 9_000, under the cap; the inert instructions ask
+        // 300_000 CU * 100_000 micro-lamports = 30_000 lamports, well over it.
+        let transaction = resolved_from_message(create_v1_message_with_instructions(
+            &fee_payer,
+            &[
+                ComputeBudgetInstruction::set_compute_unit_limit(300_000),
+                ComputeBudgetInstruction::set_compute_unit_price(100_000),
+                transfer(&fee_payer, &recipient, 1_000),
+            ],
+            v1::TransactionConfig::empty().with_priority_fee(9_000),
+        ));
+
+        assert!(validator.validate_priority_fee(&transaction).is_ok());
+    }
+
+    /// The mirror case: under-cap ComputeBudget instructions must not rescue a V1
+    /// transaction whose config priority fee is over the cap.
+    #[test]
+    fn test_validate_priority_fee_v1_rejects_over_cap_config_despite_cheap_instructions() {
+        let fee_payer = Pubkey::new_unique();
+        let recipient = Pubkey::new_unique();
+        let config = ConfigMockBuilder::new().with_max_priority_fee_lamports(10_000).build();
+        let validator = TransactionValidator::new(&config, fee_payer).unwrap();
+
+        // Config asks 11_000, over the cap; the inert instructions ask
+        // 300_000 CU * 10_000 micro-lamports = 3_000 lamports, under it.
+        let transaction = resolved_from_message(create_v1_message_with_instructions(
+            &fee_payer,
+            &[
+                ComputeBudgetInstruction::set_compute_unit_limit(300_000),
+                ComputeBudgetInstruction::set_compute_unit_price(10_000),
+                transfer(&fee_payer, &recipient, 1_000),
+            ],
+            v1::TransactionConfig::empty().with_priority_fee(11_000),
+        ));
+
+        let error = validator.validate_priority_fee(&transaction).unwrap_err();
+        assert!(
+            error.to_string().contains("Priority fee 11000 exceeds maximum allowed 10000"),
             "Unexpected error: {error}"
         );
     }

--- a/crates/lib/src/validator/transaction_validator.rs
+++ b/crates/lib/src/validator/transaction_validator.rs
@@ -1056,6 +1056,10 @@ mod tests {
             account_mock::{AccountMockBuilder, MintAccountMockBuilder, TokenAccountMockBuilder},
             config_mock::{mock_state::setup_config_mock, ConfigMockBuilder},
             rpc_mock::RpcMockBuilder,
+            transaction_mock::{
+                create_legacy_message, create_resolved_with_loaded_keys,
+                create_v0_message_with_alt_loaded_program, create_v1_message,
+            },
         },
         transaction::TransactionUtil,
     };
@@ -1068,11 +1072,8 @@ mod tests {
         instruction as alt_instruction, program::ID as ADDRESS_LOOKUP_TABLE_PROGRAM_ID,
     };
     use solana_compute_budget_interface::ComputeBudgetInstruction;
-    use solana_message::{
-        compiled_instruction::CompiledInstruction, v0, v1, Message, VersionedMessage,
-    };
+    use solana_message::{v1, Message, VersionedMessage};
     use solana_sdk::{
-        hash::Hash,
         instruction::{AccountMeta, Instruction},
         signature::{Keypair, Signer},
     };
@@ -1443,28 +1444,8 @@ mod tests {
             .is_ok());
     }
 
-    fn legacy_transaction_with_instructions(
-        fee_payer: &Pubkey,
-        instructions: &[Instruction],
-    ) -> VersionedTransactionResolved {
-        let message = VersionedMessage::Legacy(Message::new(instructions, Some(fee_payer)));
+    fn resolved_from_message(message: VersionedMessage) -> VersionedTransactionResolved {
         TransactionUtil::new_unsigned_versioned_transaction_resolved(message).unwrap()
-    }
-
-    fn v1_transaction_with_config(
-        fee_payer: &Pubkey,
-        config: v1::TransactionConfig,
-    ) -> VersionedTransactionResolved {
-        let recipient = Pubkey::new_unique();
-        let mut message = v1::Message::try_compile(
-            fee_payer,
-            &[transfer(fee_payer, &recipient, 1_000)],
-            Hash::default(),
-        )
-        .unwrap();
-        message.config = config;
-        TransactionUtil::new_unsigned_versioned_transaction_resolved(VersionedMessage::V1(message))
-            .unwrap()
     }
 
     #[test]
@@ -1473,10 +1454,10 @@ mod tests {
         let config = ConfigMockBuilder::new().build();
         let validator = TransactionValidator::new(&config, fee_payer).unwrap();
 
-        let transaction = v1_transaction_with_config(
+        let transaction = resolved_from_message(create_v1_message(
             &fee_payer,
             v1::TransactionConfig::empty().with_priority_fee(u64::MAX),
-        );
+        ));
 
         assert!(validator.validate_priority_fee(&transaction).is_ok());
     }
@@ -1487,16 +1468,16 @@ mod tests {
         let config = ConfigMockBuilder::new().with_max_priority_fee_lamports(10_000).build();
         let validator = TransactionValidator::new(&config, fee_payer).unwrap();
 
-        let under_cap = v1_transaction_with_config(
+        let under_cap = resolved_from_message(create_v1_message(
             &fee_payer,
             v1::TransactionConfig::empty().with_priority_fee(10_000),
-        );
+        ));
         assert!(validator.validate_priority_fee(&under_cap).is_ok());
 
-        let over_cap = v1_transaction_with_config(
+        let over_cap = resolved_from_message(create_v1_message(
             &fee_payer,
             v1::TransactionConfig::empty().with_priority_fee(10_001),
-        );
+        ));
         let error = validator.validate_priority_fee(&over_cap).unwrap_err();
         assert!(
             error.to_string().contains("Priority fee 10001 exceeds maximum allowed 10000"),
@@ -1512,25 +1493,25 @@ mod tests {
         let validator = TransactionValidator::new(&config, fee_payer).unwrap();
 
         // 300_000 CU * 25_000 micro-lamports = 7_500 lamports, under the cap
-        let under_cap = legacy_transaction_with_instructions(
+        let under_cap = resolved_from_message(create_legacy_message(
             &fee_payer,
             &[
                 ComputeBudgetInstruction::set_compute_unit_limit(300_000),
                 ComputeBudgetInstruction::set_compute_unit_price(25_000),
                 transfer(&fee_payer, &recipient, 1_000),
             ],
-        );
+        ));
         assert!(validator.validate_priority_fee(&under_cap).is_ok());
 
         // 300_000 CU * 50_000 micro-lamports = 15_000 lamports, over the cap
-        let over_cap = legacy_transaction_with_instructions(
+        let over_cap = resolved_from_message(create_legacy_message(
             &fee_payer,
             &[
                 ComputeBudgetInstruction::set_compute_unit_limit(300_000),
                 ComputeBudgetInstruction::set_compute_unit_price(50_000),
                 transfer(&fee_payer, &recipient, 1_000),
             ],
-        );
+        ));
         let error = validator.validate_priority_fee(&over_cap).unwrap_err();
         assert!(
             error.to_string().contains("Priority fee 15000 exceeds maximum allowed 10000"),
@@ -1545,20 +1526,20 @@ mod tests {
         let config = ConfigMockBuilder::new().with_max_priority_fee_lamports(0).build();
         let validator = TransactionValidator::new(&config, fee_payer).unwrap();
 
-        let no_priority_fee = legacy_transaction_with_instructions(
+        let no_priority_fee = resolved_from_message(create_legacy_message(
             &fee_payer,
             &[transfer(&fee_payer, &recipient, 1_000)],
-        );
+        ));
         assert!(validator.validate_priority_fee(&no_priority_fee).is_ok());
 
         let v1_no_priority_fee =
-            v1_transaction_with_config(&fee_payer, v1::TransactionConfig::empty());
+            resolved_from_message(create_v1_message(&fee_payer, v1::TransactionConfig::empty()));
         assert!(validator.validate_priority_fee(&v1_no_priority_fee).is_ok());
 
-        let v1_with_priority_fee = v1_transaction_with_config(
+        let v1_with_priority_fee = resolved_from_message(create_v1_message(
             &fee_payer,
             v1::TransactionConfig::empty().with_priority_fee(1),
-        );
+        ));
         assert!(validator.validate_priority_fee(&v1_with_priority_fee).is_err());
     }
 
@@ -1568,39 +1549,17 @@ mod tests {
         let config = ConfigMockBuilder::new().with_max_priority_fee_lamports(10_000).build();
         let validator = TransactionValidator::new(&config, fee_payer).unwrap();
 
-        let message = VersionedMessage::V0(v0::Message {
-            header: solana_message::MessageHeader {
-                num_required_signatures: 1,
-                num_readonly_signed_accounts: 0,
-                num_readonly_unsigned_accounts: 0,
-            },
-            account_keys: vec![fee_payer],
-            recent_blockhash: Hash::new_unique(),
-            instructions: vec![
-                CompiledInstruction {
-                    program_id_index: 1,
-                    accounts: vec![],
-                    data: ComputeBudgetInstruction::set_compute_unit_limit(300_000).data,
-                },
-                CompiledInstruction {
-                    program_id_index: 1,
-                    accounts: vec![],
-                    data: ComputeBudgetInstruction::set_compute_unit_price(50_000).data,
-                },
-            ],
-            address_table_lookups: vec![v0::MessageAddressTableLookup {
-                account_key: Pubkey::new_unique(),
-                writable_indexes: vec![],
-                readonly_indexes: vec![0],
-            }],
-        });
-        let recipient = Pubkey::new_unique();
-        let mut resolved = legacy_transaction_with_instructions(
+        let message = create_v0_message_with_alt_loaded_program(
             &fee_payer,
-            &[transfer(&fee_payer, &recipient, 1_000)],
+            vec![
+                ComputeBudgetInstruction::set_compute_unit_limit(300_000).data,
+                ComputeBudgetInstruction::set_compute_unit_price(50_000).data,
+            ],
         );
-        resolved.transaction.message = message;
-        resolved.all_account_keys = vec![fee_payer, solana_compute_budget_interface::id()];
+        let resolved = create_resolved_with_loaded_keys(
+            message,
+            vec![fee_payer, solana_compute_budget_interface::id()],
+        );
 
         // 300_000 CU * 50_000 micro-lamports = 15_000 lamports, over the cap;
         // the validator must see it through the resolved keys, not the static ones.

--- a/crates/lib/src/validator/transaction_validator.rs
+++ b/crates/lib/src/validator/transaction_validator.rs
@@ -1,7 +1,7 @@
 use crate::{
     config::{Config, FeePayerPolicy, ProgramsConfig},
     error::KoraError,
-    fee::fee::{FeeConfigUtil, TotalFeeCalculation},
+    fee::fee::{FeeConfigUtil, TotalFeeCalculation, TransactionFeeUtil},
     oracle::PriceSource,
     token::{
         interface::TokenMint,
@@ -25,6 +25,7 @@ use crate::fee::price::PriceModel;
 pub struct TransactionValidator {
     fee_payer_pubkey: Pubkey,
     max_allowed_lamports: u64,
+    max_priority_fee_lamports: Option<u64>,
     allowed_programs: HashSet<Pubkey>,
     allow_all_programs: bool,
     require_one_of_programs: HashSet<Pubkey>,
@@ -72,6 +73,7 @@ impl TransactionValidator {
         Ok(Self {
             fee_payer_pubkey,
             max_allowed_lamports: config.max_allowed_lamports,
+            max_priority_fee_lamports: config.max_priority_fee_lamports,
             allowed_programs,
             allow_all_programs,
             require_one_of_programs,
@@ -146,6 +148,7 @@ impl TransactionValidator {
 
         self.validate_programs(transaction_resolved)?;
         self.validate_require_one_of_programs(transaction_resolved)?;
+        self.validate_priority_fee(&transaction_resolved.transaction)?;
         self.validate_transfer_amounts(config, transaction_resolved, rpc_client).await?;
         self.validate_disallowed_accounts(transaction_resolved)?;
         self.validate_fee_payer_usage(config, transaction_resolved)?;
@@ -224,6 +227,21 @@ impl TransactionValidator {
                  its resource limits come from the transaction config"
             );
         }
+    }
+
+    fn validate_priority_fee(&self, transaction: &VersionedTransaction) -> Result<(), KoraError> {
+        let Some(max_priority_fee_lamports) = self.max_priority_fee_lamports else {
+            return Ok(());
+        };
+
+        let priority_fee = TransactionFeeUtil::get_requested_priority_fee(&transaction.message);
+        if priority_fee > max_priority_fee_lamports {
+            return Err(KoraError::InvalidTransaction(format!(
+                "Priority fee {priority_fee} exceeds maximum allowed {max_priority_fee_lamports}"
+            )));
+        }
+
+        Ok(())
     }
 
     pub fn validate_lamport_fee(&self, fee: u64) -> Result<(), KoraError> {
@@ -1044,8 +1062,9 @@ mod tests {
         instruction as alt_instruction, program::ID as ADDRESS_LOOKUP_TABLE_PROGRAM_ID,
     };
     use solana_compute_budget_interface::ComputeBudgetInstruction;
-    use solana_message::{Message, VersionedMessage};
+    use solana_message::{v1, Message, VersionedMessage};
     use solana_sdk::{
+        hash::Hash,
         instruction::{AccountMeta, Instruction},
         signature::{Keypair, Signer},
     };
@@ -1414,6 +1433,124 @@ mod tests {
             .validate_transaction(get_config().unwrap(), &mut transaction, &rpc_client)
             .await
             .is_ok());
+    }
+
+    fn legacy_transaction_with_instructions(
+        fee_payer: &Pubkey,
+        instructions: &[Instruction],
+    ) -> VersionedTransaction {
+        let message = VersionedMessage::Legacy(Message::new(instructions, Some(fee_payer)));
+        TransactionUtil::new_unsigned_versioned_transaction(message)
+    }
+
+    fn v1_transaction_with_config(
+        fee_payer: &Pubkey,
+        config: v1::TransactionConfig,
+    ) -> VersionedTransaction {
+        let recipient = Pubkey::new_unique();
+        let mut message = v1::Message::try_compile(
+            fee_payer,
+            &[transfer(fee_payer, &recipient, 1_000)],
+            Hash::default(),
+        )
+        .unwrap();
+        message.config = config;
+        TransactionUtil::new_unsigned_versioned_transaction(VersionedMessage::V1(message))
+    }
+
+    #[test]
+    fn test_validate_priority_fee_unset_allows_any() {
+        let fee_payer = Pubkey::new_unique();
+        let config = ConfigMockBuilder::new().build();
+        let validator = TransactionValidator::new(&config, fee_payer).unwrap();
+
+        let transaction = v1_transaction_with_config(
+            &fee_payer,
+            v1::TransactionConfig::empty().with_priority_fee(u64::MAX),
+        );
+
+        assert!(validator.validate_priority_fee(&transaction).is_ok());
+    }
+
+    #[test]
+    fn test_validate_priority_fee_enforces_cap_for_v1_config() {
+        let fee_payer = Pubkey::new_unique();
+        let config = ConfigMockBuilder::new().with_max_priority_fee_lamports(10_000).build();
+        let validator = TransactionValidator::new(&config, fee_payer).unwrap();
+
+        let under_cap = v1_transaction_with_config(
+            &fee_payer,
+            v1::TransactionConfig::empty().with_priority_fee(10_000),
+        );
+        assert!(validator.validate_priority_fee(&under_cap).is_ok());
+
+        let over_cap = v1_transaction_with_config(
+            &fee_payer,
+            v1::TransactionConfig::empty().with_priority_fee(10_001),
+        );
+        let error = validator.validate_priority_fee(&over_cap).unwrap_err();
+        assert!(
+            error.to_string().contains("Priority fee 10001 exceeds maximum allowed 10000"),
+            "Unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn test_validate_priority_fee_enforces_cap_for_compute_budget_instructions() {
+        let fee_payer = Pubkey::new_unique();
+        let recipient = Pubkey::new_unique();
+        let config = ConfigMockBuilder::new().with_max_priority_fee_lamports(10_000).build();
+        let validator = TransactionValidator::new(&config, fee_payer).unwrap();
+
+        // 300_000 CU * 25_000 micro-lamports = 7_500 lamports, under the cap
+        let under_cap = legacy_transaction_with_instructions(
+            &fee_payer,
+            &[
+                ComputeBudgetInstruction::set_compute_unit_limit(300_000),
+                ComputeBudgetInstruction::set_compute_unit_price(25_000),
+                transfer(&fee_payer, &recipient, 1_000),
+            ],
+        );
+        assert!(validator.validate_priority_fee(&under_cap).is_ok());
+
+        // 300_000 CU * 50_000 micro-lamports = 15_000 lamports, over the cap
+        let over_cap = legacy_transaction_with_instructions(
+            &fee_payer,
+            &[
+                ComputeBudgetInstruction::set_compute_unit_limit(300_000),
+                ComputeBudgetInstruction::set_compute_unit_price(50_000),
+                transfer(&fee_payer, &recipient, 1_000),
+            ],
+        );
+        let error = validator.validate_priority_fee(&over_cap).unwrap_err();
+        assert!(
+            error.to_string().contains("Priority fee 15000 exceeds maximum allowed 10000"),
+            "Unexpected error: {error}"
+        );
+    }
+
+    #[test]
+    fn test_validate_priority_fee_zero_cap_blocks_priority_fees() {
+        let fee_payer = Pubkey::new_unique();
+        let recipient = Pubkey::new_unique();
+        let config = ConfigMockBuilder::new().with_max_priority_fee_lamports(0).build();
+        let validator = TransactionValidator::new(&config, fee_payer).unwrap();
+
+        let no_priority_fee = legacy_transaction_with_instructions(
+            &fee_payer,
+            &[transfer(&fee_payer, &recipient, 1_000)],
+        );
+        assert!(validator.validate_priority_fee(&no_priority_fee).is_ok());
+
+        let v1_no_priority_fee =
+            v1_transaction_with_config(&fee_payer, v1::TransactionConfig::empty());
+        assert!(validator.validate_priority_fee(&v1_no_priority_fee).is_ok());
+
+        let v1_with_priority_fee = v1_transaction_with_config(
+            &fee_payer,
+            v1::TransactionConfig::empty().with_priority_fee(1),
+        );
+        assert!(validator.validate_priority_fee(&v1_with_priority_fee).is_err());
     }
 
     #[tokio::test]

--- a/crates/lib/src/validator/transaction_validator.rs
+++ b/crates/lib/src/validator/transaction_validator.rs
@@ -148,7 +148,7 @@ impl TransactionValidator {
 
         self.validate_programs(transaction_resolved)?;
         self.validate_require_one_of_programs(transaction_resolved)?;
-        self.validate_priority_fee(&transaction_resolved.transaction)?;
+        self.validate_priority_fee(transaction_resolved)?;
         self.validate_transfer_amounts(config, transaction_resolved, rpc_client).await?;
         self.validate_disallowed_accounts(transaction_resolved)?;
         self.validate_fee_payer_usage(config, transaction_resolved)?;
@@ -229,12 +229,18 @@ impl TransactionValidator {
         }
     }
 
-    fn validate_priority_fee(&self, transaction: &VersionedTransaction) -> Result<(), KoraError> {
+    fn validate_priority_fee(
+        &self,
+        transaction_resolved: &VersionedTransactionResolved,
+    ) -> Result<(), KoraError> {
         let Some(max_priority_fee_lamports) = self.max_priority_fee_lamports else {
             return Ok(());
         };
 
-        let priority_fee = TransactionFeeUtil::get_requested_priority_fee(&transaction.message);
+        let priority_fee = TransactionFeeUtil::get_requested_priority_fee(
+            &transaction_resolved.transaction.message,
+            &transaction_resolved.all_account_keys,
+        );
         if priority_fee > max_priority_fee_lamports {
             return Err(KoraError::InvalidTransaction(format!(
                 "Priority fee {priority_fee} exceeds maximum allowed {max_priority_fee_lamports}"
@@ -1062,7 +1068,9 @@ mod tests {
         instruction as alt_instruction, program::ID as ADDRESS_LOOKUP_TABLE_PROGRAM_ID,
     };
     use solana_compute_budget_interface::ComputeBudgetInstruction;
-    use solana_message::{v1, Message, VersionedMessage};
+    use solana_message::{
+        compiled_instruction::CompiledInstruction, v0, v1, Message, VersionedMessage,
+    };
     use solana_sdk::{
         hash::Hash,
         instruction::{AccountMeta, Instruction},
@@ -1438,15 +1446,15 @@ mod tests {
     fn legacy_transaction_with_instructions(
         fee_payer: &Pubkey,
         instructions: &[Instruction],
-    ) -> VersionedTransaction {
+    ) -> VersionedTransactionResolved {
         let message = VersionedMessage::Legacy(Message::new(instructions, Some(fee_payer)));
-        TransactionUtil::new_unsigned_versioned_transaction(message)
+        TransactionUtil::new_unsigned_versioned_transaction_resolved(message).unwrap()
     }
 
     fn v1_transaction_with_config(
         fee_payer: &Pubkey,
         config: v1::TransactionConfig,
-    ) -> VersionedTransaction {
+    ) -> VersionedTransactionResolved {
         let recipient = Pubkey::new_unique();
         let mut message = v1::Message::try_compile(
             fee_payer,
@@ -1455,7 +1463,8 @@ mod tests {
         )
         .unwrap();
         message.config = config;
-        TransactionUtil::new_unsigned_versioned_transaction(VersionedMessage::V1(message))
+        TransactionUtil::new_unsigned_versioned_transaction_resolved(VersionedMessage::V1(message))
+            .unwrap()
     }
 
     #[test]
@@ -1551,6 +1560,55 @@ mod tests {
             v1::TransactionConfig::empty().with_priority_fee(1),
         );
         assert!(validator.validate_priority_fee(&v1_with_priority_fee).is_err());
+    }
+
+    #[test]
+    fn test_validate_priority_fee_counts_alt_loaded_compute_budget() {
+        let fee_payer = Pubkey::new_unique();
+        let config = ConfigMockBuilder::new().with_max_priority_fee_lamports(10_000).build();
+        let validator = TransactionValidator::new(&config, fee_payer).unwrap();
+
+        let message = VersionedMessage::V0(v0::Message {
+            header: solana_message::MessageHeader {
+                num_required_signatures: 1,
+                num_readonly_signed_accounts: 0,
+                num_readonly_unsigned_accounts: 0,
+            },
+            account_keys: vec![fee_payer],
+            recent_blockhash: Hash::new_unique(),
+            instructions: vec![
+                CompiledInstruction {
+                    program_id_index: 1,
+                    accounts: vec![],
+                    data: ComputeBudgetInstruction::set_compute_unit_limit(300_000).data,
+                },
+                CompiledInstruction {
+                    program_id_index: 1,
+                    accounts: vec![],
+                    data: ComputeBudgetInstruction::set_compute_unit_price(50_000).data,
+                },
+            ],
+            address_table_lookups: vec![v0::MessageAddressTableLookup {
+                account_key: Pubkey::new_unique(),
+                writable_indexes: vec![],
+                readonly_indexes: vec![0],
+            }],
+        });
+        let recipient = Pubkey::new_unique();
+        let mut resolved = legacy_transaction_with_instructions(
+            &fee_payer,
+            &[transfer(&fee_payer, &recipient, 1_000)],
+        );
+        resolved.transaction.message = message;
+        resolved.all_account_keys = vec![fee_payer, solana_compute_budget_interface::id()];
+
+        // 300_000 CU * 50_000 micro-lamports = 15_000 lamports, over the cap;
+        // the validator must see it through the resolved keys, not the static ones.
+        let error = validator.validate_priority_fee(&resolved).unwrap_err();
+        assert!(
+            error.to_string().contains("Priority fee 15000 exceeds maximum allowed 10000"),
+            "Unexpected error: {error}"
+        );
     }
 
     #[tokio::test]

--- a/kora.toml
+++ b/kora.toml
@@ -51,6 +51,9 @@ get_version = true
 
 [validation]
 max_allowed_lamports = 1000000
+# Max priority fee in lamports (unset = unlimited, 0 = none).
+# Covers ComputeBudget instructions and the v1 transaction config.
+# max_priority_fee_lamports = 100000
 max_signatures = 10
 price_source = "Mock"
 allow_durable_transactions = false

--- a/tests/rpc/compute_budget.rs
+++ b/tests/rpc/compute_budget.rs
@@ -175,6 +175,98 @@ async fn test_estimate_transaction_fee_v1_config_priority_fee_wins_over_compute_
     assert!(fee == 35_050, "V1 fee must come from the config priority fee alone, got {fee}");
 }
 
+/// max_priority_fee_lamports is 5_000_000 in kora-test.toml; a V1 config priority
+/// fee above it must be rejected before signing.
+#[tokio::test]
+async fn test_sign_transaction_v1_rejects_priority_fee_above_config_cap() {
+    let ctx = TestContext::new().await.expect("Failed to create test context");
+    let fee_payer = FeePayerTestHelper::get_fee_payer_pubkey();
+    let sender = SenderTestHelper::get_test_sender_keypair();
+
+    let test_tx = ctx
+        .v1_transaction_builder()
+        .with_fee_payer(fee_payer)
+        .with_v1_priority_fee(6_000_000)
+        .with_transfer(&sender.pubkey(), &RecipientTestHelper::get_recipient_pubkey(), 10)
+        .build()
+        .await
+        .expect("Failed to create V1 transaction");
+
+    let result: Result<serde_json::Value, _> =
+        ctx.rpc_call("signTransaction", rpc_params![test_tx]).await;
+
+    let error = result.expect_err("Expected rejection for V1 priority fee above the config cap");
+    assert!(
+        error.to_string().contains("Priority fee 6000000 exceeds maximum allowed 5000000"),
+        "Expected priority fee cap rejection, got: {error}"
+    );
+}
+
+/// The same cap applies to legacy ComputeBudget priority fees:
+/// 1_400_000 CU * 5_000_000 micro-lamports = 7_000_000 lamports, over the cap.
+#[tokio::test]
+async fn test_sign_transaction_legacy_rejects_priority_fee_above_config_cap() {
+    let ctx = TestContext::new().await.expect("Failed to create test context");
+    let fee_payer = FeePayerTestHelper::get_fee_payer_pubkey();
+    let sender = SenderTestHelper::get_test_sender_keypair();
+
+    let test_tx = ctx
+        .transaction_builder()
+        .with_fee_payer(fee_payer)
+        .with_transfer(&sender.pubkey(), &RecipientTestHelper::get_recipient_pubkey(), 10)
+        .with_compute_budget(1_400_000, 5_000_000)
+        .build()
+        .await
+        .expect("Failed to create test transaction");
+
+    let result: Result<serde_json::Value, _> =
+        ctx.rpc_call("signTransaction", rpc_params![test_tx]).await;
+
+    let error =
+        result.expect_err("Expected rejection for legacy priority fee above the config cap");
+    assert!(
+        error.to_string().contains("Priority fee 7000000 exceeds maximum allowed 5000000"),
+        "Expected priority fee cap rejection, got: {error}"
+    );
+}
+
+/// A V1 priority fee under the cap signs normally when the payment covers
+/// base fee plus priority fee.
+#[tokio::test]
+async fn test_sign_transaction_v1_accepts_priority_fee_under_config_cap() {
+    let ctx = TestContext::new().await.expect("Failed to create test context");
+    let fee_payer = FeePayerTestHelper::get_fee_payer_pubkey();
+    let token_mint = USDCMintTestHelper::get_test_usdc_mint_pubkey();
+    let sender = SenderTestHelper::get_test_sender_keypair();
+
+    let priority_fee = 20_000;
+    let test_tx = ctx
+        .v1_transaction_builder()
+        .with_fee_payer(fee_payer)
+        .with_v1_priority_fee(priority_fee)
+        .with_spl_transfer(
+            &token_mint,
+            &sender.pubkey(),
+            &fee_payer,
+            tests::common::helpers::get_fee_for_default_transaction_in_usdc() + priority_fee,
+        )
+        .with_transfer(&sender.pubkey(), &RecipientTestHelper::get_recipient_pubkey(), 10)
+        .build()
+        .await
+        .expect("Failed to create V1 transaction");
+
+    let response: serde_json::Value = ctx
+        .rpc_call("signTransaction", rpc_params![test_tx])
+        .await
+        .expect("Failed to sign V1 transaction with priority fee under the cap");
+
+    response.assert_success();
+    assert!(
+        response["signed_transaction"].as_str().is_some(),
+        "Expected signed_transaction in response"
+    );
+}
+
 // NOTE: Lookup table is properly tested via mint address (not in transaction accounts, only ATAs)
 #[tokio::test]
 async fn test_estimate_transaction_fee_with_compute_budget_v0_with_lookup() {

--- a/tests/src/common/fixtures/kora-test.toml
+++ b/tests/src/common/fixtures/kora-test.toml
@@ -27,6 +27,7 @@ sign_and_send_bundle = true
 
 [validation]
 max_allowed_lamports = 1000000
+max_priority_fee_lamports = 5000000
 max_signatures = 10
 price_source = "Mock"
 allow_durable_transactions = false


### PR DESCRIPTION
## Summary
- Adds `validation.max_priority_fee_lamports`: an explicit cap on the priority fee a transaction may request. Unset = unlimited (backward compatible), `0` = priority fees not allowed.
- Enforced uniformly in `TransactionValidator::validate_transaction`, per version from its native source: v1 reads `message.config.priority_fee` directly; legacy/v0 parses `SetComputeUnitPrice`/`SetComputeUnitLimit` and computes ceil(price x limit / 1e6). When a price is set without an explicit limit, the 1.4M CU protocol maximum is assumed (an upper bound, so the cap can only over-reject).
- Motivation: operators could block priority fees for legacy/v0 by omitting the ComputeBudget program from `allowed_programs`, but v1 carries the priority fee in the message config rather than an instruction, so the program allowlist cannot gate it. Under `Free` or `Fixed { strict: false }` pricing this was an unintended fee-payer cost channel bounded only by `max_allowed_lamports`.
- Operator docs and commented `kora.toml` example included.

Note: the checked-in OpenAPI spec (`combined_api.json`) was not regenerated because the `docs` feature does not compile on main (pre-existing utoipa drift in `openapi/docs.rs`, 28 errors, unrelated to this change).

## Test Plan
- 10 new unit tests: priority fee extraction matrix (price+limit, ceil rounding, price-without-limit fallback, no/zero price, v1 config read, v1 ignoring ComputeBudget instructions) and validator enforcement (unset cap, over/under cap for both v1 config and ComputeBudget instructions, zero cap). Full kora-lib suite: 945 passed.
- 3 new integration tests against the live test validator (cap set to 5,000,000 in kora-test.toml): over-cap v1 config fee and over-cap legacy ComputeBudget fee rejected at `signTransaction` with the exact error, under-cap v1 fee signs normally with payment covering base plus priority. Regular phase: rpc 62/62, tokens 17/17, adversarial 9/9.

## Breaking Changes
- None. The field defaults to unset, which preserves current behavior exactly.

Closes TOO-675