### PR TITLE
test: add Loader v4 fee-payer drain property coverage

### DIFF
--- a/crates/lib/src/validator/transaction_validator/fee_payer_policy_props/loader_v4.rs
+++ b/crates/lib/src/validator/transaction_validator/fee_payer_policy_props/loader_v4.rs
@@ -1,0 +1,84 @@
+use super::{assert_role_gated_iff_flag_off, role_and_flags, DrainRole};
+use crate::{config::FeePayerPolicy, constant::LOADER_V4_PROGRAM_ID};
+use proptest::prelude::*;
+use solana_loader_v4_interface::instruction::{
+    copy, deploy, finalize, retract, set_program_length, transfer_authority, write,
+};
+use solana_sdk::{instruction::Instruction, pubkey::Pubkey};
+
+#[derive(Debug, Clone, Copy)]
+enum LoaderV4Role {
+    Write,
+    Copy,
+    SetProgramLengthAuthority,
+    SetProgramLengthRecipient,
+    Deploy,
+    Retract,
+    TransferAuthorityCurrent,
+    TransferAuthorityNew,
+    Finalize,
+}
+
+impl DrainRole for LoaderV4Role {
+    const ROLES: &'static [Self] = &[
+        Self::Write,
+        Self::Copy,
+        Self::SetProgramLengthAuthority,
+        Self::SetProgramLengthRecipient,
+        Self::Deploy,
+        Self::Retract,
+        Self::TransferAuthorityCurrent,
+        Self::TransferAuthorityNew,
+        Self::Finalize,
+    ];
+
+    fn allowed_programs() -> Vec<String> {
+        vec![LOADER_V4_PROGRAM_ID.to_string()]
+    }
+
+    fn flag(self, policy: &mut FeePayerPolicy) -> &mut bool {
+        match self {
+            Self::Write => &mut policy.loader_v4.allow_write,
+            Self::Copy => &mut policy.loader_v4.allow_copy,
+            Self::SetProgramLengthAuthority | Self::SetProgramLengthRecipient => {
+                &mut policy.loader_v4.allow_set_program_length
+            }
+            Self::Deploy => &mut policy.loader_v4.allow_deploy,
+            Self::Retract => &mut policy.loader_v4.allow_retract,
+            Self::TransferAuthorityCurrent | Self::TransferAuthorityNew => {
+                &mut policy.loader_v4.allow_transfer_authority
+            }
+            Self::Finalize => &mut policy.loader_v4.allow_finalize,
+        }
+    }
+
+    fn instruction(self, actor: &Pubkey) -> Instruction {
+        let program = Pubkey::new_unique();
+        let other = Pubkey::new_unique();
+        match self {
+            Self::Write => write(&program, actor, 0, vec![1, 2, 3]),
+            Self::Copy => copy(&program, actor, &other, 0, 0, 1),
+            // The drainage guard rejects a fee-payer authority paired with a foreign recipient
+            // regardless of the flag, so this role has to name the actor in both slots to
+            // isolate the flag as the only thing under test.
+            Self::SetProgramLengthAuthority => set_program_length(&program, actor, 0, actor),
+            Self::SetProgramLengthRecipient => set_program_length(&program, &other, 0, actor),
+            Self::Deploy => deploy(&program, actor),
+            Self::Retract => retract(&program, actor),
+            Self::TransferAuthorityCurrent => transfer_authority(&program, actor, &other),
+            Self::TransferAuthorityNew => transfer_authority(&program, &other, actor),
+            Self::Finalize => finalize(&program, actor, &other),
+        }
+    }
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(512))]
+
+    #[test]
+    fn fee_payer_role_gated_iff_flag_off(
+        (role_idx, actor_is_fee_payer, flags) in role_and_flags::<LoaderV4Role>(),
+    ) {
+        assert_role_gated_iff_flag_off::<LoaderV4Role>(role_idx, actor_is_fee_payer, &flags)?;
+    }
+}

--- a/crates/lib/src/validator/transaction_validator/fee_payer_policy_props/mod.rs
+++ b/crates/lib/src/validator/transaction_validator/fee_payer_policy_props/mod.rs
@@ -1,5 +1,6 @@
 mod alt;
 mod bpf_loader_upgradeable;
+mod loader_v4;
 mod spl_token;
 mod system;
 


### PR DESCRIPTION
Closes #645.

## Summary

- Adds `loader_v4.rs` covering all 7 `[validation.fee_payer_policy.loader_v4]` flags through the `DrainRole` harness.
- Nine roles for seven flags. `SetProgramLength` and `TransferAuthority` each gate two slots, so they get a role per slot the way `system.rs` splits `CreateAccountPayer` / `CreateAccountNewAccount`. The rest are one-to-one: authority for Write, Copy, Deploy and Retract, current authority for Finalize.
- `SetProgramLengthAuthority` puts the actor in the recipient slot too. The drainage guard rejects a fee-payer authority with a foreign recipient whatever the flag says, so otherwise the "flag on must pass" branch fails on the guard and you learn nothing about the flag.
- `allowed_programs()` returns `LOADER_V4_PROGRAM_ID`, which is what routes the parsed instructions to the loader-v4 policy tree.

Test-side only, no production code changes.

## Test Plan

- `cargo test -p kora-lib --lib fee_payer_policy_props`: 2 passed (system + loader_v4).
- `just unit-test`: 936 passed, 0 failed, 4 ignored.
- `just check`: clean (fmt, clippy, prettier, tsc).
- **Mutation proof** that the property can still fail — `LoaderV4Role::Write`'s `flag()` pointed at `allow_copy`:

```
test ...fee_payer_policy_props::loader_v4::fee_payer_role_gated_iff_flag_off ... FAILED

Test failed: Write by fee payer must pass when its flag is on,
got Err(InvalidTransaction("Fee payer cannot be used for 'Loader-v4 Write'"))
  at crates/lib/src/validator/transaction_validator/fee_payer_policy_props/mod.rs:71.

test result: FAILED. 0 passed; 1 failed
```

  Reverted after; back to 2 passed.

- Did the same for the other six flags, and separately took the actor out of each two-slot role's own slot. All eleven fail, so nothing is vacuous and neither two-slot role is riding on its sibling.
