### PR TITLE
feat(rpc): make `CORS` allow `origins` configurable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4021,6 +4021,7 @@ dependencies = [
  "tower-http 0.3.5",
  "tracing",
  "tracing-subscriber",
+ "url",
  "utoipa",
  "vaultrs",
  "wincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ license = "MIT"
 repository = "https://github.com/solana-foundation/kora"
 
 [workspace.dependencies]
+url = "2"
 kora-lib = { path = "crates/lib", version = "2.2.0-beta.8" }
 kora-deploy = { path = "crates/kora-deploy", version = "0.2.0" }
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/lib/Cargo.toml
+++ b/crates/lib/Cargo.toml
@@ -17,6 +17,7 @@ name = "update-config"
 path = "src/metrics/bin/update-config.rs"
 
 [dependencies]
+url = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 anyhow = { workspace = true }

--- a/crates/lib/src/config.rs
+++ b/crates/lib/src/config.rs
@@ -26,6 +26,67 @@ use crate::{
 
 pub use crate::usage_limit::{UsageLimitConfig, UsageLimitRuleConfig};
 
+/// Validates a CORS origin string
+pub fn is_valid_cors_origin(origin: &str) -> bool {
+    if origin == "*" {
+        return true;
+    }
+
+    let rest = if let Some(stripped) = origin.strip_prefix("https://") {
+        stripped
+    } else if let Some(stripped) = origin.strip_prefix("http://") {
+        stripped
+    } else {
+        return false;
+    };
+
+    if rest.is_empty() {
+        return false;
+    }
+
+    if rest.contains('/') || rest.contains('?') || rest.contains('#') || rest.contains('@') {
+        return false;
+    }
+
+    let (host_str, colon_idx) = if rest.starts_with('[') {
+        if let Some(close_bracket) = rest.find(']') {
+            let host = &rest[1..close_bracket];
+            let after_bracket = &rest[close_bracket + 1..];
+            let idx = if after_bracket.is_empty() {
+                None
+            } else if after_bracket.starts_with(':') {
+                Some(close_bracket + 1)
+            } else {
+                return false; // Malformed IPv6 (garbage after closing bracket)
+            };
+            (host, idx)
+        } else {
+            return false;
+        }
+    } else {
+        let idx = rest.rfind(':');
+        let host = if let Some(i) = idx { &rest[..i] } else { rest };
+        (host, idx)
+    };
+
+    if host_str.is_empty() {
+        return false;
+    }
+
+    if let Some(idx) = colon_idx {
+        let port_str = &rest[idx + 1..];
+        if port_str.is_empty() || port_str.parse::<u16>().is_err() {
+            return false;
+        }
+
+        if !rest.starts_with('[') && rest[..idx].contains(':') {
+            return false;
+        }
+    }
+
+    true
+}
+
 #[derive(Clone, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct Config {
@@ -714,6 +775,7 @@ pub struct PluginsConfig {
 #[serde(default, deny_unknown_fields)]
 pub struct KoraConfig {
     pub rate_limit: u64,
+    pub cors_allow_origins: Vec<String>,
     pub max_request_body_size: usize,
     pub enabled_methods: EnabledMethods,
     pub auth: AuthConfig,
@@ -740,6 +802,7 @@ impl Default for KoraConfig {
     fn default() -> Self {
         Self {
             rate_limit: 100,
+            cors_allow_origins: vec!["*".to_string()],
             max_request_body_size: DEFAULT_MAX_REQUEST_BODY_SIZE,
             enabled_methods: EnabledMethods::default(),
             auth: AuthConfig::default(),

--- a/crates/lib/src/config.rs
+++ b/crates/lib/src/config.rs
@@ -1,8 +1,10 @@
+use http::HeaderValue;
 use serde::{Deserialize, Serialize};
 use solana_sdk::pubkey::Pubkey;
 use spl_token_2022_interface::extension::ExtensionType;
 use std::{fs, path::Path, str::FromStr};
 use toml;
+use url::Url;
 use utoipa::ToSchema;
 
 use crate::{
@@ -26,65 +28,76 @@ use crate::{
 
 pub use crate::usage_limit::{UsageLimitConfig, UsageLimitRuleConfig};
 
-/// Validates a CORS origin string
+pub const CORS_WILDCARD: &str = "*";
+
+/// Validates a CORS origin `scheme://host[:port]` without path, query, fragment, or trailing slash.
 pub fn is_valid_cors_origin(origin: &str) -> bool {
-    if origin == "*" {
+    if origin == CORS_WILDCARD {
         return true;
     }
 
-    let rest = if let Some(stripped) = origin.strip_prefix("https://") {
-        stripped
-    } else if let Some(stripped) = origin.strip_prefix("http://") {
-        stripped
-    } else {
-        return false;
+    let url = match Url::parse(origin) {
+        Ok(u) => u,
+        Err(_) => return false,
     };
 
-    if rest.is_empty() {
+    if url.scheme() != "http" && url.scheme() != "https" {
         return false;
     }
 
-    if rest.contains('/') || rest.contains('?') || rest.contains('#') || rest.contains('@') {
+    if url.path() != "" && url.path() != "/" {
         return false;
     }
 
-    let (host_str, colon_idx) = if rest.starts_with('[') {
-        if let Some(close_bracket) = rest.find(']') {
-            let host = &rest[1..close_bracket];
-            let after_bracket = &rest[close_bracket + 1..];
-            let idx = if after_bracket.is_empty() {
-                None
-            } else if after_bracket.starts_with(':') {
-                Some(close_bracket + 1)
-            } else {
-                return false; // Malformed IPv6 (garbage after closing bracket)
-            };
-            (host, idx)
-        } else {
-            return false;
+    if url.query().is_some() || url.fragment().is_some() {
+        return false;
+    }
+
+    if !url.username().is_empty() || url.password().is_some() {
+        return false;
+    }
+
+    // A valid origin per Fetch spec exactly matches its ascii_serialization.
+    origin == url.origin().ascii_serialization()
+}
+
+pub enum CorsOriginsClassification {
+    Empty,
+    Wildcard { has_redundant: bool },
+    AllInvalid { invalid_origins: Vec<String> },
+    ValidWithSomeInvalid { valid_origins: Vec<HeaderValue>, invalid_origins: Vec<String> },
+    AllValid { valid_origins: Vec<HeaderValue> },
+}
+
+pub fn classify_cors_origins(origins: &[String]) -> CorsOriginsClassification {
+    if origins.is_empty() {
+        return CorsOriginsClassification::Empty;
+    }
+
+    if origins.iter().any(|o| o == CORS_WILDCARD) {
+        return CorsOriginsClassification::Wildcard { has_redundant: origins.len() > 1 };
+    }
+
+    let mut valid_origins = Vec::new();
+    let mut invalid_origins = Vec::new();
+
+    for o in origins {
+        if is_valid_cors_origin(o) {
+            if let Ok(hv) = o.parse::<HeaderValue>() {
+                valid_origins.push(hv);
+                continue;
+            }
         }
+        invalid_origins.push(o.clone());
+    }
+
+    if valid_origins.is_empty() {
+        CorsOriginsClassification::AllInvalid { invalid_origins }
+    } else if !invalid_origins.is_empty() {
+        CorsOriginsClassification::ValidWithSomeInvalid { valid_origins, invalid_origins }
     } else {
-        let idx = rest.rfind(':');
-        let host = if let Some(i) = idx { &rest[..i] } else { rest };
-        (host, idx)
-    };
-
-    if host_str.is_empty() {
-        return false;
+        CorsOriginsClassification::AllValid { valid_origins }
     }
-
-    if let Some(idx) = colon_idx {
-        let port_str = &rest[idx + 1..];
-        if port_str.is_empty() || port_str.parse::<u16>().is_err() {
-            return false;
-        }
-
-        if !rest.starts_with('[') && rest[..idx].contains(':') {
-            return false;
-        }
-    }
-
-    true
 }
 
 #[derive(Clone, Deserialize)]
@@ -802,7 +815,7 @@ impl Default for KoraConfig {
     fn default() -> Self {
         Self {
             rate_limit: 100,
-            cors_allow_origins: vec!["*".to_string()],
+            cors_allow_origins: vec![CORS_WILDCARD.to_string()],
             max_request_body_size: DEFAULT_MAX_REQUEST_BODY_SIZE,
             enabled_methods: EnabledMethods::default(),
             auth: AuthConfig::default(),
@@ -975,6 +988,52 @@ mod tests {
     };
 
     use super::*;
+
+    #[test]
+    fn test_is_valid_cors_origin_table() {
+        let cases = vec![
+            // Wildcard
+            ("*", true),
+            // Valid IPv4/Hostnames
+            ("https://example.com", true),
+            ("http://example.com", true),
+            ("https://example.com:8080", true),
+            ("https://localhost", true),
+            ("https://127.0.0.1", true),
+            // Valid IPv6
+            ("https://[::1]", true),
+            ("https://[::1]:8080", true),
+            ("https://[2001:db8::1]", true),
+            // Malformed/Empty hosts
+            ("https://", false),
+            ("https://:8080", false),
+            ("https://[]:8080", false),
+            ("https://example.com:", false),
+            // Invalid IPv6 brackets
+            ("https://[not-ipv6]", false),
+            ("https://[::1]garbage", false),
+            ("https://[::1]garbage:8080", false),
+            // Invalid ports
+            ("https://example.com:badport", false),
+            ("https://example.com:99999", false),
+            // Userinfo/Credentials
+            ("https://user@example.com", false),
+            ("https://user:pass@example.com", false),
+            // Paths, Queries, Fragments
+            ("https://example.com/", false),
+            ("https://example.com/path", false),
+            ("https://example.com?q=1", false),
+            ("https://example.com#frag", false),
+            // Other invalid schemes
+            ("ftp://example.com", false),
+            ("ws://example.com", false),
+            ("example.com", false),
+        ];
+
+        for (input, expected) in cases {
+            assert_eq!(is_valid_cors_origin(input), expected, "Failed on input: '{}'", input);
+        }
+    }
 
     #[test]
     fn test_load_valid_config() {

--- a/crates/lib/src/config.rs
+++ b/crates/lib/src/config.rs
@@ -63,8 +63,8 @@ pub fn is_valid_cors_origin(origin: &str) -> bool {
 
 pub enum CorsOriginsClassification {
     Empty,
+    AllInvalid,
     Wildcard { has_redundant: bool },
-    AllInvalid { invalid_origins: Vec<String> },
     ValidWithSomeInvalid { valid_origins: Vec<HeaderValue>, invalid_origins: Vec<String> },
     AllValid { valid_origins: Vec<HeaderValue> },
 }
@@ -92,7 +92,7 @@ pub fn classify_cors_origins(origins: &[String]) -> CorsOriginsClassification {
     }
 
     if valid_origins.is_empty() {
-        CorsOriginsClassification::AllInvalid { invalid_origins }
+        CorsOriginsClassification::AllInvalid
     } else if !invalid_origins.is_empty() {
         CorsOriginsClassification::ValidWithSomeInvalid { valid_origins, invalid_origins }
     } else {

--- a/crates/lib/src/config.rs
+++ b/crates/lib/src/config.rs
@@ -992,8 +992,7 @@ mod tests {
     #[test]
     fn test_is_valid_cors_origin_table() {
         let cases = vec![
-            // Wildcard
-            ("*", true),
+            (CORS_WILDCARD, true),
             // Valid IPv4/Hostnames
             ("https://example.com", true),
             ("http://example.com", true),

--- a/crates/lib/src/rpc_server/server.rs
+++ b/crates/lib/src/rpc_server/server.rs
@@ -122,8 +122,7 @@ fn build_allow_origin(origins: &[String]) -> AllowOrigin {
             AllowOrigin::any()
         }
         CorsOriginsClassification::AllInvalid { .. } => {
-            log::warn!("None of the provided origin(s) are valid. Must be a valid web origin (e.g., 'https://your-app.com').");
-            log::warn!("cors_allow_origins contains no valid origin(s). All cross-origin requests will be blocked.");
+            log::warn!("cors_allow_origins contains no valid origin(s) (must be e.g., 'https://your-app.com'). All cross-origin requests will be blocked.");
             AllowOrigin::list(empty::<HeaderValue>())
         }
         CorsOriginsClassification::ValidWithSomeInvalid { valid_origins, invalid_origins } => {
@@ -335,7 +334,7 @@ fn build_rpc_module(rpc: KoraRpc) -> Result<RpcModule<KoraRpc>, anyhow::Error> {
 mod tests {
     use super::*;
     use crate::{
-        config::EnabledMethods,
+        config::{EnabledMethods, CORS_WILDCARD},
         tests::{
             common::setup_or_get_test_signer,
             config_mock::{ConfigMockBuilder, KoraConfigBuilder},
@@ -575,12 +574,12 @@ mod tests {
 
     #[test]
     fn test_cors_wildcard_handling() {
-        let wildcard_only = vec!["*".to_string()];
+        let wildcard_only = vec![CORS_WILDCARD.to_string()];
         let allow_origin = build_allow_origin(&wildcard_only);
         let debug_str = format!("{:?}", allow_origin);
         assert!(debug_str.contains(r#"Const("*")"#));
 
-        let mixed = vec!["*".to_string(), "https://example.com".to_string()];
+        let mixed = vec![CORS_WILDCARD.to_string(), "https://example.com".to_string()];
         let allow_origin_mixed = build_allow_origin(&mixed);
         let mixed_debug_str = format!("{:?}", allow_origin_mixed);
         assert!(mixed_debug_str.contains(r#"Const("*")"#));

--- a/crates/lib/src/rpc_server/server.rs
+++ b/crates/lib/src/rpc_server/server.rs
@@ -1,5 +1,5 @@
 use crate::{
-    config::{is_valid_cors_origin, AuthConfig},
+    config::{classify_cors_origins, AuthConfig, CorsOriginsClassification},
     constant::{X_API_KEY, X_HMAC_SIGNATURE, X_RECAPTCHA_TOKEN, X_TIMESTAMP},
     metrics::run_metrics_server_if_required,
     rpc_server::{
@@ -110,35 +110,29 @@ fn get_value_by_priority(env_var: &str, config_value: Option<String>) -> Option<
 }
 
 fn build_allow_origin(origins: &[String]) -> AllowOrigin {
-    if origins.is_empty() {
-        log::warn!("cors_allow_origins is empty. All cross-origin requests will be blocked.");
-        AllowOrigin::list(empty::<HeaderValue>())
-    } else if origins.iter().any(|o| o == "*") {
-        if origins.len() > 1 {
-            log::warn!("CORS allow origins contains '*' alongside specific origins. The specific origins are redundant and will be silently ignored.");
+    match classify_cors_origins(origins) {
+        CorsOriginsClassification::Empty => {
+            log::warn!("cors_allow_origins is empty. All cross-origin requests will be blocked.");
+            AllowOrigin::list(empty::<HeaderValue>())
         }
-        AllowOrigin::any()
-    } else {
-        let parsed_origins: Vec<_> = origins
-            .iter()
-            .filter_map(|o| {
-                if !is_valid_cors_origin(o) {
-                    log::warn!("Invalid CORS origin '{}': Must be a valid web origin (e.g., 'https://your-app.com').", o);
-                    return None;
-                }
-                o.parse::<HeaderValue>()
-                    .map_err(|e| log::warn!("Invalid CORS origin '{}': {}", o, e))
-                    .ok()
-            })
-            .collect();
-
-        if parsed_origins.is_empty() {
-            log::warn!(
-                "cors_allow_origins contains no valid origins. All cross-origin requests will be blocked."
-            );
+        CorsOriginsClassification::Wildcard { has_redundant } => {
+            if has_redundant {
+                log::warn!("cors_allow_origins contains '*' alongside specific origin(s). The specific origin(s) are redundant and will be silently ignored.");
+            }
+            AllowOrigin::any()
         }
-
-        AllowOrigin::list(parsed_origins)
+        CorsOriginsClassification::AllInvalid { .. } => {
+            log::warn!("None of the provided origin(s) are valid. Must be a valid web origin (e.g., 'https://your-app.com').");
+            log::warn!("cors_allow_origins contains no valid origin(s). All cross-origin requests will be blocked.");
+            AllowOrigin::list(empty::<HeaderValue>())
+        }
+        CorsOriginsClassification::ValidWithSomeInvalid { valid_origins, invalid_origins } => {
+            for o in invalid_origins {
+                log::warn!("Invalid CORS origin '{}': Must be a valid web origin (e.g., 'https://your-app.com').", o);
+            }
+            AllowOrigin::list(valid_origins)
+        }
+        CorsOriginsClassification::AllValid { valid_origins } => AllowOrigin::list(valid_origins),
     }
 }
 
@@ -523,6 +517,7 @@ mod tests {
             "https://your-app.com/".to_string(),
             "https://your-app.com/path".to_string(),
             "https://your-app.com?q=1".to_string(),
+            "https://example.com#frag".to_string(),
             "https://example.com:badport".to_string(),
             "https://user:pass@example.com".to_string(),
             "https://example.com:99999".to_string(),
@@ -534,29 +529,37 @@ mod tests {
         assert!(!debug_str.contains("https://your-app.com/"));
         assert!(!debug_str.contains("https://your-app.com/path"));
         assert!(!debug_str.contains("https://your-app.com?q=1"));
+        assert!(!debug_str.contains("https://example.com#frag"));
         assert!(!debug_str.contains("https://example.com:badport"));
         assert!(!debug_str.contains("https://user:pass@example.com"));
         assert!(!debug_str.contains("https://example.com:99999"));
         assert!(debug_str.contains("[]") || debug_str.contains("List([])"));
 
         // Valid ones should be accepted
-        let valid_origins =
-            vec!["https://your-app.com".to_string(), "https://your-app.com:8080".to_string()];
+        let valid_origins = vec![
+            "https://your-app.com".to_string(),
+            "https://your-app.com:8080".to_string(),
+            "https://[::1]:8080".to_string(),
+            "https://[::1]".to_string(),
+        ];
         let allow_origin_valid = build_allow_origin(&valid_origins);
         let valid_debug_str = format!("{:?}", allow_origin_valid);
         assert!(valid_debug_str.contains("https://your-app.com"));
         assert!(valid_debug_str.contains("https://your-app.com:8080"));
+        assert!(valid_debug_str.contains("https://[::1]:8080"));
+        assert!(valid_debug_str.contains("https://[::1]"));
     }
 
     #[test]
     fn test_empty_host_rejected() {
-        // These should be rejected because the host part is empty
+        // These should be rejected because the host part is empty or malformed
         let origins = vec![
             "https://:8080".to_string(),
             "https://[]:8080".to_string(),
             "https://example.com:".to_string(),
             "https://[::1]garbage".to_string(),
             "https://[::1]garbage:8080".to_string(),
+            "https://[not-ipv6]".to_string(),
         ];
         let allow_origin = build_allow_origin(&origins);
 
@@ -566,6 +569,20 @@ mod tests {
         assert!(!debug_str.contains("https://example.com:"));
         assert!(!debug_str.contains("https://[::1]garbage"));
         assert!(!debug_str.contains("https://[::1]garbage:8080"));
+        assert!(!debug_str.contains("https://[not-ipv6]"));
         assert!(debug_str.contains("[]") || debug_str.contains("List([])"));
+    }
+
+    #[test]
+    fn test_cors_wildcard_handling() {
+        let wildcard_only = vec!["*".to_string()];
+        let allow_origin = build_allow_origin(&wildcard_only);
+        let debug_str = format!("{:?}", allow_origin);
+        assert!(debug_str.contains(r#"Const("*")"#));
+
+        let mixed = vec!["*".to_string(), "https://example.com".to_string()];
+        let allow_origin_mixed = build_allow_origin(&mixed);
+        let mixed_debug_str = format!("{:?}", allow_origin_mixed);
+        assert!(mixed_debug_str.contains(r#"Const("*")"#));
     }
 }

--- a/crates/lib/src/rpc_server/server.rs
+++ b/crates/lib/src/rpc_server/server.rs
@@ -1,5 +1,5 @@
 use crate::{
-    config::AuthConfig,
+    config::{is_valid_cors_origin, AuthConfig},
     constant::{X_API_KEY, X_HMAC_SIGNATURE, X_RECAPTCHA_TOKEN, X_TIMESTAMP},
     metrics::run_metrics_server_if_required,
     rpc_server::{
@@ -19,15 +19,15 @@ use crate::state::get_config;
 
 #[cfg(test)]
 use crate::tests::config_mock::mock_state::get_config;
-use http::{header, Method};
+use http::{header, HeaderValue, Method};
 use jsonrpsee::{
     server::{middleware::proxy_get_request::ProxyGetRequestLayer, ServerBuilder, ServerHandle},
     RpcModule,
 };
-use std::{net::SocketAddr, time::Duration};
+use std::{iter::empty, net::SocketAddr, time::Duration};
 use tokio::task::JoinHandle;
 use tower::limit::RateLimitLayer;
-use tower_http::cors::CorsLayer;
+use tower_http::cors::{AllowOrigin, CorsLayer};
 
 pub struct ServerHandles {
     pub rpc_handle: ServerHandle,
@@ -109,6 +109,39 @@ fn get_value_by_priority(env_var: &str, config_value: Option<String>) -> Option<
     AuthConfig::resolve_secret(env_var, config_value.as_deref())
 }
 
+fn build_allow_origin(origins: &[String]) -> AllowOrigin {
+    if origins.is_empty() {
+        log::warn!("cors_allow_origins is empty. All cross-origin requests will be blocked.");
+        AllowOrigin::list(empty::<HeaderValue>())
+    } else if origins.iter().any(|o| o == "*") {
+        if origins.len() > 1 {
+            log::warn!("CORS allow origins contains '*' alongside specific origins. The specific origins are redundant and will be silently ignored.");
+        }
+        AllowOrigin::any()
+    } else {
+        let parsed_origins: Vec<_> = origins
+            .iter()
+            .filter_map(|o| {
+                if !is_valid_cors_origin(o) {
+                    log::warn!("Invalid CORS origin '{}': Must be a valid web origin (e.g., 'https://your-app.com').", o);
+                    return None;
+                }
+                o.parse::<HeaderValue>()
+                    .map_err(|e| log::warn!("Invalid CORS origin '{}': {}", o, e))
+                    .ok()
+            })
+            .collect();
+
+        if parsed_origins.is_empty() {
+            log::warn!(
+                "cors_allow_origins contains no valid origins. All cross-origin requests will be blocked."
+            );
+        }
+
+        AllowOrigin::list(parsed_origins)
+    }
+}
+
 pub async fn run_rpc_server(rpc: KoraRpc, port: u16) -> Result<ServerHandles, anyhow::Error> {
     let addr = SocketAddr::from(([0, 0, 0, 0], port));
     log::info!("RPC server started on {addr}, port {port}");
@@ -118,8 +151,13 @@ pub async fn run_rpc_server(rpc: KoraRpc, port: u16) -> Result<ServerHandles, an
         return Err(anyhow::anyhow!("Usage limiter initialization failed: {e}"));
     }
 
+    let config = get_config()?;
+
+    let allow_origins = build_allow_origin(&config.kora.cors_allow_origins);
+
+    // Build middleware stack with tracing and CORS
     let cors = CorsLayer::new()
-        .allow_origin(tower_http::cors::Any)
+        .allow_origin(allow_origins)
         .allow_methods([Method::POST, Method::GET])
         .allow_headers([
             header::CONTENT_TYPE,
@@ -129,8 +167,6 @@ pub async fn run_rpc_server(rpc: KoraRpc, port: u16) -> Result<ServerHandles, an
             header::HeaderName::from_static(X_TIMESTAMP),
         ])
         .max_age(Duration::from_secs(3600));
-
-    let config = get_config()?;
 
     let rpc_client = rpc.get_rpc_client().clone();
 
@@ -312,7 +348,30 @@ mod tests {
             rpc_mock::RpcMockBuilder,
         },
     };
-    use std::env;
+    use serial_test::serial;
+    use std::{env, net::TcpListener};
+
+    #[tokio::test]
+    #[serial]
+    async fn test_empty_cors_origins_does_not_panic() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let port = listener.local_addr().unwrap().port();
+        drop(listener);
+
+        let kora_config = KoraConfigBuilder::new().with_cors_allow_origins(vec![]).build();
+        let _m = ConfigMockBuilder::new().with_kora(kora_config).build_and_setup();
+        let _ = setup_or_get_test_signer();
+
+        let rpc_client = RpcMockBuilder::new().build();
+
+        // This should not panic and should start successfully
+        let result = run_rpc_server(KoraRpc::new(rpc_client), port).await;
+        match result {
+            Ok(_) => (),
+            Err(e) if e.to_string().contains("already initialized") => (),
+            Err(e) => panic!("Server failed to start: {:?}", e),
+        }
+    }
 
     #[test]
     fn test_get_value_by_priority_env_var_takes_precedence() {
@@ -456,5 +515,57 @@ mod tests {
         assert!(method_names.contains(&"liveness"));
         assert!(method_names.contains(&"getConfig"));
         assert!(method_names.contains(&"getSupportedTokens"));
+    }
+
+    #[test]
+    fn test_malformed_origins_rejected() {
+        let origins = vec![
+            "https://your-app.com/".to_string(),
+            "https://your-app.com/path".to_string(),
+            "https://your-app.com?q=1".to_string(),
+            "https://example.com:badport".to_string(),
+            "https://user:pass@example.com".to_string(),
+            "https://example.com:99999".to_string(),
+        ];
+        let allow_origin = build_allow_origin(&origins);
+
+        let debug_str = format!("{:?}", allow_origin);
+        // None of these origins should be in the AllowOrigin list
+        assert!(!debug_str.contains("https://your-app.com/"));
+        assert!(!debug_str.contains("https://your-app.com/path"));
+        assert!(!debug_str.contains("https://your-app.com?q=1"));
+        assert!(!debug_str.contains("https://example.com:badport"));
+        assert!(!debug_str.contains("https://user:pass@example.com"));
+        assert!(!debug_str.contains("https://example.com:99999"));
+        assert!(debug_str.contains("[]") || debug_str.contains("List([])"));
+
+        // Valid ones should be accepted
+        let valid_origins =
+            vec!["https://your-app.com".to_string(), "https://your-app.com:8080".to_string()];
+        let allow_origin_valid = build_allow_origin(&valid_origins);
+        let valid_debug_str = format!("{:?}", allow_origin_valid);
+        assert!(valid_debug_str.contains("https://your-app.com"));
+        assert!(valid_debug_str.contains("https://your-app.com:8080"));
+    }
+
+    #[test]
+    fn test_empty_host_rejected() {
+        // These should be rejected because the host part is empty
+        let origins = vec![
+            "https://:8080".to_string(),
+            "https://[]:8080".to_string(),
+            "https://example.com:".to_string(),
+            "https://[::1]garbage".to_string(),
+            "https://[::1]garbage:8080".to_string(),
+        ];
+        let allow_origin = build_allow_origin(&origins);
+
+        let debug_str = format!("{:?}", allow_origin);
+        assert!(!debug_str.contains("https://:8080"));
+        assert!(!debug_str.contains("https://[]:8080"));
+        assert!(!debug_str.contains("https://example.com:"));
+        assert!(!debug_str.contains("https://[::1]garbage"));
+        assert!(!debug_str.contains("https://[::1]garbage:8080"));
+        assert!(debug_str.contains("[]") || debug_str.contains("List([])"));
     }
 }

--- a/crates/lib/src/rpc_server/server.rs
+++ b/crates/lib/src/rpc_server/server.rs
@@ -121,7 +121,7 @@ fn build_allow_origin(origins: &[String]) -> AllowOrigin {
             }
             AllowOrigin::any()
         }
-        CorsOriginsClassification::AllInvalid { .. } => {
+        CorsOriginsClassification::AllInvalid => {
             log::warn!("cors_allow_origins contains no valid origin(s) (must be e.g., 'https://your-app.com'). All cross-origin requests will be blocked.");
             AllowOrigin::list(empty::<HeaderValue>())
         }

--- a/crates/lib/src/tests/config_mock.rs
+++ b/crates/lib/src/tests/config_mock.rs
@@ -5,7 +5,7 @@ use crate::{
         FeePayerBalanceMetricsConfig, FeePayerPolicy, KoraConfig, LighthouseConfig, MetricsConfig,
         NonceInstructionPolicy, PluginsConfig, ProgramsConfig, SplTokenConfig,
         SplTokenInstructionPolicy, SystemInstructionPolicy, Token2022Config,
-        Token2022InstructionPolicy, ValidationConfig,
+        Token2022InstructionPolicy, ValidationConfig, CORS_WILDCARD,
     },
     constant::DEFAULT_MAX_REQUEST_BODY_SIZE,
     fee::price::{PriceConfig, PriceModel},
@@ -101,7 +101,7 @@ impl ConfigMockBuilder {
                 },
                 kora: KoraConfig {
                     rate_limit: 100,
-                    cors_allow_origins: vec!["*".to_string()],
+                    cors_allow_origins: vec![CORS_WILDCARD.to_string()],
                     max_request_body_size: DEFAULT_MAX_REQUEST_BODY_SIZE,
                     enabled_methods: EnabledMethods::default(),
                     auth: AuthConfig::default(),
@@ -394,7 +394,7 @@ impl KoraConfigBuilder {
         Self {
             config: KoraConfig {
                 rate_limit: 100,
-                cors_allow_origins: vec!["*".to_string()],
+                cors_allow_origins: vec![CORS_WILDCARD.to_string()],
                 max_request_body_size: DEFAULT_MAX_REQUEST_BODY_SIZE,
                 enabled_methods: EnabledMethods::default(),
                 auth: AuthConfig::default(),

--- a/crates/lib/src/tests/config_mock.rs
+++ b/crates/lib/src/tests/config_mock.rs
@@ -101,6 +101,7 @@ impl ConfigMockBuilder {
                 },
                 kora: KoraConfig {
                     rate_limit: 100,
+                    cors_allow_origins: vec!["*".to_string()],
                     max_request_body_size: DEFAULT_MAX_REQUEST_BODY_SIZE,
                     enabled_methods: EnabledMethods::default(),
                     auth: AuthConfig::default(),
@@ -393,6 +394,7 @@ impl KoraConfigBuilder {
         Self {
             config: KoraConfig {
                 rate_limit: 100,
+                cors_allow_origins: vec!["*".to_string()],
                 max_request_body_size: DEFAULT_MAX_REQUEST_BODY_SIZE,
                 enabled_methods: EnabledMethods::default(),
                 auth: AuthConfig::default(),
@@ -417,6 +419,11 @@ impl KoraConfigBuilder {
 
     pub fn build(self) -> KoraConfig {
         self.config
+    }
+
+    pub fn with_cors_allow_origins(mut self, origins: Vec<String>) -> Self {
+        self.config.cors_allow_origins = origins;
+        self
     }
 
     pub fn with_rate_limit(mut self, rate_limit: u64) -> Self {

--- a/crates/lib/src/validator/config_validator.rs
+++ b/crates/lib/src/validator/config_validator.rs
@@ -3,7 +3,8 @@ use std::{collections::HashSet, path::Path, str::FromStr};
 use crate::{
     admin::token_util::find_missing_atas,
     config::{
-        FeePayerPolicy, SplTokenConfig, Token2022Config, TransferHookPolicy, ValidationConfig,
+        is_valid_cors_origin, FeePayerPolicy, SplTokenConfig, Token2022Config, TransferHookPolicy,
+        ValidationConfig,
     },
     constant::{
         BPF_LOADER_UPGRADEABLE_PROGRAM_ID, LIGHTHOUSE_PROGRAM_ID, LOADER_V4_PROGRAM_ID,
@@ -425,6 +426,32 @@ impl ConfigValidator {
             warnings.push("Rate limit is set to 0 - this will block all requests".to_string());
         }
 
+        // Validate CORS origins
+        if config.kora.cors_allow_origins.is_empty() {
+            warnings.push(
+                "cors_allow_origins is empty - all cross-origin requests will be blocked"
+                    .to_string(),
+            );
+        } else if config.kora.cors_allow_origins.iter().any(|o| o == "*") {
+            if config.kora.cors_allow_origins.len() > 1 {
+                warnings.push("cors_allow_origins contains '*' alongside specific origins. The specific origins are redundant and will be silently ignored.".to_string());
+            }
+        } else {
+            let invalid_count = config
+                .kora
+                .cors_allow_origins
+                .iter()
+                .filter(|o| !is_valid_cors_origin(o) || o.parse::<http::HeaderValue>().is_err())
+                .count();
+
+            if invalid_count == config.kora.cors_allow_origins.len() {
+                warnings.push("cors_allow_origins contains no valid origins - all cross-origin requests will be blocked".to_string());
+            } else if invalid_count > 0 {
+                warnings.push(format!("cors_allow_origins contains {} invalid origin(s) that will be silently filtered out at runtime", invalid_count));
+            }
+        }
+
+        // Validate payment address
         if let Some(payment_address) = &config.kora.payment_address {
             if let Err(e) = Pubkey::from_str(payment_address) {
                 errors.push(format!("Invalid payment address: {e}"));
@@ -1370,6 +1397,7 @@ mod tests {
             },
             kora: KoraConfig {
                 rate_limit: 0,
+                cors_allow_origins: vec![],
                 max_request_body_size: DEFAULT_MAX_REQUEST_BODY_SIZE,
                 enabled_methods: EnabledMethods {
                     liveness: false,
@@ -1400,7 +1428,8 @@ mod tests {
             metrics: MetricsConfig::default(),
         };
 
-        let _ = update_config(config);
+        // Initialize global config
+        let _ = update_config(config.clone());
 
         let rpc_client = RpcClient::new_with_commitment(
             "http://localhost:8899".to_string(),
@@ -1412,11 +1441,54 @@ mod tests {
 
         assert!(!warnings.is_empty());
         assert!(warnings.iter().any(|w| w.contains("Rate limit is set to 0")));
+        assert!(warnings.iter().any(|w| w
+            .contains("cors_allow_origins is empty - all cross-origin requests will be blocked")));
         assert!(warnings.iter().any(|w| w.contains("All rpc methods are disabled")));
         assert!(warnings.iter().any(|w| w.contains("Max allowed lamports is 0")));
         assert!(warnings.iter().any(|w| w.contains("Max signatures is 0")));
         assert!(warnings.iter().any(|w| w.contains("Using Mock price source")));
         assert!(warnings.iter().any(|w| w.contains("No allowed programs configured")));
+
+        // Test partially invalid CORS origins
+        let mut config_cors = config.clone();
+        config_cors.kora.cors_allow_origins =
+            vec!["https://valid.com".to_string(), "invalid\norigin".to_string()];
+        let _ = update_config(config_cors);
+
+        let result_cors = ConfigValidator::validate_with_result(&rpc_client, true).await;
+        let warnings_cors = result_cors.unwrap();
+        assert!(warnings_cors.iter().any(|w| w.contains(
+            "cors_allow_origins contains 1 invalid origin(s) that will be silently filtered out"
+        )));
+
+        // Test wildcard with redundant specific origins
+        let mut config_cors_wildcard = config.clone();
+        config_cors_wildcard.kora.cors_allow_origins =
+            vec!["*".to_string(), "https://redundant.com".to_string()];
+        let _ = update_config(config_cors_wildcard);
+
+        let result_cors_wildcard = ConfigValidator::validate_with_result(&rpc_client, true).await;
+        let warnings_cors_wildcard = result_cors_wildcard.unwrap();
+        assert!(warnings_cors_wildcard
+            .iter()
+            .any(|w| w.contains("cors_allow_origins contains '*' alongside specific origins")));
+
+        // Test all invalid CORS origins
+        let mut config_cors_all_invalid = config.clone();
+        config_cors_all_invalid.kora.cors_allow_origins = vec![
+            "invalid\n1".to_string(),
+            "https://your-app.com/".to_string(),
+            "https://example.com:badport".to_string(),
+            "https://user:pass@example.com".to_string(),
+        ];
+        let _ = update_config(config_cors_all_invalid);
+
+        let result_cors_all_invalid =
+            ConfigValidator::validate_with_result(&rpc_client, true).await;
+        let warnings_cors_all_invalid = result_cors_all_invalid.unwrap();
+        assert!(warnings_cors_all_invalid
+            .iter()
+            .any(|w| w.contains("cors_allow_origins contains no valid origins - all cross-origin requests will be blocked")));
     }
 
     #[tokio::test]

--- a/crates/lib/src/validator/config_validator.rs
+++ b/crates/lib/src/validator/config_validator.rs
@@ -440,8 +440,7 @@ impl ConfigValidator {
                 }
             }
             CorsOriginsClassification::AllInvalid { .. } => {
-                warnings.push("None of the provided origin(s) are valid. Must be a valid web origin (e.g., 'https://your-app.com').".to_string());
-                warnings.push("cors_allow_origins contains no valid origin(s) - all cross-origin requests will be blocked".to_string());
+                warnings.push("cors_allow_origins contains no valid origin(s) (must be e.g., 'https://your-app.com') - all cross-origin requests will be blocked".to_string());
             }
             CorsOriginsClassification::ValidWithSomeInvalid { invalid_origins, .. } => {
                 warnings.push(format!("cors_allow_origins contains {} invalid origin(s) that will be silently filtered out at runtime", invalid_origins.len()));
@@ -973,7 +972,7 @@ mod tests {
             KoraConfig, LighthouseConfig, MetricsConfig, NonceInstructionPolicy, PluginsConfig,
             ProgramsConfig, SplTokenConfig, SplTokenInstructionPolicy, SystemInstructionPolicy,
             Token2022InstructionPolicy, TransactionPluginType, TransferHookPolicy,
-            UsageLimitConfig, ValidationConfig,
+            UsageLimitConfig, ValidationConfig, CORS_WILDCARD,
         },
         constant::{DEFAULT_MAX_REQUEST_BODY_SIZE, LIGHTHOUSE_PROGRAM_ID},
         fee::price::PriceConfig,
@@ -1460,7 +1459,7 @@ mod tests {
         // Test wildcard with redundant specific origin(s)
         let mut config_cors_wildcard = config.clone();
         config_cors_wildcard.kora.cors_allow_origins =
-            vec!["*".to_string(), "https://redundant.com".to_string()];
+            vec![CORS_WILDCARD.to_string(), "https://redundant.com".to_string()];
         let _ = update_config(config_cors_wildcard);
 
         let result_cors_wildcard = ConfigValidator::validate_with_result(&rpc_client, true).await;
@@ -1485,11 +1484,7 @@ mod tests {
         let warnings_cors_all_invalid = result_cors_all_invalid.unwrap();
         assert!(warnings_cors_all_invalid
             .iter()
-            .any(|w| w
-                .contains("None of the provided origin(s) are valid. Must be a valid web origin")));
-        assert!(warnings_cors_all_invalid
-            .iter()
-            .any(|w| w.contains("cors_allow_origins contains no valid origin(s) - all cross-origin requests will be blocked")));
+            .any(|w| w.contains("cors_allow_origins contains no valid origin(s) (must be e.g., 'https://your-app.com') - all cross-origin requests will be blocked")));
     }
 
     #[tokio::test]

--- a/crates/lib/src/validator/config_validator.rs
+++ b/crates/lib/src/validator/config_validator.rs
@@ -439,7 +439,7 @@ impl ConfigValidator {
                     warnings.push("cors_allow_origins contains '*' alongside specific origin(s). The specific origin(s) are redundant and will be silently ignored.".to_string());
                 }
             }
-            CorsOriginsClassification::AllInvalid { .. } => {
+            CorsOriginsClassification::AllInvalid => {
                 warnings.push("cors_allow_origins contains no valid origin(s) (must be e.g., 'https://your-app.com') - all cross-origin requests will be blocked".to_string());
             }
             CorsOriginsClassification::ValidWithSomeInvalid { invalid_origins, .. } => {

--- a/crates/lib/src/validator/config_validator.rs
+++ b/crates/lib/src/validator/config_validator.rs
@@ -3,8 +3,8 @@ use std::{collections::HashSet, path::Path, str::FromStr};
 use crate::{
     admin::token_util::find_missing_atas,
     config::{
-        is_valid_cors_origin, FeePayerPolicy, SplTokenConfig, Token2022Config, TransferHookPolicy,
-        ValidationConfig,
+        classify_cors_origins, CorsOriginsClassification, FeePayerPolicy, SplTokenConfig,
+        Token2022Config, TransferHookPolicy, ValidationConfig,
     },
     constant::{
         BPF_LOADER_UPGRADEABLE_PROGRAM_ID, LIGHTHOUSE_PROGRAM_ID, LOADER_V4_PROGRAM_ID,
@@ -427,31 +427,28 @@ impl ConfigValidator {
         }
 
         // Validate CORS origins
-        if config.kora.cors_allow_origins.is_empty() {
-            warnings.push(
-                "cors_allow_origins is empty - all cross-origin requests will be blocked"
-                    .to_string(),
-            );
-        } else if config.kora.cors_allow_origins.iter().any(|o| o == "*") {
-            if config.kora.cors_allow_origins.len() > 1 {
-                warnings.push("cors_allow_origins contains '*' alongside specific origins. The specific origins are redundant and will be silently ignored.".to_string());
+        match classify_cors_origins(&config.kora.cors_allow_origins) {
+            CorsOriginsClassification::Empty => {
+                warnings.push(
+                    "cors_allow_origins is empty - all cross-origin requests will be blocked"
+                        .to_string(),
+                );
             }
-        } else {
-            let invalid_count = config
-                .kora
-                .cors_allow_origins
-                .iter()
-                .filter(|o| !is_valid_cors_origin(o) || o.parse::<http::HeaderValue>().is_err())
-                .count();
-
-            if invalid_count == config.kora.cors_allow_origins.len() {
-                warnings.push("cors_allow_origins contains no valid origins - all cross-origin requests will be blocked".to_string());
-            } else if invalid_count > 0 {
-                warnings.push(format!("cors_allow_origins contains {} invalid origin(s) that will be silently filtered out at runtime", invalid_count));
+            CorsOriginsClassification::Wildcard { has_redundant } => {
+                if has_redundant {
+                    warnings.push("cors_allow_origins contains '*' alongside specific origin(s). The specific origin(s) are redundant and will be silently ignored.".to_string());
+                }
             }
+            CorsOriginsClassification::AllInvalid { .. } => {
+                warnings.push("None of the provided origin(s) are valid. Must be a valid web origin (e.g., 'https://your-app.com').".to_string());
+                warnings.push("cors_allow_origins contains no valid origin(s) - all cross-origin requests will be blocked".to_string());
+            }
+            CorsOriginsClassification::ValidWithSomeInvalid { invalid_origins, .. } => {
+                warnings.push(format!("cors_allow_origins contains {} invalid origin(s) that will be silently filtered out at runtime", invalid_origins.len()));
+            }
+            CorsOriginsClassification::AllValid { .. } => {}
         }
 
-        // Validate payment address
         if let Some(payment_address) = &config.kora.payment_address {
             if let Err(e) = Pubkey::from_str(payment_address) {
                 errors.push(format!("Invalid payment address: {e}"));
@@ -1428,7 +1425,6 @@ mod tests {
             metrics: MetricsConfig::default(),
         };
 
-        // Initialize global config
         let _ = update_config(config.clone());
 
         let rpc_client = RpcClient::new_with_commitment(
@@ -1461,7 +1457,7 @@ mod tests {
             "cors_allow_origins contains 1 invalid origin(s) that will be silently filtered out"
         )));
 
-        // Test wildcard with redundant specific origins
+        // Test wildcard with redundant specific origin(s)
         let mut config_cors_wildcard = config.clone();
         config_cors_wildcard.kora.cors_allow_origins =
             vec!["*".to_string(), "https://redundant.com".to_string()];
@@ -1471,7 +1467,7 @@ mod tests {
         let warnings_cors_wildcard = result_cors_wildcard.unwrap();
         assert!(warnings_cors_wildcard
             .iter()
-            .any(|w| w.contains("cors_allow_origins contains '*' alongside specific origins")));
+            .any(|w| w.contains("cors_allow_origins contains '*' alongside specific origin(s)")));
 
         // Test all invalid CORS origins
         let mut config_cors_all_invalid = config.clone();
@@ -1480,6 +1476,7 @@ mod tests {
             "https://your-app.com/".to_string(),
             "https://example.com:badport".to_string(),
             "https://user:pass@example.com".to_string(),
+            "https://[not-ipv6]".to_string(),
         ];
         let _ = update_config(config_cors_all_invalid);
 
@@ -1488,7 +1485,11 @@ mod tests {
         let warnings_cors_all_invalid = result_cors_all_invalid.unwrap();
         assert!(warnings_cors_all_invalid
             .iter()
-            .any(|w| w.contains("cors_allow_origins contains no valid origins - all cross-origin requests will be blocked")));
+            .any(|w| w
+                .contains("None of the provided origin(s) are valid. Must be a valid web origin")));
+        assert!(warnings_cors_all_invalid
+            .iter()
+            .any(|w| w.contains("cors_allow_origins contains no valid origin(s) - all cross-origin requests will be blocked")));
     }
 
     #[tokio::test]

--- a/examples/deploy/kora.toml
+++ b/examples/deploy/kora.toml
@@ -1,5 +1,10 @@
 [kora]
 rate_limit = 100
+
+# Allowed CORS origins. Defaults to ["*"] (allow all).
+# Set to specific origins for production deployments.
+# cors_allow_origins = ["https://your-app.com", "https://admin.your-app.com"]
+cors_allow_origins = ["*"]
 # Optional: Payment address to receive payment tokens (defaults to signer address)
 # payment_address = "YourPaymentAddressPubkey11111111111111111111"
 

--- a/examples/devnet-deploy-paymaster/kora.toml
+++ b/examples/devnet-deploy-paymaster/kora.toml
@@ -2,6 +2,11 @@
 [kora]
 rate_limit = 100
 
+# Allowed CORS origins. Defaults to ["*"] (allow all).
+# Set to specific origins for production deployments.
+# cors_allow_origins = ["https://your-app.com", "https://admin.your-app.com"]
+cors_allow_origins = ["*"]
+
 [kora.auth]
 
 [kora.cache]

--- a/examples/getting-started/demo/server/kora.toml
+++ b/examples/getting-started/demo/server/kora.toml
@@ -1,5 +1,10 @@
 [kora]
 rate_limit = 100
+
+# Allowed CORS origins. Defaults to ["*"] (allow all).
+# Set to specific origins for production deployments.
+# cors_allow_origins = ["https://your-app.com", "https://admin.your-app.com"]
+cors_allow_origins = ["*"]
 # Optional: Payment address to receive payment tokens (defaults to signer address)
 # payment_address = "YourPaymentAddressPubkey11111111111111111111"
 

--- a/examples/jito-bundles/server/kora.toml
+++ b/examples/jito-bundles/server/kora.toml
@@ -1,5 +1,10 @@
 [kora]
 rate_limit = 100
+
+# Allowed CORS origins. Defaults to ["*"] (allow all).
+# Set to specific origins for production deployments.
+# cors_allow_origins = ["https://your-app.com", "https://admin.your-app.com"]
+cors_allow_origins = ["*"]
 # Optional: Payment address to receive payment tokens (defaults to signer address)
 # payment_address = "YourPaymentAddressPubkey11111111111111111111"
 

--- a/examples/x402/demo/kora/kora.toml
+++ b/examples/x402/demo/kora/kora.toml
@@ -1,5 +1,10 @@
 [kora]
 rate_limit = 100
+
+# Allowed CORS origins. Defaults to ["*"] (allow all).
+# Set to specific origins for production deployments.
+# cors_allow_origins = ["https://your-app.com", "https://admin.your-app.com"]
+cors_allow_origins = ["*"]
 # Optional: Payment address to receive payment tokens (defaults to signer address)
 # payment_address = "YourPaymentAddressPubkey11111111111111111111"
 

--- a/kora.toml
+++ b/kora.toml
@@ -1,6 +1,11 @@
 [kora]
 rate_limit = 100
 
+# Allowed CORS origins. Defaults to ["*"] (allow all).
+# Set to specific origins for production deployments.
+# cors_allow_origins = ["https://your-app.com", "https://admin.your-app.com"]
+cors_allow_origins = ["*"]
+
 [kora.auth]
 # Optional: API key for simple authentication
 # api_key = "your-api-key"

--- a/tests/src/common/fixtures/auth-test.toml
+++ b/tests/src/common/fixtures/auth-test.toml
@@ -1,6 +1,7 @@
 # Auth test configuration file
 [kora]
 rate_limit = 100
+cors_allow_origins = ["*"]
 
 [kora.auth]
 api_key = "test-api-key-123"

--- a/tests/src/common/fixtures/fee-payer-policy-test.toml
+++ b/tests/src/common/fixtures/fee-payer-policy-test.toml
@@ -1,6 +1,7 @@
 # Adversarial testing configuration file with restrictive fee payer policies
 [kora]
 rate_limit = 100
+cors_allow_origins = ["*"]
 
 [kora.auth]
 

--- a/tests/src/common/fixtures/gas-swap-plugin-test.toml
+++ b/tests/src/common/fixtures/gas-swap-plugin-test.toml
@@ -1,6 +1,7 @@
 # This file is used for integration testing with the gas_swap plugin enabled
 [kora]
 rate_limit = 100
+cors_allow_origins = ["*"]
 
 [kora.auth]
 

--- a/tests/src/common/fixtures/kora-free-test.toml
+++ b/tests/src/common/fixtures/kora-free-test.toml
@@ -1,6 +1,7 @@
 # This file is used for free pricing tests (no payment validation)
 [kora]
 rate_limit = 100
+cors_allow_origins = ["*"]
 
 [kora.auth]
 

--- a/tests/src/common/fixtures/kora-test.toml
+++ b/tests/src/common/fixtures/kora-test.toml
@@ -1,6 +1,7 @@
 # This file is used for integration testing
 [kora]
 rate_limit = 100
+cors_allow_origins = ["*"]
 
 [kora.auth]
 

--- a/tests/src/common/fixtures/lighthouse-test.toml
+++ b/tests/src/common/fixtures/lighthouse-test.toml
@@ -1,6 +1,7 @@
 # This file is used for lighthouse integration testing
 [kora]
 rate_limit = 100
+cors_allow_origins = ["*"]
 
 [kora.auth]
 

--- a/tests/src/common/fixtures/loader-v3-deploy-test.toml
+++ b/tests/src/common/fixtures/loader-v3-deploy-test.toml
@@ -1,5 +1,6 @@
 [kora]
 rate_limit = 100
+cors_allow_origins = ["*"]
 
 [kora.auth]
 

--- a/tests/src/common/fixtures/paymaster-address-test.toml
+++ b/tests/src/common/fixtures/paymaster-address-test.toml
@@ -1,6 +1,7 @@
 # Payment address test configuration file
 [kora]
 rate_limit = 100
+cors_allow_origins = ["*"]
 payment_address = "CWvWnVwqAb9HzqwCGkn4purGEUuu27aNsPQM252uLerV"
 
 # Cache configuration - disabled for testing

--- a/tests/src/common/fixtures/usage-limit-test.toml
+++ b/tests/src/common/fixtures/usage-limit-test.toml
@@ -2,6 +2,7 @@
 # This file is used for testing usage limit functionality
 [kora]
 rate_limit = 100
+cors_allow_origins = ["*"]
 
 [kora.auth]
 


### PR DESCRIPTION
Replaces the hardcoded `allow_origin(Any)` CORS policy with a configurable `cors_allow_origins` field, allowing operators to restrict cross-origin access in production deployments instead of allowing all origins by default.

Note: this is a split-out of #559.