### PR TITLE
fix(transaction): reject v1 transactions that cannot execute

### DIFF
--- a/crates/lib/src/lighthouse/assertion.rs
+++ b/crates/lib/src/lighthouse/assertion.rs
@@ -274,16 +274,23 @@ impl LighthouseUtil {
             })?
             .len();
 
-        let max_size = TransactionUtil::max_transaction_size(&tx_with_assertion.message);
-        if new_size > max_size {
+        // Appending the assertion adds accounts and an instruction, either of which can push
+        // the message past a limit that is not about byte size
+        let rejection = if let Err(e) = tx_with_assertion.message.sanitize() {
+            Some(format!("would produce an invalid message ({e})"))
+        } else {
+            let max_size = TransactionUtil::max_transaction_size(&tx_with_assertion.message);
+            (new_size > max_size)
+                .then(|| format!("would exceed transaction size limit ({new_size} > {max_size})"))
+        };
+
+        if let Some(reason) = rejection {
             if config.fail_if_transaction_size_overflow {
                 return Err(KoraError::ValidationError(format!(
-                    "Adding Lighthouse assertion would exceed transaction size limit ({new_size} > {max_size})"
+                    "Adding Lighthouse assertion {reason}"
                 )));
             } else {
-                log::warn!(
-                    "Lighthouse assertion would exceed transaction size limit ({new_size} > {max_size}). Skipping."
-                );
+                log::warn!("Lighthouse assertion {reason}. Skipping.");
                 return Ok(());
             }
         }
@@ -481,6 +488,67 @@ mod tests {
             LighthouseUtil::append_lighthouse_assertion(&mut transaction, assertion_ix, &config);
         assert!(result.is_ok());
         assert!(transaction.message.static_account_keys().contains(&LIGHTHOUSE_PROGRAM_ID));
+    }
+
+    /// Build a V1 transaction whose account list already sits at the format's 64-address
+    /// limit, so appending any account the message does not already hold makes it
+    /// unsanitary.
+    fn v1_transaction_with_max_addresses(keypair: &Keypair) -> VersionedTransaction {
+        let mut account_keys = vec![keypair.pubkey()];
+        account_keys.extend((1..v1::MAX_ADDRESSES).map(|_| Pubkey::new_unique()));
+
+        let v1_message = v1::Message {
+            header: solana_message::MessageHeader {
+                num_required_signatures: 1,
+                num_readonly_signed_accounts: 0,
+                num_readonly_unsigned_accounts: v1::MAX_ADDRESSES - 1,
+            },
+            config: v1::TransactionConfig::empty(),
+            lifetime_specifier: Hash::new_unique(),
+            account_keys,
+            instructions: vec![solana_message::compiled_instruction::CompiledInstruction {
+                program_id_index: 1,
+                accounts: vec![0],
+                data: vec![1, 2, 3],
+            }],
+        };
+
+        VersionedTransaction::try_new(VersionedMessage::V1(v1_message), &[keypair]).unwrap()
+    }
+
+    #[test]
+    fn test_append_lighthouse_assertion_v1_rejects_exceeding_address_limit() {
+        let keypair = Keypair::new();
+        let mut transaction = v1_transaction_with_max_addresses(&keypair);
+
+        let assertion_ix = LighthouseUtil::build_fee_payer_assertion(&keypair.pubkey(), 1_000_000);
+        let config = LighthouseConfig { enabled: true, fail_if_transaction_size_overflow: true };
+
+        let result =
+            LighthouseUtil::append_lighthouse_assertion(&mut transaction, assertion_ix, &config);
+
+        let error = result.expect_err("assertion must not push the message past 64 addresses");
+        assert!(
+            error.to_string().contains("would produce an invalid message"),
+            "unexpected error: {error}"
+        );
+        assert!(!transaction.message.static_account_keys().contains(&LIGHTHOUSE_PROGRAM_ID));
+    }
+
+    #[test]
+    fn test_append_lighthouse_assertion_v1_skips_exceeding_address_limit_when_configured() {
+        let keypair = Keypair::new();
+        let mut transaction = v1_transaction_with_max_addresses(&keypair);
+        let original_ix_count = transaction.message.instructions().len();
+
+        let assertion_ix = LighthouseUtil::build_fee_payer_assertion(&keypair.pubkey(), 1_000_000);
+        let config = LighthouseConfig { enabled: true, fail_if_transaction_size_overflow: false };
+
+        LighthouseUtil::append_lighthouse_assertion(&mut transaction, assertion_ix, &config)
+            .expect("assertion is skipped, not an error");
+
+        assert_eq!(transaction.message.instructions().len(), original_ix_count);
+        assert!(!transaction.message.static_account_keys().contains(&LIGHTHOUSE_PROGRAM_ID));
     }
 
     #[test]

--- a/crates/lib/src/lighthouse/assertion.rs
+++ b/crates/lib/src/lighthouse/assertion.rs
@@ -304,6 +304,7 @@ impl LighthouseUtil {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::tests::transaction_mock::create_mock_v1_transaction_with_max_addresses;
     use solana_message::{v0, v1, Message, VersionedMessage};
     use solana_sdk::{hash::Hash, instruction::AccountMeta, signature::Keypair, signer::Signer};
 
@@ -490,37 +491,10 @@ mod tests {
         assert!(transaction.message.static_account_keys().contains(&LIGHTHOUSE_PROGRAM_ID));
     }
 
-    /// Build a V1 transaction whose account list already sits at the format's 64-address
-    /// limit, so appending any account the message does not already hold makes it
-    /// unsanitary.
-    fn v1_transaction_with_max_addresses(keypair: &Keypair) -> VersionedTransaction {
-        let mut account_keys = vec![keypair.pubkey()];
-        account_keys
-            .extend((1..v1::MAX_ADDRESSES).map(|index| Pubkey::new_from_array([index; 32])));
-
-        let v1_message = v1::Message {
-            header: solana_message::MessageHeader {
-                num_required_signatures: 1,
-                num_readonly_signed_accounts: 0,
-                num_readonly_unsigned_accounts: v1::MAX_ADDRESSES - 1,
-            },
-            config: v1::TransactionConfig::empty(),
-            lifetime_specifier: Hash::new_from_array([7; 32]),
-            account_keys,
-            instructions: vec![solana_message::compiled_instruction::CompiledInstruction {
-                program_id_index: 1,
-                accounts: vec![0],
-                data: vec![1, 2, 3],
-            }],
-        };
-
-        VersionedTransaction::try_new(VersionedMessage::V1(v1_message), &[keypair]).unwrap()
-    }
-
     #[test]
     fn test_append_lighthouse_assertion_v1_rejects_exceeding_address_limit() {
         let keypair = Keypair::new_from_array([1; 32]);
-        let mut transaction = v1_transaction_with_max_addresses(&keypair);
+        let mut transaction = create_mock_v1_transaction_with_max_addresses(&keypair);
 
         let assertion_ix = LighthouseUtil::build_fee_payer_assertion(&keypair.pubkey(), 1_000_000);
         let config = LighthouseConfig { enabled: true, fail_if_transaction_size_overflow: true };
@@ -539,7 +513,7 @@ mod tests {
     #[test]
     fn test_append_lighthouse_assertion_v1_skips_exceeding_address_limit_when_configured() {
         let keypair = Keypair::new_from_array([2; 32]);
-        let mut transaction = v1_transaction_with_max_addresses(&keypair);
+        let mut transaction = create_mock_v1_transaction_with_max_addresses(&keypair);
         let original_ix_count = transaction.message.instructions().len();
 
         let assertion_ix = LighthouseUtil::build_fee_payer_assertion(&keypair.pubkey(), 1_000_000);

--- a/crates/lib/src/lighthouse/assertion.rs
+++ b/crates/lib/src/lighthouse/assertion.rs
@@ -495,7 +495,8 @@ mod tests {
     /// unsanitary.
     fn v1_transaction_with_max_addresses(keypair: &Keypair) -> VersionedTransaction {
         let mut account_keys = vec![keypair.pubkey()];
-        account_keys.extend((1..v1::MAX_ADDRESSES).map(|_| Pubkey::new_unique()));
+        account_keys
+            .extend((1..v1::MAX_ADDRESSES).map(|index| Pubkey::new_from_array([index; 32])));
 
         let v1_message = v1::Message {
             header: solana_message::MessageHeader {
@@ -504,7 +505,7 @@ mod tests {
                 num_readonly_unsigned_accounts: v1::MAX_ADDRESSES - 1,
             },
             config: v1::TransactionConfig::empty(),
-            lifetime_specifier: Hash::new_unique(),
+            lifetime_specifier: Hash::new_from_array([7; 32]),
             account_keys,
             instructions: vec![solana_message::compiled_instruction::CompiledInstruction {
                 program_id_index: 1,
@@ -518,7 +519,7 @@ mod tests {
 
     #[test]
     fn test_append_lighthouse_assertion_v1_rejects_exceeding_address_limit() {
-        let keypair = Keypair::new();
+        let keypair = Keypair::new_from_array([1; 32]);
         let mut transaction = v1_transaction_with_max_addresses(&keypair);
 
         let assertion_ix = LighthouseUtil::build_fee_payer_assertion(&keypair.pubkey(), 1_000_000);
@@ -537,7 +538,7 @@ mod tests {
 
     #[test]
     fn test_append_lighthouse_assertion_v1_skips_exceeding_address_limit_when_configured() {
-        let keypair = Keypair::new();
+        let keypair = Keypair::new_from_array([2; 32]);
         let mut transaction = v1_transaction_with_max_addresses(&keypair);
         let original_ix_count = transaction.message.instructions().len();
 

--- a/crates/lib/src/tests/transaction_mock.rs
+++ b/crates/lib/src/tests/transaction_mock.rs
@@ -1,5 +1,9 @@
-use solana_message::{Message, VersionedMessage};
+use solana_message::{
+    compiled_instruction::CompiledInstruction, v1, Message, MessageHeader, VersionedMessage,
+};
 use solana_sdk::{
+    hash::Hash,
+    instruction::{AccountMeta, Instruction},
     pubkey::Pubkey,
     signature::Keypair,
     signer::Signer,
@@ -28,4 +32,55 @@ pub fn create_mock_transaction() -> VersionedTransaction {
 pub fn create_mock_resolved_transaction() -> VersionedTransactionResolved {
     let tx = create_mock_transaction();
     VersionedTransactionResolved::from_kora_built_transaction(&tx).unwrap()
+}
+
+/// Sign a V1 transaction carrying `config`, from fixed key material so a failure
+/// reproduces from the test alone.
+pub fn create_mock_v1_transaction(config: v1::TransactionConfig) -> VersionedTransaction {
+    let keypair = Keypair::new_from_array([3; 32]);
+    let instruction = Instruction::new_with_bytes(
+        Pubkey::new_from_array([9; 32]),
+        &[1, 2, 3],
+        vec![AccountMeta::new(keypair.pubkey(), true)],
+    );
+    let message = VersionedMessage::V1(
+        v1::Message::try_compile_with_config(
+            &keypair.pubkey(),
+            &[instruction],
+            Hash::new_from_array([5; 32]),
+            config,
+        )
+        .unwrap(),
+    );
+
+    VersionedTransaction::try_new(message, &[&keypair]).unwrap()
+}
+
+pub fn create_mock_encoded_v1_transaction(config: v1::TransactionConfig) -> String {
+    TransactionUtil::encode_versioned_transaction(&create_mock_v1_transaction(config)).unwrap()
+}
+
+/// Sign a V1 transaction whose account list already sits at the format's 64-address limit,
+/// so appending any account the message does not already hold makes it unsanitary.
+pub fn create_mock_v1_transaction_with_max_addresses(fee_payer: &Keypair) -> VersionedTransaction {
+    let mut account_keys = vec![fee_payer.pubkey()];
+    account_keys.extend((1..v1::MAX_ADDRESSES).map(|index| Pubkey::new_from_array([index; 32])));
+
+    let message = VersionedMessage::V1(v1::Message {
+        header: MessageHeader {
+            num_required_signatures: 1,
+            num_readonly_signed_accounts: 0,
+            num_readonly_unsigned_accounts: v1::MAX_ADDRESSES - 1,
+        },
+        config: v1::TransactionConfig::empty(),
+        lifetime_specifier: Hash::new_from_array([7; 32]),
+        account_keys,
+        instructions: vec![CompiledInstruction {
+            program_id_index: 1,
+            accounts: vec![0],
+            data: vec![1, 2, 3],
+        }],
+    });
+
+    VersionedTransaction::try_new(message, &[fee_payer]).unwrap()
 }

--- a/crates/lib/src/transaction/transaction.rs
+++ b/crates/lib/src/transaction/transaction.rs
@@ -37,6 +37,8 @@ impl TransactionUtil {
             KoraError::InvalidTransaction(format!("Invalid transaction message: {e}"))
         })?;
 
+        Self::validate_v1_resource_limits(&transaction.message)?;
+
         let max_size = Self::max_transaction_size(&transaction.message);
         if decoded.len() > max_size {
             return Err(KoraError::InvalidTransaction(format!(
@@ -46,6 +48,41 @@ impl TransactionUtil {
         }
 
         Ok(transaction)
+    }
+
+    /// A limit a V1 transaction config leaves unset is zero, not the runtime default legacy
+    /// and V0 transactions fall back to, and zero compute units or zero loadable account
+    /// bytes cannot run any instruction. Rejecting that here means the caller gets an
+    /// actionable error before Kora simulates, signs, or pays for a transaction that cannot
+    /// execute.
+    fn validate_v1_resource_limits(message: &VersionedMessage) -> Result<(), KoraError> {
+        let VersionedMessage::V1(v1_message) = message else {
+            return Ok(());
+        };
+
+        let mut unset_limits = Vec::new();
+        if v1_message.config.compute_unit_limit.unwrap_or(0) == 0 {
+            unset_limits.push("compute_unit_limit");
+        }
+        if v1_message.config.loaded_accounts_data_size_limit.unwrap_or(0) == 0 {
+            unset_limits.push("loaded_accounts_data_size_limit");
+        }
+
+        if !unset_limits.is_empty() {
+            return Err(KoraError::InvalidTransaction(format!(
+                "V1 transaction config must set {} to a non-zero value",
+                unset_limits.join(" and ")
+            )));
+        }
+
+        if v1_message.account_keys.contains(&solana_compute_budget_interface::id()) {
+            log::warn!(
+                "V1 transaction references the ComputeBudget program, whose instructions the \
+                 runtime ignores; its resource limits come from the transaction config"
+            );
+        }
+
+        Ok(())
     }
 
     pub fn new_unsigned_versioned_transaction(message: VersionedMessage) -> VersionedTransaction {
@@ -105,7 +142,21 @@ mod tests {
             &data,
             vec![AccountMeta::new(keypair.pubkey(), true)],
         );
-        v1::Message::try_compile(&keypair.pubkey(), &[instruction], Hash::new_unique()).unwrap()
+        v1::Message::try_compile_with_config(
+            &keypair.pubkey(),
+            &[instruction],
+            Hash::new_unique(),
+            v1_resource_limits(),
+        )
+        .unwrap()
+    }
+
+    /// V1 resource limits have to be set explicitly for a transaction to be executable, so
+    /// every V1 fixture that is meant to be valid carries them.
+    fn v1_resource_limits() -> v1::TransactionConfig {
+        v1::TransactionConfig::empty()
+            .with_compute_unit_limit(200_000)
+            .with_loaded_accounts_data_size_limit(64 * 1024)
     }
 
     #[test]
@@ -231,6 +282,59 @@ mod tests {
         let result = TransactionUtil::decode_b64_transaction(&encoded);
 
         assert!(matches!(result, Err(KoraError::InvalidTransaction(_))));
+    }
+
+    #[test]
+    fn test_decode_b64_transaction_v1_rejects_unset_resource_limits() {
+        let keypair = Keypair::new();
+        let instruction = Instruction::new_with_bytes(
+            Pubkey::new_unique(),
+            &[1, 2, 3],
+            vec![AccountMeta::new(keypair.pubkey(), true)],
+        );
+        let message = VersionedMessage::V1(
+            v1::Message::try_compile(&keypair.pubkey(), &[instruction], Hash::new_unique())
+                .unwrap(),
+        );
+        let transaction = VersionedTransaction::try_new(message, &[&keypair]).unwrap();
+        let encoded = TransactionUtil::encode_versioned_transaction(&transaction).unwrap();
+
+        let error = TransactionUtil::decode_b64_transaction(&encoded)
+            .expect_err("an empty V1 config requests zero compute units and zero loaded bytes");
+        let error_message = error.to_string();
+        assert!(error_message.contains("compute_unit_limit"), "unexpected error: {error_message}");
+        assert!(
+            error_message.contains("loaded_accounts_data_size_limit"),
+            "unexpected error: {error_message}"
+        );
+    }
+
+    #[test]
+    fn test_decode_b64_transaction_v1_rejects_unset_loaded_accounts_data_size_limit() {
+        let keypair = Keypair::new();
+        let instruction = Instruction::new_with_bytes(
+            Pubkey::new_unique(),
+            &[1, 2, 3],
+            vec![AccountMeta::new(keypair.pubkey(), true)],
+        );
+        let message = VersionedMessage::V1(
+            v1::Message::try_compile_with_config(
+                &keypair.pubkey(),
+                &[instruction],
+                Hash::new_unique(),
+                v1::TransactionConfig::empty().with_compute_unit_limit(200_000),
+            )
+            .unwrap(),
+        );
+        let transaction = VersionedTransaction::try_new(message, &[&keypair]).unwrap();
+        let encoded = TransactionUtil::encode_versioned_transaction(&transaction).unwrap();
+
+        let error = TransactionUtil::decode_b64_transaction(&encoded)
+            .expect_err("a V1 config without a data size limit requests zero loaded bytes");
+        assert!(
+            error.to_string().contains("loaded_accounts_data_size_limit"),
+            "unexpected error: {error}"
+        );
     }
 
     #[test]

--- a/crates/lib/src/transaction/transaction.rs
+++ b/crates/lib/src/transaction/transaction.rs
@@ -75,13 +75,6 @@ impl TransactionUtil {
             )));
         }
 
-        if v1_message.account_keys.contains(&solana_compute_budget_interface::id()) {
-            log::warn!(
-                "V1 transaction references the ComputeBudget program, whose instructions the \
-                 runtime ignores; its resource limits come from the transaction config"
-            );
-        }
-
         Ok(())
     }
 
@@ -126,7 +119,7 @@ impl TransactionUtil {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::error::KoraError;
+    use crate::{error::KoraError, tests::transaction_mock::create_mock_encoded_v1_transaction};
     use solana_message::{compiled_instruction::CompiledInstruction, v0, v1, Message};
     use solana_sdk::{
         hash::Hash,
@@ -284,32 +277,9 @@ mod tests {
         assert!(matches!(result, Err(KoraError::InvalidTransaction(_))));
     }
 
-    /// Encode a signed V1 transaction carrying `config`, from fixed key material so a
-    /// failure reproduces from the test alone.
-    fn encoded_v1_transaction_with_config(config: v1::TransactionConfig) -> String {
-        let keypair = Keypair::new_from_array([3; 32]);
-        let instruction = Instruction::new_with_bytes(
-            Pubkey::new_from_array([9; 32]),
-            &[1, 2, 3],
-            vec![AccountMeta::new(keypair.pubkey(), true)],
-        );
-        let message = VersionedMessage::V1(
-            v1::Message::try_compile_with_config(
-                &keypair.pubkey(),
-                &[instruction],
-                Hash::new_from_array([5; 32]),
-                config,
-            )
-            .unwrap(),
-        );
-        let transaction = VersionedTransaction::try_new(message, &[&keypair]).unwrap();
-
-        TransactionUtil::encode_versioned_transaction(&transaction).unwrap()
-    }
-
     #[test]
     fn test_decode_b64_transaction_v1_rejects_unset_resource_limits() {
-        let encoded = encoded_v1_transaction_with_config(v1::TransactionConfig::empty());
+        let encoded = create_mock_encoded_v1_transaction(v1::TransactionConfig::empty());
 
         let error = TransactionUtil::decode_b64_transaction(&encoded)
             .expect_err("an empty V1 config requests zero compute units and zero loaded bytes");
@@ -323,7 +293,7 @@ mod tests {
 
     #[test]
     fn test_decode_b64_transaction_v1_rejects_unset_loaded_accounts_data_size_limit() {
-        let encoded = encoded_v1_transaction_with_config(
+        let encoded = create_mock_encoded_v1_transaction(
             v1::TransactionConfig::empty().with_compute_unit_limit(200_000),
         );
 

--- a/crates/lib/src/transaction/transaction.rs
+++ b/crates/lib/src/transaction/transaction.rs
@@ -284,20 +284,32 @@ mod tests {
         assert!(matches!(result, Err(KoraError::InvalidTransaction(_))));
     }
 
-    #[test]
-    fn test_decode_b64_transaction_v1_rejects_unset_resource_limits() {
-        let keypair = Keypair::new();
+    /// Encode a signed V1 transaction carrying `config`, from fixed key material so a
+    /// failure reproduces from the test alone.
+    fn encoded_v1_transaction_with_config(config: v1::TransactionConfig) -> String {
+        let keypair = Keypair::new_from_array([3; 32]);
         let instruction = Instruction::new_with_bytes(
-            Pubkey::new_unique(),
+            Pubkey::new_from_array([9; 32]),
             &[1, 2, 3],
             vec![AccountMeta::new(keypair.pubkey(), true)],
         );
         let message = VersionedMessage::V1(
-            v1::Message::try_compile(&keypair.pubkey(), &[instruction], Hash::new_unique())
-                .unwrap(),
+            v1::Message::try_compile_with_config(
+                &keypair.pubkey(),
+                &[instruction],
+                Hash::new_from_array([5; 32]),
+                config,
+            )
+            .unwrap(),
         );
         let transaction = VersionedTransaction::try_new(message, &[&keypair]).unwrap();
-        let encoded = TransactionUtil::encode_versioned_transaction(&transaction).unwrap();
+
+        TransactionUtil::encode_versioned_transaction(&transaction).unwrap()
+    }
+
+    #[test]
+    fn test_decode_b64_transaction_v1_rejects_unset_resource_limits() {
+        let encoded = encoded_v1_transaction_with_config(v1::TransactionConfig::empty());
 
         let error = TransactionUtil::decode_b64_transaction(&encoded)
             .expect_err("an empty V1 config requests zero compute units and zero loaded bytes");
@@ -311,23 +323,9 @@ mod tests {
 
     #[test]
     fn test_decode_b64_transaction_v1_rejects_unset_loaded_accounts_data_size_limit() {
-        let keypair = Keypair::new();
-        let instruction = Instruction::new_with_bytes(
-            Pubkey::new_unique(),
-            &[1, 2, 3],
-            vec![AccountMeta::new(keypair.pubkey(), true)],
+        let encoded = encoded_v1_transaction_with_config(
+            v1::TransactionConfig::empty().with_compute_unit_limit(200_000),
         );
-        let message = VersionedMessage::V1(
-            v1::Message::try_compile_with_config(
-                &keypair.pubkey(),
-                &[instruction],
-                Hash::new_unique(),
-                v1::TransactionConfig::empty().with_compute_unit_limit(200_000),
-            )
-            .unwrap(),
-        );
-        let transaction = VersionedTransaction::try_new(message, &[&keypair]).unwrap();
-        let encoded = TransactionUtil::encode_versioned_transaction(&transaction).unwrap();
 
         let error = TransactionUtil::decode_b64_transaction(&encoded)
             .expect_err("a V1 config without a data size limit requests zero loaded bytes");

--- a/crates/lib/src/validator/transaction_validator.rs
+++ b/crates/lib/src/validator/transaction_validator.rs
@@ -16,6 +16,7 @@ use crate::{
     },
 };
 use solana_client::nonblocking::rpc_client::RpcClient;
+use solana_message::VersionedMessage;
 use solana_sdk::{pubkey::Pubkey, transaction::VersionedTransaction};
 use std::{collections::HashSet, str::FromStr};
 
@@ -133,6 +134,7 @@ impl TransactionValidator {
         }
 
         self.validate_has_non_compute_instruction(transaction_resolved)?;
+        Self::warn_on_ignored_compute_budget_instructions(transaction_resolved);
 
         if transaction_resolved.all_account_keys.is_empty() {
             return Err(KoraError::InvalidTransaction(
@@ -199,6 +201,29 @@ impl TransactionValidator {
         }
 
         Ok(())
+    }
+
+    /// ComputeBudget instructions are neither parsed nor rejected in a V1 transaction: they
+    /// execute successfully while doing nothing, so a client that sets its resource limits
+    /// there silently gets the transaction config's limits instead of the ones it asked for.
+    fn warn_on_ignored_compute_budget_instructions(
+        transaction_resolved: &VersionedTransactionResolved,
+    ) {
+        if !matches!(transaction_resolved.transaction.message, VersionedMessage::V1(_)) {
+            return;
+        }
+
+        let compute_budget_program_id = solana_compute_budget_interface::id();
+        if transaction_resolved
+            .all_instructions
+            .iter()
+            .any(|ix| ix.program_id == compute_budget_program_id)
+        {
+            log::warn!(
+                "V1 transaction contains ComputeBudget instructions, which the runtime ignores; \
+                 its resource limits come from the transaction config"
+            );
+        }
     }
 
     pub fn validate_lamport_fee(&self, fee: u64) -> Result<(), KoraError> {

--- a/tests/rpc/compute_budget.rs
+++ b/tests/rpc/compute_budget.rs
@@ -113,6 +113,68 @@ async fn test_estimate_transaction_fee_with_v1_config_priority_fee() {
     assert!(fee_with == 35_050, "Fee should include the V1 config priority fee, got {fee_with}");
 }
 
+/// ComputeBudget instructions are inert in V1: the runtime neither parses nor rejects
+/// them, so their priority fee must not reach the estimate. The fee has to match the same
+/// transaction built without them.
+#[tokio::test]
+async fn test_estimate_transaction_fee_v1_ignores_compute_budget_instructions() {
+    let ctx = TestContext::new().await.expect("Failed to create test context");
+    let fee_payer = FeePayerTestHelper::get_fee_payer_keypair();
+    let sender = SenderTestHelper::get_test_sender_keypair();
+    let recipient = RecipientTestHelper::get_recipient_pubkey();
+
+    let test_tx = ctx
+        .v1_transaction_builder()
+        .with_fee_payer(fee_payer.pubkey())
+        .with_transfer(&sender.pubkey(), &recipient, 500_000)
+        .with_compute_budget(1_400_000, 50_000)
+        .build()
+        .await
+        .expect("Failed to create V1 transaction with compute budget instructions");
+
+    let response: serde_json::Value = ctx
+        .rpc_call("estimateTransactionFee", rpc_params![test_tx])
+        .await
+        .expect("Failed to estimate transaction fee");
+
+    let fee = response["fee_in_lamports"].as_u64().expect("Fee should be a number");
+
+    // Base transaction fee (2 signatures) 10_000 + payment instruction fee 50, with nothing
+    // from the 1_400_000 * 50_000 / 1_000_000 = 70_000 lamports the instructions ask for
+    assert!(fee == 10_050, "V1 fee must ignore ComputeBudget instructions, got {fee}");
+}
+
+/// When a V1 transaction carries both a config priority fee and ComputeBudget
+/// instructions, only the config counts.
+#[tokio::test]
+async fn test_estimate_transaction_fee_v1_config_priority_fee_wins_over_compute_budget() {
+    let ctx = TestContext::new().await.expect("Failed to create test context");
+    let fee_payer = FeePayerTestHelper::get_fee_payer_keypair();
+    let sender = SenderTestHelper::get_test_sender_keypair();
+    let recipient = RecipientTestHelper::get_recipient_pubkey();
+
+    let test_tx = ctx
+        .v1_transaction_builder()
+        .with_fee_payer(fee_payer.pubkey())
+        .with_transfer(&sender.pubkey(), &recipient, 500_000)
+        .with_compute_budget(1_400_000, 50_000)
+        .with_v1_priority_fee(25_000)
+        .build()
+        .await
+        .expect("Failed to create V1 transaction with compute budget instructions");
+
+    let response: serde_json::Value = ctx
+        .rpc_call("estimateTransactionFee", rpc_params![test_tx])
+        .await
+        .expect("Failed to estimate transaction fee");
+
+    let fee = response["fee_in_lamports"].as_u64().expect("Fee should be a number");
+
+    // Base transaction fee (2 signatures) 10_000 + payment instruction fee 50 + the flat
+    // 25_000 lamport config priority fee
+    assert!(fee == 35_050, "V1 fee must come from the config priority fee alone, got {fee}");
+}
+
 // NOTE: Lookup table is properly tested via mint address (not in transaction accounts, only ATAs)
 #[tokio::test]
 async fn test_estimate_transaction_fee_with_compute_budget_v0_with_lookup() {

--- a/tests/rpc/transaction_signing.rs
+++ b/tests/rpc/transaction_signing.rs
@@ -195,6 +195,39 @@ async fn test_sign_transaction_v1_rejects_priority_fee_above_max_allowed_lamport
     );
 }
 
+/// An unset V1 resource limit means zero, not a runtime default, so a transaction that
+/// leaves one out cannot execute: it is rejected while loading accounts, after the fee
+/// payer has been charged. Kora must reject it before signing.
+#[tokio::test]
+async fn test_sign_transaction_v1_rejects_unset_resource_limits() {
+    let ctx = TestContext::new().await.expect("Failed to create test context");
+
+    let fee_payer = FeePayerTestHelper::get_fee_payer_pubkey();
+    let token_mint = USDCMintTestHelper::get_test_usdc_mint_pubkey();
+    let sender = SenderTestHelper::get_test_sender_keypair();
+
+    let v1_transaction = ctx
+        .v1_transaction_builder()
+        .with_fee_payer(fee_payer)
+        .with_v1_unset_resource_limits()
+        .with_spl_transfer(&token_mint, &sender.pubkey(), &fee_payer, 3_000_000)
+        .with_transfer(&sender.pubkey(), &RecipientTestHelper::get_recipient_pubkey(), 10)
+        .build()
+        .await
+        .expect("Failed to create V1 transaction");
+
+    let result: Result<serde_json::Value, _> =
+        ctx.rpc_call("signTransaction", rpc_params![v1_transaction]).await;
+
+    let error = result.expect_err("Expected rejection for V1 transaction with unset limits");
+    let message = error.to_string();
+    assert!(message.contains("compute_unit_limit"), "Expected limit rejection, got: {message}");
+    assert!(
+        message.contains("loaded_accounts_data_size_limit"),
+        "Expected limit rejection, got: {message}"
+    );
+}
+
 // **************************************************************************************
 // Sign and send transaction tests
 // **************************************************************************************

--- a/tests/src/common/transaction.rs
+++ b/tests/src/common/transaction.rs
@@ -48,6 +48,7 @@ pub struct TransactionBuilder {
     signers: Vec<Keypair>,
     rpc_client: Option<Arc<RpcClient>>,
     v1_priority_fee: Option<u64>,
+    v1_unset_resource_limits: bool,
 }
 
 impl TransactionBuilder {
@@ -60,6 +61,7 @@ impl TransactionBuilder {
             signers: Vec::new(),
             rpc_client: None,
             v1_priority_fee: None,
+            v1_unset_resource_limits: false,
         }
     }
 
@@ -72,6 +74,7 @@ impl TransactionBuilder {
             signers: Vec::new(),
             rpc_client: None,
             v1_priority_fee: None,
+            v1_unset_resource_limits: false,
         }
     }
 
@@ -84,6 +87,7 @@ impl TransactionBuilder {
             signers: Vec::new(),
             rpc_client: None,
             v1_priority_fee: None,
+            v1_unset_resource_limits: false,
         }
     }
 
@@ -96,6 +100,7 @@ impl TransactionBuilder {
             signers: Vec::new(),
             rpc_client: None,
             v1_priority_fee: None,
+            v1_unset_resource_limits: false,
         }
     }
 
@@ -277,6 +282,13 @@ impl TransactionBuilder {
     /// Set the priority fee (flat lamports) in the V1 transaction config
     pub fn with_v1_priority_fee(mut self, lamports: u64) -> Self {
         self.v1_priority_fee = Some(lamports);
+        self
+    }
+
+    /// Leave the compute unit limit and loaded accounts data size limit out of the V1
+    /// transaction config, which requests zero of each.
+    pub fn with_v1_unset_resource_limits(mut self) -> Self {
+        self.v1_unset_resource_limits = true;
         self
     }
 
@@ -706,9 +718,13 @@ impl TransactionBuilder {
                 TransactionVersion::V1 => {
                     // An empty config mask requests 0 compute units and a 0 (32KiB)
                     // loaded-accounts-data cap, so real limits must be set explicitly.
-                    let mut config = TransactionConfig::empty()
-                        .with_compute_unit_limit(1_400_000)
-                        .with_loaded_accounts_data_size_limit(64 * 1024 * 1024);
+                    let mut config = if self.v1_unset_resource_limits {
+                        TransactionConfig::empty()
+                    } else {
+                        TransactionConfig::empty()
+                            .with_compute_unit_limit(1_400_000)
+                            .with_loaded_accounts_data_size_limit(64 * 1024 * 1024)
+                    };
                     if let Some(priority_fee) = self.v1_priority_fee {
                         config = config.with_priority_fee(priority_fee);
                     }


### PR DESCRIPTION
- reject transactions that have v1 message configs that are unset
- lighthouse assert -- fail if sanitze has too many accounts

Refs: TOO-527