### PR TITLE
docs: slim skills to guides and push detail into references

### DIFF
--- a/.claude/skills/complete-release/SKILL.md
+++ b/.claude/skills/complete-release/SKILL.md
@@ -5,109 +5,38 @@ description: "Reviewer workflow for completing a Kora mainline release after the
 
 # Kora Complete Release
 
-Run this after a mainline release PR has been approved. It squash-merges the PR and triggers the appropriate CI publish workflows on `main`.
+Run after a mainline release PR is approved: squash-merge it, then trigger the publish workflows
+on `main`.
 
----
+## Merge
 
-## Step 1 — Identify the release PR
+Find the release PR (`gh pr list --base main --search "chore: release"`) and confirm the number
+with the user before merging — this publishes to crates.io and npm, which cannot be undone.
+Squash-merge, delete the branch, then pull `main`.
 
-```bash
-# List open release PRs
-gh pr list --base main --search "chore: release" --json number,title,headRefName
-```
+## Decide which workflows to run
 
-Confirm the correct PR number with the user before proceeding.
-
----
-
-## Step 2 — Squash-merge the PR
+Publish only what the release actually changed. Inspect the merge commit: paths under
+`crates/`, `Cargo.toml`, `Cargo.lock` or `CHANGELOG.md` mean Rust; paths under `sdks/` mean
+TypeScript. A combined release triggers both.
 
 ```bash
-gh pr merge "${PR_NUMBER}" --squash --delete-branch
+gh workflow run "Publish Rust Crates" --ref main \
+  -f publish-kora-lib=true -f publish-kora-cli=true -f create-github-release=true
+
+gh workflow run "Publish TypeScript SDK" --ref main \
+  -f publish-to-npm=true -f create-github-release=true
 ```
 
----
+Watch with `gh run list --workflow "<name>" --limit 3`. Verify against `git tag` and
+`npm view @solana/kora version` once green.
 
-## Step 3 — Pull latest main
+## Constraints
 
-```bash
-git checkout main && git pull origin main
-```
-
----
-
-## Step 4 — Detect what changed
-
-```bash
-# Find the merge commit
-merge_commit=$(git log --oneline -1 --format="%H")
-
-# Check for Rust changes
-rust_changed=$(git diff-tree --no-commit-id -r "$merge_commit" \
-  --name-only | grep -E '^(Cargo\.toml|Cargo\.lock|CHANGELOG\.md|crates/)' | head -1)
-
-# Check for TypeScript changes
-ts_changed=$(git diff-tree --no-commit-id -r "$merge_commit" \
-  --name-only | grep -E '^sdks/' | head -1)
-
-echo "Rust changed: ${rust_changed:-no}"
-echo "TS changed:   ${ts_changed:-no}"
-```
-
----
-
-## Step 5 — Trigger Rust publish workflow (if Rust changed)
-
-```bash
-gh workflow run "Publish Rust Crates" \
-  --ref main \
-  -f publish-kora-lib=true \
-  -f publish-kora-cli=true \
-  -f create-github-release=true
-```
-
-Monitor progress:
-
-```bash
-gh run list --workflow "Publish Rust Crates" --limit 3
-```
-
----
-
-## Step 6 — Trigger TypeScript publish workflow (if TS changed)
-
-```bash
-gh workflow run "Publish TypeScript SDK" \
-  --ref main \
-  -f publish-to-npm=true \
-  -f create-github-release=true
-```
-
-Monitor progress:
-
-```bash
-gh run list --workflow "Publish TypeScript SDK" --limit 3
-```
-
----
-
-## Step 7 — Verify
-
-```bash
-# Rust — confirm tags and crates.io
-git tag --sort=-version:refname | head -5
-
-# TypeScript — confirm npm
-npm view @solana/kora version
-```
-
----
-
-## Notes
-
-- This skill is for mainline releases. For hotfix releases, trigger publish workflows from `hotfix/*` before merging back to `main`.
-- Publish workflows allow `main` and `hotfix/*` refs.
-- Rust publish order: `kora-lib` first, then `kora-cli` (kora-cli depends on kora-lib).
-- A 30-second crates.io indexing delay is built into the CI workflow between the two publishes.
-- TS prerelease versions are published with the `beta` npm tag; stable versions use `latest`.
-- If a workflow fails mid-run, re-trigger with only the failed steps by setting the relevant booleans to `false`.
+- **Mainline only.** Hotfixes publish from `hotfix/*` *before* merging back to `main`. The publish
+  workflows accept `main` and `hotfix/*` refs only.
+- `kora-lib` publishes before `kora-cli` (cli depends on lib). CI already waits ~30s between them
+  for crates.io indexing; don't run them as separate manual dispatches.
+- On a partial failure, re-dispatch with the already-succeeded booleans set to `false` rather than
+  re-running the whole workflow — a repeat publish of an existing version fails the run.
+- TS prereleases publish under the `beta` npm tag, stable under `latest`.

--- a/.claude/skills/kora-client/SKILL.md
+++ b/.claude/skills/kora-client/SKILL.md
@@ -5,182 +5,78 @@ description: "Kora TypeScript SDK and JSON-RPC API integration for Solana gasles
 
 # Kora Client Integration
 
-Kora is a Solana paymaster that enables gasless transactions. Users pay fees in SPL tokens (e.g. USDC) instead of SOL.
+Kora is a Solana paymaster: users pay fees in SPL tokens (e.g. USDC) instead of SOL.
 
-**Docs**: https://launch.solana.com/docs/kora/
-**SDK**: `@solana/kora` (npm)
+**Docs**: https://launch.solana.com/docs/kora/ · **SDK**: `@solana/kora` (npm)
 **Peer deps**: `@solana/kit` v6+, `@solana-program/token` v0.10+
 
-## Two Client Patterns
+## Where things are
 
-### 1. Standalone KoraClient
+| Topic | Reference |
+|---|---|
+| Per-method params, responses, TS types, error format | [references/rpc-api.md](references/rpc-api.md) |
+| Complete worked gasless flow, Jito bundles, x402, troubleshooting | [references/guides.md](references/guides.md) |
+
+## Two client shapes
+
+`KoraClient` is standalone; `koraPlugin` composes into a Kit client and returns Kit types
+(`Address`, `Blockhash`) rather than raw strings.
 
 ```ts
 import { KoraClient } from '@solana/kora';
+const client = new KoraClient({ rpcUrl, apiKey, hmacSecret, getRecaptchaToken });
 
-const client = new KoraClient({
-  rpcUrl: 'https://kora.example.com',
-  apiKey: 'optional-api-key',           // x-api-key header
-  hmacSecret: 'optional-hmac-secret',   // x-timestamp + x-hmac-signature headers
-  getRecaptchaToken: async () => {      // optional: reCAPTCHA v3 bot protection
-    return await grecaptcha.execute('site-key', { action: 'sign' });
-  },
-});
-```
-
-### 2. Kit Plugin (composable)
-
-```ts
+// or
 import { createEmptyClient } from '@solana/kit';
 import { koraPlugin } from '@solana/kora';
-
-const client = createEmptyClient()
-  .use(koraPlugin({
-    endpoint: 'https://kora.example.com',
-    apiKey: 'optional',
-    getRecaptchaToken: async () => token,
-  }));
-
-// Access via client.kora.* - responses use Kit types (Address, Blockhash)
-const config = await client.kora.getConfig();
+const client = createEmptyClient().use(koraPlugin({ endpoint, apiKey, getRecaptchaToken }));
+await client.kora.getConfig();
 ```
 
-## Core Transaction Flow
+## The transaction flow
 
-The gasless transaction pattern has 6 steps:
+Build instructions → build an estimate transaction with a **noop signer** as fee payer →
+`getPaymentInstruction()` → rebuild the final transaction with a **fresh blockhash** including the
+payment instruction → user partially signs → Kora co-signs via `signTransaction` or
+`signAndSendTransaction`.
 
-1. **Build instructions** - Create the user's intended operations using `@solana-program/*` libraries
-2. **Build estimate tx** - Wrap instructions in a transaction with noop signer as fee payer
-3. **Get payment instruction** - Call `getPaymentInstruction()` to get the fee transfer instruction
-4. **Build final tx** - Combine user instructions + payment instruction with fresh blockhash
-5. **User signs** - User partially signs (authorizes transfers + payment)
-6. **Kora co-signs** - Call `signTransaction()` or `signAndSendTransaction()` for Kora's fee payer signature
+Worked end-to-end code is in [references/guides.md](references/guides.md).
 
-### Key Concepts
+The parts that trip people up:
 
-- **Noop signer**: Placeholder for Kora's fee payer when building transactions before Kora signs
-  ```ts
-  const noopSigner = createNoopSigner(address(signerAddress));
-  ```
-- **Partial signing**: User signs their parts, Kora adds fee payer signature
-- **Fresh blockhash**: Always get a new blockhash for the final transaction
-- **`signer_key` param**: Optional on all methods - use when working with multi-signer pools for consistency
-- **`user_id` param**: Optional on signing methods - required when pricing is `free` and usage tracking is enabled
+- **The estimate transaction is thrown away.** It exists only so Kora can price the transaction.
+  The final transaction needs a new blockhash, not the estimate's.
+- **Noop signer**: `createNoopSigner(address(signerAddress))` reserves the fee payer slot before
+  Kora has signed. Get the address from `getPayerSigner()`.
+- **Signing order**: the user signs their own instructions *and* the payment transfer. Kora only
+  adds the fee payer signature; it will not fix a missing user signature.
+- **`signer_key`**: optional, but pass it when the node runs a multi-signer pool so estimate and
+  signature come from the same signer.
+- **`user_id`**: required on signing methods when the operator runs `free` pricing with usage
+  tracking enabled.
 
-## Quick Examples
+## Lighthouse invalidates your signatures
 
-### User Pays Fees in Token
+If the operator enables Lighthouse, `signTransaction` and `signBundle` may return a transaction
+with an extra balance-assertion instruction. That changes the message, so any signature already
+applied is void: re-sign the returned transaction client-side and submit it yourself.
 
-```ts
-import { getTransferInstruction, findAssociatedTokenPda, TOKEN_PROGRAM_ADDRESS } from '@solana-program/token';
-import { getTransferSolInstruction } from '@solana-program/system';
+Lighthouse never applies to `signAndSendTransaction` / `signAndSendBundle` — Kora broadcasts those
+itself, so there is no opportunity to re-sign and the assertion is skipped.
 
-// 1. Build instructions using @solana-program libraries
-const [sourceAta] = await findAssociatedTokenPda({ owner: sender.address, mint: address(usdcMint), tokenProgram: TOKEN_PROGRAM_ADDRESS });
-const [destAta] = await findAssociatedTokenPda({ owner: recipient.address, mint: address(usdcMint), tokenProgram: TOKEN_PROGRAM_ADDRESS });
-const tokenTransferIx = getTransferInstruction({ source: sourceAta, destination: destAta, authority: sender, amount: 10_000_000n });
+## Bundles
 
-// 2. Build estimate transaction with noop signer
-const { signer_address } = await client.getPayerSigner();
-const noopSigner = createNoopSigner(address(signer_address));
-const { blockhash } = await client.getBlockhash();
-
-const estimateTx = pipe(
-  createTransactionMessage({ version: 0 }),
-  tx => setTransactionMessageFeePayerSigner(noopSigner, tx),
-  tx => setTransactionMessageLifetimeUsingBlockhash({ blockhash: blockhash as Blockhash, lastValidBlockHeight: 0n }, tx),
-  tx => appendTransactionMessageInstructions([tokenTransferIx], tx),
-);
-const signedEstimate = await partiallySignTransactionMessageWithSigners(estimateTx);
-
-// 3. Get payment instruction
-const { payment_instruction } = await client.getPaymentInstruction({
-  transaction: getBase64EncodedWireTransaction(signedEstimate),
-  fee_token: usdcMint,
-  source_wallet: sender.address,
-});
-
-// 4. Build final tx with payment instruction appended
-const newBlockhash = await client.getBlockhash();
-const finalTx = pipe(
-  createTransactionMessage({ version: 0 }),
-  tx => setTransactionMessageFeePayerSigner(noopSigner, tx),
-  tx => setTransactionMessageLifetimeUsingBlockhash({ blockhash: newBlockhash.blockhash as Blockhash, lastValidBlockHeight: 0n }, tx),
-  tx => appendTransactionMessageInstructions([tokenTransferIx, payment_instruction], tx),
-);
-
-// 5. User signs
-const partiallySigned = await partiallySignTransactionMessageWithSigners(finalTx);
-const userSigned = await partiallySignTransaction([sender.keyPair], partiallySigned);
-
-// 6. Kora co-signs and sends
-const result = await client.signAndSendTransaction({
-  transaction: getBase64EncodedWireTransaction(userSigned),
-  signer_key: signer_address,
-});
-```
-
-### Fee Estimation
-
-```ts
-const fees = await client.estimateTransactionFee({
-  transaction: base64Tx,
-  fee_token: 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
-});
-// fees.fee_in_lamports, fees.fee_in_token, fees.signer_pubkey, fees.payment_address
-```
-
-### Jito Bundle
-
-```ts
-// Sign and submit bundle atomically via Jito (max 5 transactions)
-const { bundle_uuid, signed_transactions } = await client.signAndSendBundle({
-  transactions: [base64Tx1, base64Tx2, base64Tx3],
-  signer_key: signerAddress,
-});
-
-// Or sign without submitting (for client-side Jito submission)
-const { signed_transactions } = await client.signBundle({
-  transactions: [base64Tx1, base64Tx2],
-  sign_only_indices: [0],  // only sign first transaction
-});
-
-// Estimate bundle fees
-const estimate = await client.estimateBundleFee({
-  transactions: [base64Tx1, base64Tx2],
-  fee_token: usdcMint,
-});
-```
-
-### Lighthouse Re-sign Flow
-
-When the operator has Lighthouse fee payer protection enabled, `signTransaction`/`signBundle` may modify the transaction message (adding a balance assertion). Client signatures become invalid and must be re-applied:
-
-```
-signTransaction → client receives modified tx → client re-signs → client sends to network
-```
-
-Note: Lighthouse does NOT apply to `signAndSendTransaction`/`signAndSendBundle` (broadcast methods).
-
-## RPC Methods Reference
-
-For detailed method specs (params, responses, types), see [references/rpc-api.md](references/rpc-api.md).
-
-## Full Transaction Flow Guide
-
-For a complete step-by-step gasless transaction tutorial, see [references/guides.md](references/guides.md).
+`signBundle` / `signAndSendBundle` take up to 5 transactions and execute atomically via Jito.
+`sign_only_indices` restricts which ones Kora signs. `estimateBundleFee` prices the set.
 
 ## Authentication
 
-Three optional methods (all can be active simultaneously):
+| Method | Header | Constructor option |
+|---|---|---|
+| API key | `x-api-key` | `apiKey` |
+| HMAC | `x-timestamp` + `x-hmac-signature` | `hmacSecret` |
+| reCAPTCHA v3 | `x-recaptcha-token` | `getRecaptchaToken` callback |
 
-| Method | Headers | Config |
-|--------|---------|--------|
-| API Key | `x-api-key` | `apiKey` in constructor |
-| HMAC | `x-timestamp` + `x-hmac-signature` | `hmacSecret` in constructor |
-| reCAPTCHA v3 | `x-recaptcha-token` | `getRecaptchaToken` callback in constructor |
-
-HMAC: SHA256 of `timestamp + JSON body`. SDK handles this automatically.
-reCAPTCHA: Token auto-attached via callback. Only verified on server-configured protected methods (signing methods by default).
-
-The `/liveness` endpoint always bypasses authentication.
+All three can be active together, and the SDK builds the HMAC (SHA256 of `timestamp + JSON body`)
+for you. reCAPTCHA is checked only on the methods the operator marked protected, and only after
+API key / HMAC pass. `/liveness` always bypasses auth.

--- a/.claude/skills/kora-operator/SKILL.md
+++ b/.claude/skills/kora-operator/SKILL.md
@@ -7,244 +7,93 @@ description: "Kora paymaster node operator guide. Use when the user asks about: 
 
 Run Kora nodes to validate, sign, and sponsor Solana transaction fees for your users.
 
-**Docs**: https://launch.solana.com/docs/kora/operators
-**Install**: `cargo install kora-cli`
-**Docker**: `docker pull ghcr.io/solana-foundation/kora:latest`
-**Source**: https://github.com/solana-foundation/kora
+**Docs**: https://launch.solana.com/docs/kora/operators · **Install**: `cargo install kora-cli`
+**Docker**: `ghcr.io/solana-foundation/kora:latest` · **Source**: https://github.com/solana-foundation/kora
 
-## Quick Start
+## Where things are
+
+| Topic | Reference |
+|---|---|
+| Every `kora.toml` section and field, production example | [references/configuration.md](references/configuration.md) |
+| `signers.toml`: memory, Turnkey, Privy, Vault, pools, multi-signer | [references/signers.md](references/signers.md) |
+| Fee components, pricing models, drain vectors | [references/fees.md](references/fees.md) |
+| Docker and Railway deployment | [references/deployment.md](references/deployment.md) |
+
+`crates/lib/src/config.rs` is the authority on config shape, and `kora config validate` is the
+fastest way to check a real file. Prefer both over any enumeration written down in prose.
+
+## Getting running
+
+Two files are required: `kora.toml` (validation, auth, pricing, caching, methods, bundles,
+lighthouse, metrics) and `signers.toml` (keys, types, selection strategy).
 
 ```bash
-# Install
-cargo install kora-cli
-
-# Minimal config files needed: kora.toml + signers.toml
-
-# Validate config
 kora --config kora.toml config validate
-
-# Start server
 kora --config kora.toml rpc start --signers-config signers.toml
-
-# Initialize payment ATAs (for receiving token payments)
 kora --config kora.toml rpc initialize-atas --signers-config signers.toml
 ```
 
-## CLI Reference
+`config validate-with-rpc` additionally checks the config against live chain state (that allowed
+mints exist, that the fee payer is funded). Worth running before a first deploy.
 
-```bash
-# Global flags
-kora --config <path>     # kora.toml location (default: ./kora.toml)
-kora --rpc-url <url>     # Solana RPC URL (overrides config, env: RPC_URL)
+`initialize-atas` is required before the node can receive token payments — without it the payment
+destination has no associated token accounts and transactions fail at execution, not validation.
 
-# Commands
-kora config validate                    # Validate kora.toml
-kora config validate-with-rpc           # Validate with live RPC calls
-kora rpc start --signers-config <path>  # Start RPC server
-kora rpc start --no-load-signer         # Start without loading signers (limited functionality)
-kora rpc start --port 8080              # Custom port (default: 8080)
-kora rpc start --logging-format json    # JSON logging (default: standard)
-kora rpc initialize-atas --signers-config <path>  # Initialize payment ATAs
+`--rpc-url` (env `RPC_URL`) overrides the config. `kora rpc start --help` covers port, logging
+format, `--no-load-signer`, and the ATA batching flags.
 
-# ATA init options
---fee-payer-key <base58>     # Custom fee payer for ATA creation
---compute-unit-price <num>   # Priority fee
---compute-unit-limit <num>   # Compute budget
---chunk-size <num>           # Batch size for ATA creation
-```
+## Decisions that matter
 
-## Configuration Overview
+### Pricing, and the drain risk it carries
 
-Two config files required:
+| Model | Use case | Risk |
+|---|---|---|
+| `margin` (default) | cost + markup | Safest — prices in fee payer outflow |
+| `fixed` | flat fee per transaction | Fee payer can be drained |
+| `free` | full sponsorship | Fee payer can be drained |
 
-| File | Purpose |
-|------|---------|
-| `kora.toml` | Server config: validation, auth, pricing, caching, methods, bundles, lighthouse, metrics |
-| `signers.toml` | Signer pool: keys, types, selection strategy |
+With `fixed` or `free`, the node is not pricing the SOL it spends, so a transaction that moves fee
+payer funds is a direct loss. Keep `allow_transfer = false` on the system and token policies.
+[references/fees.md](references/fees.md) works through the vectors.
 
-### Minimal kora.toml
+### Fee payer policy
 
-```toml
-[kora]
-rate_limit = 100
+Controls what the fee payer signer may do inside a submitted transaction. Every flag defaults to
+`false`, so an unlisted action is denied — enable only what your flows need, and treat each `true`
+as a deliberate acceptance of the corresponding drain vector.
 
-[validation]
-max_allowed_lamports = 1000000
-max_signatures = 10
-price_source = "Mock"  # or "Jupiter" (requires JUPITER_API_KEY env var)
+Sections exist for `system` (plus `system.nonce`), `spl_token`, `token_2022`, `alt`,
+`bpf_loader_upgradeable`, and `loader_v4`. For the current field list read the policy structs in
+`config.rs` rather than trusting a copied table.
 
-allowed_programs = [
-    "11111111111111111111111111111111",
-    "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
-    "ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL",
-    "ComputeBudget111111111111111111111111111111",
-]
+### Lighthouse does nothing on broadcast methods
 
-allowed_tokens = ["<your-token-mint>"]
-allowed_spl_paid_tokens = ["<your-token-mint>"]
+Lighthouse appends a fee-payer balance assertion, which changes the message and requires the client
+to re-sign. It is therefore skipped outright when Kora broadcasts: enabling it buys **zero**
+protection on `signAndSendTransaction` and `signAndSendBundle`, with no error raised.
+`config validate` warns about this; it does not block startup.
 
-[validation.price]
-type = "margin"
-margin = 0.1  # 10% markup
-```
-
-### Minimal signers.toml
-
-```toml
-[signer_pool]
-strategy = "round_robin"  # or "random", "weighted"
-
-[[signers]]
-name = "signer_1"
-type = "memory"
-private_key_env = "KORA_PRIVATE_KEY"
-weight = 1
-```
-
-## Detailed References
-
-- **Full kora.toml reference**: See [references/configuration.md](references/configuration.md) - all sections, fields, and production examples
-- **Signer types and setup**: See [references/signers.md](references/signers.md) - memory, Turnkey, Privy, Vault configuration
-- **Fee calculation and pricing**: See [references/fees.md](references/fees.md) - fee components, pricing models, security considerations
-
-## Key Operator Decisions
-
-### Pricing Model
-
-| Model | Use Case | Security |
-|-------|----------|----------|
-| `margin` (default) | Charge users cost + markup | Safest - includes fee payer outflow |
-| `fixed` | Flat fee per transaction | Must disable fee payer transfers in policy |
-| `free` | Sponsor all fees | Must disable fee payer transfers in policy |
+If lighthouse is the drain protection, the node must serve `signTransaction` / `signBundle` and the
+client must re-sign. Add `L2TExMFKdjpN9kozasaurPirfHy9P8sbXoAN1qA3S95` to `allowed_programs`.
 
 ### Authentication
 
-Three optional methods, can be used simultaneously:
-- **API Key**: Simple `x-api-key` header. Set `api_key` in `[kora.auth]` or `KORA_API_KEY` env var.
-- **HMAC**: Cryptographic signature with timestamp. Set `hmac_secret` in `[kora.auth]` or `KORA_HMAC_SECRET` env var.
-- **reCAPTCHA v3**: Bot protection for signing methods. Set `recaptcha_secret` in `[kora.auth]` or `KORA_RECAPTCHA_SECRET` env var. Configurable `recaptcha_score_threshold` (default: 0.5) and `protected_methods`.
+API key (`x-api-key`), HMAC (`x-timestamp` + `x-hmac-signature`), and reCAPTCHA v3 can all be
+active at once. Each reads from `[kora.auth]` or an env var (`KORA_API_KEY`, `KORA_HMAC_SECRET`,
+`KORA_RECAPTCHA_SECRET`). reCAPTCHA runs only after API key and HMAC have passed, and only on
+`protected_methods`. `/liveness` bypasses all of it.
 
-### Fee Payer Policy
+### Jito bundles
 
-Control what actions the fee payer can perform in transactions. All default to `false` (restrictive). Explicitly set to `true` only what you need.
+Atomic multi-transaction execution via `[kora.bundle]` + `[kora.bundle.jito]`. If Kora pays the
+Jito tip, that tip is a system transfer from the fee payer, so it needs
+`allow_transfer = true` in `[validation.fee_payer_policy.system]` — which reopens the drain vector
+above. Pair it with `margin` pricing.
 
-Critical for `fixed`/`free` pricing: ensure `allow_transfer` remains `false` (the default) on system and token programs to prevent fee payer fund drain.
+### Usage limits, caching, metrics
 
-### Jito Bundle Support
-
-Enable atomic multi-transaction execution via Jito:
-```toml
-[kora.bundle]
-enabled = true
-
-[kora.bundle.jito]
-block_engine_url = "https://mainnet.block-engine.jito.wtf"
-```
-
-When using Jito tips paid by Kora, set `allow_transfer = true` in `[validation.fee_payer_policy.system]`.
-
-### Lighthouse Fee Payer Protection
-
-Adds balance assertion instructions to protect the fee payer from drainage attacks:
-```toml
-[kora.lighthouse]
-enabled = true
-fail_if_transaction_size_overflow = true
-```
-
-Only works with `signTransaction`/`signBundle` (not broadcast methods). Requires Lighthouse program in `allowed_programs`: `L2TExMFKdjpN9kozasaurPirfHy9P8sbXoAN1qA3S95`
-
-### Usage Limits
-
-Rule-based per-user limiting with Redis backend:
-```toml
-[kora.usage_limit]
-enabled = true
-cache_url = "redis://redis:6379"
-fallback_if_unavailable = false
-
-[[kora.usage_limit.rules]]
-type = "transaction"
-max = 100
-window_seconds = 3600
-
-[[kora.usage_limit.rules]]
-type = "instruction"
-program = "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"
-instruction = "Transfer"
-max = 10
-window_seconds = 3600
-```
-
-Requires `user_id` parameter in signing requests when enabled with free pricing.
-
-### Caching
-
-Optional Redis caching for token account lookups:
-```toml
-[kora.cache]
-enabled = true
-url = "redis://localhost:6379"
-default_ttl = 300
-account_ttl = 60
-```
-
-### Monitoring
-
-Optional Prometheus metrics at `/metrics`:
-```toml
-[metrics]
-enabled = true
-endpoint = "/metrics"
-port = 9090
-```
-
-Key metrics: `kora_http_requests_total`, `kora_http_request_duration_seconds`, `signer_balance_lamports`.
-
-## Deployment
-
-### Docker
-
-Pre-built image available (tags: `latest`, `beta`, `v<version>`):
-```bash
-docker pull ghcr.io/solana-foundation/kora:latest
-docker run -v ./kora.toml:/kora.toml -v ./signers.toml:/signers.toml \
-  -e RPC_URL=https://api.mainnet-beta.solana.com \
-  -e KORA_PRIVATE_KEY=<key> \
-  -p 8080:8080 \
-  ghcr.io/solana-foundation/kora:latest
-```
-
-Or build from source:
-```dockerfile
-FROM rust:1.86-bookworm AS builder
-RUN cargo install kora-cli
-FROM debian:bookworm-slim
-COPY --from=builder /usr/local/cargo/bin/kora /usr/local/bin/kora
-COPY kora.toml signers.toml ./
-ENV RPC_URL=https://api.mainnet-beta.solana.com
-CMD ["kora", "rpc", "start", "--signers-config", "signers.toml"]
-```
-
-### Railway
-
-1. Create project with kora.toml, signers.toml, Dockerfile
-2. `railway login && railway init && railway up`
-3. Set env vars in dashboard: `RPC_URL`, `KORA_PRIVATE_KEY`, `RUST_LOG`
-4. Generate public domain from settings
-
-**Docs**: https://launch.solana.com/docs/kora/operators/deployment/railway
-
-## Kora Core Development
-
-For contributors working on the Kora codebase itself:
-
-```bash
-just build          # Build all crates
-just build-lib      # Build kora-lib only
-just build-cli      # Build kora-cli only
-just check          # Check formatting
-just fmt            # Format + lint with auto-fix
-just unit-test      # Run unit tests
-just integration-test  # Run full integration test suite
-```
+Usage limits are rule-based per user with a Redis backend, and require a `user_id` on signing
+requests once enabled. `fallback_if_unavailable` decides whether a Redis outage fails open or
+closed — the default (`false`) fails closed. Redis account caching and Prometheus metrics at
+`/metrics` are both independent opt-ins. Config shapes in
+[references/configuration.md](references/configuration.md).

--- a/.claude/skills/kora-operator/references/configuration.md
+++ b/.claude/skills/kora-operator/references/configuration.md
@@ -234,53 +234,33 @@ Block specific Token-2022 extensions from being used in transactions.
 
 ## Fee Payer Policy
 
-Controls what actions the fee payer signer can perform. All default to `false` (restrictive via Rust's `#[derive(Default)]` on bool). Explicitly enable only what you need.
+Controls what actions the fee payer signer can perform. Every flag defaults to `false`, so an
+omitted section denies everything in it. Enable only what your flows need.
+
+Sections, each named after the program it gates:
 
 ```toml
-# All fields default to false if omitted. Only enable what you need.
-[validation.fee_payer_policy.system]
-allow_transfer = false         # System Transfer/TransferWithSeed
-allow_assign = false           # System Assign/AssignWithSeed
-allow_create_account = false   # System CreateAccount/CreateAccountWithSeed
-allow_allocate = false         # System Allocate/AllocateWithSeed
-
-[validation.fee_payer_policy.system.nonce]
-allow_initialize = false       # InitializeNonceAccount
-allow_advance = false          # AdvanceNonceAccount
-allow_authorize = false        # AuthorizeNonceAccount
-allow_withdraw = false         # WithdrawNonceAccount
-
+[validation.fee_payer_policy.system]                  # transfer, assign, create_account, allocate
+[validation.fee_payer_policy.system.nonce]            # initialize, advance, authorize, withdraw
 [validation.fee_payer_policy.spl_token]
-allow_transfer = false         # Transfer/TransferChecked
-allow_burn = false             # Burn/BurnChecked
-allow_close_account = false    # CloseAccount
-allow_approve = false          # Approve/ApproveChecked
-allow_revoke = false           # Revoke
-allow_set_authority = false    # SetAuthority
-allow_mint_to = false          # MintTo/MintToChecked
-allow_initialize_mint = false  # InitializeMint/InitializeMint2
-allow_initialize_account = false # InitializeAccount/InitializeAccount3
-allow_initialize_multisig = false # InitializeMultisig/InitializeMultisig2
-allow_freeze_account = false   # FreezeAccount
-allow_thaw_account = false     # ThawAccount
-
-[validation.fee_payer_policy.token_2022]
-# Same 12 fields as spl_token above, all default to false
-allow_transfer = false
-allow_burn = false
-allow_close_account = false
-allow_approve = false
-allow_revoke = false
-allow_set_authority = false
-allow_mint_to = false
-allow_initialize_mint = false
-allow_initialize_account = false
-allow_initialize_multisig = false
-allow_freeze_account = false
-allow_thaw_account = false
+[validation.fee_payer_policy.token_2022]              # spl_token's flags plus extension-authority ones
+[validation.fee_payer_policy.alt]                     # create, extend, freeze, deactivate, close
+[validation.fee_payer_policy.bpf_loader_upgradeable]
+[validation.fee_payer_policy.loader_v4]
 ```
 
-**Security note**: Since all fields default to `false`, the fee payer policy is secure by default. Only enable operations your use case requires. For `fixed`/`free` pricing, ensure transfer operations remain `false` to prevent fee payer fund drain.
+Every flag is named `allow_<instruction>` in snake_case. The token and loader sections carry more
+than a dozen flags each and gain new ones as instructions are gated, so read the policy structs in
+`crates/lib/src/config.rs` for the current list instead of copying a table. `kora config validate`
+rejects unknown keys, which makes it a reliable check on a hand-written policy.
+
+A couple of guards are deliberately *not* flag-gated and always apply: BPF Loader Upgradeable
+`Close` with a foreign recipient, and Loader v4 `SetProgramLength` with a recipient other than the
+fee payer.
+
+**Security note**: defaulting to `false` means the policy is safe when under-specified, and each
+`true` is an explicit acceptance of that drain vector. Under `fixed`/`free` pricing the node does
+not price its own SOL outflow, so transfer flags in particular must stay `false`.
 
 ---
 

--- a/.claude/skills/kora-operator/references/deployment.md
+++ b/.claude/skills/kora-operator/references/deployment.md
@@ -1,0 +1,51 @@
+# Deployment
+
+Both config files must be present in the container and every secret must arrive through the
+environment, never baked into the image. `signers.toml` names env vars; it does not hold keys.
+
+## Docker
+
+Pre-built images are published to `ghcr.io/solana-foundation/kora` with tags `latest`, `beta`, and
+`v<version>`. Pin `v<version>` in production — `latest` tracks stable releases and will move under
+a running deployment on the next publish.
+
+```bash
+docker run \
+  -v ./kora.toml:/kora.toml \
+  -v ./signers.toml:/signers.toml \
+  -e RPC_URL=https://api.mainnet-beta.solana.com \
+  -e KORA_PRIVATE_KEY=<key> \
+  -p 8080:8080 \
+  ghcr.io/solana-foundation/kora:v<version>
+```
+
+Building from source instead:
+
+```dockerfile
+FROM rust:1.86-bookworm AS builder
+RUN cargo install kora-cli
+
+FROM debian:bookworm-slim
+COPY --from=builder /usr/local/cargo/bin/kora /usr/local/bin/kora
+COPY kora.toml signers.toml ./
+ENV RPC_URL=https://api.mainnet-beta.solana.com
+CMD ["kora", "rpc", "start", "--signers-config", "signers.toml"]
+```
+
+## Railway
+
+1. Create a project containing `kora.toml`, `signers.toml`, and a Dockerfile.
+2. `railway login && railway init && railway up`
+3. Set `RPC_URL`, `KORA_PRIVATE_KEY`, and `RUST_LOG` in the dashboard.
+4. Generate a public domain from project settings.
+
+Full walkthrough: https://launch.solana.com/docs/kora/operators/deployment/railway
+
+## Before going live
+
+- `kora config validate-with-rpc` against the production RPC endpoint, not just `config validate` —
+  it catches an unfunded fee payer and non-existent mints.
+- Run `rpc initialize-atas` if the node accepts token payments.
+- Point a health check at `/liveness`; it bypasses auth by design.
+- A public node with no `api_key` or `hmac_secret` set is an open paymaster. Rate limiting alone
+  does not stop a funded attacker draining the fee payer.

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -5,163 +5,69 @@ description: "Prepare a Kora release PR. Bumps Rust crate versions (kora-lib + k
 
 # Kora Release Preparation
 
-Prepare a release PR for Kora. This updates version numbers, generates the CHANGELOG, and opens a PR against `main`. For mainline releases, publishing happens after merge via CI.
+Bump versions, generate the CHANGELOG, open a PR against `main`. Publishing happens after merge
+via CI — see the `complete-release` skill.
 
----
+## Decide first
 
-## Prerequisites
-
-Verify these tools are installed before starting:
-
-```bash
-cargo set-version --version   # from cargo-edit: cargo install cargo-edit
-git cliff --version           # cargo install git-cliff
-gh --version                  # GitHub CLI
-jq --version
-```
-
----
-
-## Step 1 — Get current versions
+Read current versions, then ask the user which components to release and at what versions:
 
 ```bash
-# Rust (workspace root Cargo.toml)
-cargo metadata --no-deps --format-version 1 \
-  | jq -r '.packages[] | select(.name == "kora-lib") | .version'
-
-# TypeScript SDK
+cargo metadata --no-deps --format-version 1 | jq -r '.packages[] | select(.name=="kora-lib") | .version'
 node -p "require('./sdks/ts/package.json').version"
 ```
 
-Ask the user which component(s) to release and what version(s) to use.
+Rust and TypeScript release independently. Prereleases use semver suffixes (`2.3.0-beta.1`).
 
----
+Work on a `chore/release-v${VERSION}` branch off `main` with a clean tree.
 
-## Step 2 — Verify clean working directory
+## Bump only kora-lib and kora-cli
 
-```bash
-git status --porcelain
-```
+**Do not run `cargo set-version --workspace`.** The workspace also contains `crates/kora-deploy`
+(published separately, currently on its own `0.x` line) and `examples/devnet-deploy-paymaster`.
+A workspace-wide bump drags both onto the Kora version and `kora-deploy` has no `publish = false`
+to stop it reaching crates.io.
 
-If output is non-empty, stop and ask the user to commit or stash first.
-
----
-
-## Step 3 — Create release branch
+Four places move together, and `kora-lib` + `kora-cli` always share one version:
 
 ```bash
-# Rust-only release
-git checkout -b "chore/release-v${RUST_VERSION}"
-
-# Both Rust + TypeScript
-git checkout -b "chore/release-v${RUST_VERSION}-ts-v${TS_VERSION}"
+cargo set-version -p kora-lib -p kora-cli "${RUST_VERSION}"
 ```
 
----
+Then edit by hand in the root `Cargo.toml`:
+- `[workspace.package] version` — `tests` inherits this
+- the `kora-lib = { path = "crates/lib", version = "..." }` pin in `[workspace.dependencies]`
 
-## Step 4 — Bump Rust versions
+Confirm nothing else moved before committing:
 
 ```bash
-# Update all workspace crates to the new version
-cargo set-version --workspace "${RUST_VERSION}"
-
-# Update the kora-lib version pin in workspace.dependencies
-sed -i.bak \
-  "s/kora-lib = { path = \"crates\/lib\", version = \"[^\"]*\" }/kora-lib = { path = \"crates\/lib\", version = \"${RUST_VERSION}\" }/" \
-  Cargo.toml
-rm -f Cargo.toml.bak
+git diff --stat
+grep -rn '^version' crates/*/Cargo.toml Cargo.toml
 ```
 
----
+`crates/kora-deploy/Cargo.toml` must be untouched.
 
-## Step 5 — Generate CHANGELOG
+## CHANGELOG
 
-```bash
-last_tag=$(git tag -l "v*" --sort=-version:refname | head -1)
+git-cliff appends rather than regenerates, and the invocation differs depending on whether a
+previous tag and CHANGELOG exist. See [references/changelog.md](references/changelog.md).
 
-if [ -z "$last_tag" ]; then
-  git cliff "$(git rev-list --max-parents=0 HEAD)"..HEAD \
-    --tag "v${RUST_VERSION}" \
-    --config .github/cliff.toml \
-    --output CHANGELOG.md \
-    --strip all
-elif [ -f CHANGELOG.md ]; then
-  git cliff "${last_tag}"..HEAD \
-    --tag "v${RUST_VERSION}" \
-    --config .github/cliff.toml \
-    --strip all > CHANGELOG.new.md
-  cat CHANGELOG.md >> CHANGELOG.new.md
-  mv CHANGELOG.new.md CHANGELOG.md
-else
-  git cliff "${last_tag}"..HEAD \
-    --tag "v${RUST_VERSION}" \
-    --config .github/cliff.toml \
-    --output CHANGELOG.md \
-    --strip all
-fi
-```
-
----
-
-## Step 6 — Bump TypeScript SDK (if releasing TS)
+## TypeScript
 
 ```bash
 npm version "${TS_VERSION}" --no-git-tag-version --prefix sdks/ts
 ```
 
----
+## Commit and PR
 
-## Step 7 — Stage and commit
+Commit message: `chore: release v${RUST_VERSION}`, plus ` rust + ts-sdk v${TS_VERSION}` when both
+move. PR targets `main`, reviewers `dev-jodee,amilz`. Body should list the crates and versions
+being released and point at the `complete-release` skill for publishing.
 
-```bash
-git add Cargo.toml Cargo.lock CHANGELOG.md crates/*/Cargo.toml
+## Constraints
 
-# If TS was bumped
-git add sdks/ts/package.json
-
-# Rust-only commit message
-git commit -m "chore: release v${RUST_VERSION}"
-
-# Combined commit message
-git commit -m "chore: release v${RUST_VERSION} rust + ts-sdk v${TS_VERSION}"
-```
-
----
-
-## Step 8 — Push and open PR
-
-```bash
-git push -u origin HEAD
-
-gh pr create \
-  --base main \
-  --title "chore: release v${RUST_VERSION}" \
-  --reviewer dev-jodee,amilz \
-  --body "$(cat <<EOF
-## Release v${RUST_VERSION}
-
-### Rust Crates
-- **kora-lib** \`${RUST_VERSION}\`
-- **kora-cli** \`${RUST_VERSION}\`
-- CHANGELOG updated from commits since last tag
-
-### TypeScript SDK
-- **@solana/kora** \`${TS_VERSION}\` *(omit section if not releasing)*
-
-## Publish
-For mainline releases from \`main\`, trigger CI workflows from \`main\` using the \`complete-release\` skill (or manually):
-- **Rust**: Actions → "Publish Rust Crates"
-- **TypeScript**: Actions → "Publish TypeScript SDK"
-EOF
-)"
-```
-
----
-
-## Notes
-
-- All release PRs target `main` regardless of current branch.
-- Hotfix patch releases are published from `hotfix/*` before merge-back to `main`.
-- Do NOT call `just release` or `just release-ts-sdk` — both are interactive.
-- Tags (`v{VERSION}`, `kora-lib-v{VERSION}`, `kora-cli-v{VERSION}`) are created by CI after merge.
-- Prerelease versions use semver suffixes, e.g. `2.3.0-beta.1`.
+- Release PRs always target `main`, regardless of the current branch.
+- Hotfix patches publish from `hotfix/*` *before* merge-back to `main`.
+- Never call `just release` or `just release-ts-sdk` — both are interactive and will hang.
+- Tags (`v{VERSION}`, `kora-lib-v{VERSION}`, `kora-cli-v{VERSION}`) are created by CI after merge,
+  not here.

--- a/.claude/skills/release/references/changelog.md
+++ b/.claude/skills/release/references/changelog.md
@@ -1,0 +1,39 @@
+# CHANGELOG generation
+
+git-cliff renders only the commit range you hand it, so an existing `CHANGELOG.md` has to be
+concatenated underneath the new section rather than overwritten. Three cases:
+
+```bash
+last_tag=$(git tag -l "v*" --sort=-version:refname | head -1)
+
+if [ -z "$last_tag" ]; then
+  # First ever release: whole history
+  git cliff "$(git rev-list --max-parents=0 HEAD)"..HEAD \
+    --tag "v${RUST_VERSION}" --config .github/cliff.toml --output CHANGELOG.md --strip all
+
+elif [ -f CHANGELOG.md ]; then
+  # Normal case: prepend the new section to the existing file
+  git cliff "${last_tag}"..HEAD \
+    --tag "v${RUST_VERSION}" --config .github/cliff.toml --strip all > CHANGELOG.new.md
+  cat CHANGELOG.md >> CHANGELOG.new.md
+  mv CHANGELOG.new.md CHANGELOG.md
+
+else
+  git cliff "${last_tag}"..HEAD \
+    --tag "v${RUST_VERSION}" --config .github/cliff.toml --output CHANGELOG.md --strip all
+fi
+```
+
+`--output` truncates. Using it in the middle case silently drops every prior release, which is why
+that branch redirects to a temp file instead.
+
+`--strip all` removes the header/footer so the appended section stacks cleanly.
+
+Grouping is driven by commit type via `.github/cliff.toml`: `feat`, `fix`, `perf`, `refactor`,
+`doc`, `test` appear; `chore`, `ci`, `build` are skipped. A release with only skipped types
+produces an empty section.
+
+## Tools
+
+`cargo install cargo-edit git-cliff` provides `cargo set-version` and `git cliff`. `gh` and `jq`
+are also required.

--- a/.claude/skills/sync-keychain/SKILL.md
+++ b/.claude/skills/sync-keychain/SKILL.md
@@ -5,173 +5,65 @@ description: "Sync the solana-keychain dependency and scaffold adapters for sign
 
 # Sync solana-keychain
 
-Bump the `solana-keychain` pin and reconcile Kora's `SignerTypeConfig` against the signer backends upstream actually ships.
+Bump the `solana-keychain` pin, then reconcile Kora's `SignerTypeConfig` against the backends
+upstream actually ships.
 
----
+## Bump the pin
 
-## Step 1 — Compare versions
+Compare the crates.io `max_stable_version` against the pin in `crates/lib/Cargo.toml`, edit if they
+differ, then `cargo update -p solana-keychain`.
 
-```bash
-latest=$(curl -sS -H "User-Agent: kora-sync-keychain" \
-  https://crates.io/api/v1/crates/solana-keychain | jq -r '.crate.max_stable_version')
-current=$(grep -oE 'solana-keychain = \{ version = "[^"]+"' crates/lib/Cargo.toml \
-  | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
+Keep `default-features = false` and the `features = ["all", "sdk-v4"]` list intact. `sdk-v4`
+exact-pins `solana-sdk` for the entire workspace, so a major keychain bump cascades into every
+crate — expect that to be the bulk of the work on a major.
 
-echo "current=$current latest=$latest"
-```
+## Find the gap
 
-If they differ, Edit the version string in `crates/lib/Cargo.toml` (the `solana-keychain` entry), then run `cargo update -p solana-keychain`.
-
-Keep `default-features = false` and the `features = ["all", "sdk-v4"]` list intact. `sdk-v4` exact-pins `solana-sdk` for the whole workspace, so a major bump may cascade.
-
----
-
-## Step 2 — Enumerate upstream backends
+Upstream backends, from a shallow clone of `solana-foundation/solana-keychain`:
 
 ```bash
-tmp=$(mktemp -d)
-git clone --depth 1 -q https://github.com/solana-foundation/solana-keychain "$tmp/kc"
 grep -rhoE "pub struct [A-Za-z]+SignerConfig" --include="*.rs" "$tmp/kc" \
   | sed 's/pub struct //;s/SignerConfig//' | sort -u
 ```
 
-Enumerate by `*SignerConfig` struct, not by `from_*` method. `from_*` also matches key-format helpers (`from_bytes`, `from_pem`, `from_u8_array_string`, `from_private_key_file`, …) that are not backends and would be scaffolded as phantom signers.
+Enumerate by `*SignerConfig` struct, **not** by `from_*` method. `from_*` also matches key-format
+helpers (`from_bytes`, `from_pem`, `from_u8_array_string`, …) which are not backends and would be
+scaffolded as phantom signers.
 
-For each backend, record whether its constructor is async:
-
-```bash
-grep -rhoE "pub (async )?fn from_\w+" --include="*.rs" "$tmp/kc" | sort -u
-```
-
-Delete `$tmp` when done.
-
----
-
-## Step 3 — Enumerate Kora's variants
-
-Derive this list, never hardcode it:
+Kora's side — derive it, never hardcode:
 
 ```bash
 awk '/pub enum SignerTypeConfig/,/^}/' crates/lib/src/signer/config.rs \
   | grep -E "^    [A-Z][A-Za-z]* \{" | tr -d ' {'
 ```
 
-Variant names are the upstream struct prefix in PascalCase: `AwsKmsSignerConfig` → `AwsKms` → `from_aws_kms`.
+Variant names are the upstream struct prefix: `AwsKmsSignerConfig` → `AwsKms` → `from_aws_kms`.
+Also record whether each `from_<name>` is `async`; the build function must match.
 
-The difference between Step 2 and Step 3 is the work. If it is empty, report and stop.
+The difference between the two lists is the work. If it's empty, report and stop.
 
----
+## Scaffold what's missing
 
-## Step 4 — Scaffold each missing signer
+Six edits per signer, five of them in `crates/lib/src/signer/config.rs`: config struct, enum
+variant, build function, validation function, two match arms — plus an arm in
+`crates/lib/src/validator/signer_validator.rs`. That last match is exhaustive, so omitting it is a
+compile error rather than a silent gap.
 
-Read the upstream `<Name>SignerConfig` struct and the `from_<name>` signature first. Kora's config struct mirrors the upstream one, with secret-bearing fields replaced by `*_env` names holding the env var to read.
+Copy the shape of the nearest existing analogue (`Fireblocks` for an async HTTP backend, `AwsKms`
+for a cloud-KMS one). [references/scaffolding.md](references/scaffolding.md) has the templates and
+the reasoning behind each piece.
 
-Copy the shape of the nearest existing analogue in `crates/lib/src/signer/config.rs` (`Fireblocks` for an async HTTP backend, `AwsKms` for a cloud-KMS one) rather than the templates below verbatim.
+Two rules that are not obvious from the surrounding code:
 
-**1. Config struct** — alongside the other `*SignerConfig` structs:
+- Secrets are referenced by env var *name* in `signers.toml`, never inlined. Any new config field
+  holding a credential must be named `*_env`.
+- Never interpolate an upstream error directly. `sanitize_error!` strips secrets out of error
+  strings from remote signer SDKs.
 
-```rust
-/// <Name> signer configuration
-#[derive(Clone, Serialize, Deserialize)]
-pub struct <Name>SignerConfig {
-    pub api_key_env: String,
-    #[serde(default)]
-    pub api_base_url: Option<String>,
-    #[serde(default)]
-    pub http_config: Option<RemoteSignerHttpConfig>,
-}
-```
+Verify with `cargo check -p kora-lib`, `just fmt`, `cargo test -p kora-lib --lib signer`.
 
-Include `http_config` only if the upstream config has an `http_client_config` field.
+## Report
 
-**2. Enum variant** in `SignerTypeConfig`:
-
-```rust
-/// <Name> signer configuration
-<Name> {
-    #[serde(flatten)]
-    config: <Name>SignerConfig,
-},
-```
-
-**3. Build function** — `async` iff `from_<name>` is async:
-
-```rust
-async fn build_<name>_signer(
-    config: &<Name>SignerConfig,
-    signer_name: &str,
-) -> Result<Signer, KoraError> {
-    let api_key = get_env_var_for_signer(&config.api_key_env, signer_name)?;
-
-    let keychain_config = solana_keychain::<Name>SignerConfig {
-        api_key,
-        api_base_url: config.api_base_url.clone(),
-        http_client_config: config
-            .http_config
-            .as_ref()
-            .map(solana_keychain::HttpClientConfig::from),
-    };
-
-    Signer::from_<name>(keychain_config).await.map_err(|e| {
-        KoraError::SigningError(format!(
-            "Failed to create <Name> signer '{signer_name}': {}",
-            sanitize_error!(e)
-        ))
-    })
-}
-```
-
-Never interpolate `e` directly; `sanitize_error!` strips secrets out of upstream error strings.
-
-**4. Validation function**:
-
-```rust
-fn validate_<name>_config(
-    config: &<Name>SignerConfig,
-    signer_name: &str,
-) -> Result<(), KoraError> {
-    let env_vars = [("api_key_env", &config.api_key_env)];
-
-    for (field_name, env_var) in env_vars {
-        if env_var.is_empty() {
-            return Err(KoraError::ValidationError(format!(
-                "<Name> signer '{signer_name}' must specify non-empty {field_name}"
-            )));
-        }
-        get_env_var_for_signer(env_var, signer_name)?;
-    }
-    Ok(())
-}
-```
-
-Both checks matter: the empty check catches a missing TOML field, `get_env_var_for_signer` catches a named env var that is unset.
-
-**5. Match arms** — `build_signer_from_config` and `validate_individual_signer_config`, both in `crates/lib/src/signer/config.rs`.
-
-**6. HTTP config arm** in `crates/lib/src/validator/signer_validator.rs` — `&config.http_config` if the signer has one, `&None` otherwise. This match is exhaustive, so omitting it is a compile error.
-
----
-
-## Step 5 — Verify
-
-```bash
-cargo check -p kora-lib
-just fmt
-cargo test -p kora-lib --lib signer
-```
-
----
-
-## Step 6 — Report
-
-- Version: `<old>` → `<new>`, or already latest
-- Upstream backends: count
-- New signers scaffolded, or none
-- Files modified
-
----
-
-## Notes
-
-- Scaffolding is a starting point, not a finished adapter. Flag to the user that a new signer has no integration test and no `signers.toml` docs entry.
-- Secrets are referenced by env var name in `signers.toml`, never inlined. A new config field holding a credential must be named `*_env`.
+Version before/after, upstream backend count, signers scaffolded, files touched. Say plainly that
+scaffolding is a starting point: a new signer lands with no integration test and no `signers.toml`
+documentation entry.

--- a/.claude/skills/sync-keychain/references/scaffolding.md
+++ b/.claude/skills/sync-keychain/references/scaffolding.md
@@ -1,0 +1,104 @@
+# Scaffolding a signer adapter
+
+Read the upstream `<Name>SignerConfig` struct and the `from_<name>` signature before writing
+anything. Kora's config struct mirrors the upstream one, with every secret-bearing field replaced
+by a `*_env` field holding the name of the env var to read.
+
+These are templates, not a spec. Prefer the shape of the nearest existing analogue in
+`crates/lib/src/signer/config.rs`.
+
+## 1. Config struct
+
+Alongside the other `*SignerConfig` structs:
+
+```rust
+/// <Name> signer configuration
+#[derive(Clone, Serialize, Deserialize)]
+pub struct <Name>SignerConfig {
+    pub api_key_env: String,
+    #[serde(default)]
+    pub api_base_url: Option<String>,
+    #[serde(default)]
+    pub http_config: Option<RemoteSignerHttpConfig>,
+}
+```
+
+Include `http_config` only if the upstream config has an `http_client_config` field.
+
+## 2. Enum variant
+
+In `SignerTypeConfig`:
+
+```rust
+/// <Name> signer configuration
+<Name> {
+    #[serde(flatten)]
+    config: <Name>SignerConfig,
+},
+```
+
+## 3. Build function
+
+`async` if and only if `from_<name>` is async upstream:
+
+```rust
+async fn build_<name>_signer(
+    config: &<Name>SignerConfig,
+    signer_name: &str,
+) -> Result<Signer, KoraError> {
+    let api_key = get_env_var_for_signer(&config.api_key_env, signer_name)?;
+
+    let keychain_config = solana_keychain::<Name>SignerConfig {
+        api_key,
+        api_base_url: config.api_base_url.clone(),
+        http_client_config: config
+            .http_config
+            .as_ref()
+            .map(solana_keychain::HttpClientConfig::from),
+    };
+
+    Signer::from_<name>(keychain_config).await.map_err(|e| {
+        KoraError::SigningError(format!(
+            "Failed to create <Name> signer '{signer_name}': {}",
+            sanitize_error!(e)
+        ))
+    })
+}
+```
+
+`sanitize_error!` is mandatory here — remote signer SDKs routinely echo the credential back inside
+error strings.
+
+## 4. Validation function
+
+```rust
+fn validate_<name>_config(
+    config: &<Name>SignerConfig,
+    signer_name: &str,
+) -> Result<(), KoraError> {
+    let env_vars = [("api_key_env", &config.api_key_env)];
+
+    for (field_name, env_var) in env_vars {
+        if env_var.is_empty() {
+            return Err(KoraError::ValidationError(format!(
+                "<Name> signer '{signer_name}' must specify non-empty {field_name}"
+            )));
+        }
+        get_env_var_for_signer(env_var, signer_name)?;
+    }
+    Ok(())
+}
+```
+
+Both checks earn their place: the empty check catches a missing TOML field, `get_env_var_for_signer`
+catches a field that names an env var which is unset at runtime.
+
+## 5. Match arms
+
+`build_signer_from_config` and `validate_individual_signer_config`, both in
+`crates/lib/src/signer/config.rs`.
+
+## 6. HTTP config arm
+
+`crates/lib/src/validator/signer_validator.rs` — pass `&config.http_config` if the signer has one,
+`&None` otherwise.


### PR DESCRIPTION
## Summary

Applies two rules to the five skills in `.claude/skills/`: keep them lightweight guides that help Claude *find* information rather than prescribe every step, and use progressive disclosure so long content lives in separate files.

SKILL.md bodies load in full on every trigger; `references/` load on demand. That budget went **893 → 365 lines**, with detail relocated rather than deleted (3 new reference files).

| Skill | SKILL.md | Moved to references |
|---|---|---|
| kora-operator | 250 → 99 | new `deployment.md` |
| kora-client | 186 → 82 | worked example already existed in `guides.md` |
| sync-keychain | 177 → 69 | new `scaffolding.md` (5 code templates) |
| release | 167 → 73 | new `changelog.md` (git-cliff branching) |
| complete-release | 113 → 42 | — |

What got cut is copy-paste bash for routine steps (`git status`, `checkout -b`, `npm version`, `gh pr create` boilerplate) and reference material duplicated from the `references/` files sitting next to it. What got kept, and in places sharpened, is the non-obvious constraints — the "highly important areas" where being prescriptive earns its cost.

## Two defects found while auditing

**1. `release` would publish the wrong crate.** It instructed `cargo set-version --workspace`. The workspace includes `crates/kora-deploy`, versioned independently at `0.2.0` and with no `publish = false`. A release at 2.2.x would bump it to 2.2.x and CI would push it to crates.io. Replaced with `cargo set-version -p kora-lib -p kora-cli` plus the two explicit root `Cargo.toml` edits (`[workspace.package]`, the `kora-lib` pin), and a verification step asserting `crates/kora-deploy/Cargo.toml` is unchanged.

**2. `kora-operator` understated the Lighthouse gap.** It said Lighthouse "only works with signTransaction/signBundle". It does not merely not-apply on broadcast methods — `LighthouseUtil::add_fee_payer_assertion` returns early on `will_send` (`lighthouse/assertion.rs:43`), so an operator who enables it for drain protection on a `signAndSend*` node gets none, silently. `config_validator.rs:557` warns but does not block startup. Now stated as the failure mode.

## Also fixed: stale config reference

`kora-operator/references/configuration.md` enumerated the fee payer policy fields and had drifted: 12 `spl_token` flags listed against 14 in `config.rs`, `token_2022` annotated "same 12 fields" against its actual 16, and the `alt` / `bpf_loader_upgradeable` / `loader_v4` sections missing entirely. Replaced the enumeration with the section list, the naming rule, and a pointer to `config.rs` + `kora config validate` — the list regrows every time an instruction is gated, so restating it guarantees the next drift.

## Test Plan
- Docs only; no Rust or TS touched.
- All 11 `references/*.md` links from SKILL.md files resolve (verified).
- Claims re-checked against source: `Cargo.toml` workspace members and per-crate versions, `assertion.rs` early return, `SplTokenInstructionPolicy`/`Token2022InstructionPolicy` field counts, `fallback_if_unavailable` semantics.

## Notes for the reviewer
- The `release` bump is the one part worth reading closely — it is the only behavioural change, and a wrong version bump is expensive. Worth a dry run on a throwaway branch before the next release.
- Stacked conceptually on #655 (CLAUDE.md), but independent: no file overlap, either can merge first.