### PR TITLE
fix(ci): bump docker builder to rust 1.97-bookworm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 # cargo-chef splits dependency compilation into a layer keyed only on the dependency manifest
 # (recipe.json), so app-source changes reuse the cached dep build instead of recompiling everything.
-# Pin the builder distro to bookworm to match the runtime base below: the unsuffixed rust:1.91 image
-# now tracks Debian trixie (glibc 2.41), producing a binary that links GLIBC_2.38/2.39 — symbols the
+# Pin the builder distro to bookworm to match the runtime base below: the unsuffixed rust image
+# tracks Debian trixie (glibc 2.41), producing a binary that links GLIBC_2.38/2.39 - symbols the
 # debian:bookworm-slim runtime (glibc 2.36) lacks, so the container exits with a libc version error.
-FROM rust:1.91-bookworm AS chef
+FROM rust:1.97-bookworm AS chef
 RUN cargo install cargo-chef --locked
 WORKDIR /usr/src/app
 


### PR DESCRIPTION
## Summary
- `Publish Edge Docker Image` has failed on every push to `main` since #627 merged: the lockfile refresh brought the `aws-sdk` / `aws-smithy` tree (via the `solana-keychain` KMS signer) up to versions declaring `rust-version = 1.94.1`, so `cargo chef cook` aborts on the `rust:1.91-bookworm` builder with `error: rustc 1.91.1 is not supported by the following packages`.
- Bumps the builder image to `rust:1.97-bookworm` (rustc 1.97.1, Debian 12). Max MSRV across the whole dependency graph is 1.94.1 per `cargo metadata`, so 1.97 clears it with headroom.
- Keeps the `-bookworm` suffix: the unsuffixed tag tracks trixie (glibc 2.41) and would link GLIBC_2.38/2.39 symbols the `debian:bookworm-slim` runtime lacks (see #575).

## Test Plan
- No PR-triggered job builds the Dockerfile (`docker-edge.yml` runs on push to `main` + `workflow_dispatch` only), so this was verified locally: `docker build .` completes end to end on the new builder, and `docker run rust:1.97-bookworm rustc --version` reports `1.97.1` on Debian 12.
- Post-merge, the `Publish Edge Docker Image` run on `main` is the real confirmation.
- No other workflow is affected: the Rust jobs use `rust-toolchain.toml` (nightly) and were already green.