### PR TITLE
ci: consolidate rust caches and drop unused stable toolchain

### DIFF
--- a/.github/workflows/build-rust.yml
+++ b/.github/workflows/build-rust.yml
@@ -26,11 +26,14 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master
+        with:
+          toolchain: nightly-2026-07-13
 
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           shared-key: ${{ inputs.cache-key }}
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Calculate source files hash
         id: source-hash

--- a/.github/workflows/fork-external-live-manual.yml
+++ b/.github/workflows/fork-external-live-manual.yml
@@ -61,11 +61,14 @@ jobs:
         with:
           ref: ${{ steps.pr.outputs.merge_ref }}
 
-      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master
+        with:
+          toolchain: nightly-2026-07-13
 
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
-          shared-key: "rust-integration-fork-live-manual"
+          shared-key: "rust-dev"
+          save-if: false
 
       - name: Install just
         uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4.0.0

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -52,6 +52,7 @@ jobs:
         with:
           workspaces: fuzz
           shared-key: "fuzz"
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Build fuzz targets
         run: cargo fuzz build --target x86_64-unknown-linux-gnu
       - name: Smoke each target
@@ -93,6 +94,7 @@ jobs:
         with:
           workspaces: fuzz
           shared-key: "fuzz"
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Fuzz ${{ matrix.target }}
         run: cargo fuzz run ${{ matrix.target }} --target x86_64-unknown-linux-gnu -- -max_total_time=600
       - name: Upload corpus and crashes

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -51,6 +51,7 @@ jobs:
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           workspaces: fuzz
+          shared-key: "fuzz"
       - name: Build fuzz targets
         run: cargo fuzz build --target x86_64-unknown-linux-gnu
       - name: Smoke each target
@@ -91,6 +92,7 @@ jobs:
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           workspaces: fuzz
+          shared-key: "fuzz"
       - name: Fuzz ${{ matrix.target }}
         run: cargo fuzz run ${{ matrix.target }} --target x86_64-unknown-linux-gnu -- -max_total_time=600
       - name: Upload corpus and crashes

--- a/.github/workflows/rust-unit.yml
+++ b/.github/workflows/rust-unit.yml
@@ -42,10 +42,14 @@ jobs:
           --health-retries 5
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master
         with:
+          toolchain: nightly-2026-07-13
           components: rustfmt, clippy
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+        with:
+          shared-key: "rust-unit"
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Run fmt and clippy
         run: |
           cargo fmt --all -- --check

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -34,7 +34,7 @@ jobs:
     name: Build Artifacts
     uses: ./.github/workflows/build-rust.yml
     with:
-      cache-key: "rust-integration-build"
+      cache-key: "rust-dev"
       artifact-name: "rust-binaries"
 
   integration:
@@ -64,14 +64,17 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master
+        with:
+          toolchain: nightly-2026-07-13
 
       # test_runner shells out to `cargo test` per phase, so the integration
       # jobs need the toolchain and the incremental build cache even though
       # they download prebuilt kora/test_runner binaries
       - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
-          shared-key: "rust-integration-build"
+          shared-key: "rust-dev"
+          save-if: false
 
       - name: Download build artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -20,7 +20,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+      - uses: dtolnay/rust-toolchain@6c977a6ca4077a0ceb28ffbe03f59d46e9ac8772 # master
+        with:
+          toolchain: nightly-2026-07-13
       - uses: taiki-e/install-action@b8cecb83565409bcc297b2df6e77f030b2a468d5 # v2.82.0
         with:
           tool: cargo-audit

--- a/.github/workflows/typescript-integration.yml
+++ b/.github/workflows/typescript-integration.yml
@@ -39,7 +39,7 @@ jobs:
     name: Build Rust Backend
     uses: ./.github/workflows/build-rust.yml
     with:
-      cache-key: "typescript-integration-build"
+      cache-key: "rust-dev"
       artifact-name: "rust-binaries-ts"
 
   typescript-integration:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,9 @@ members = ["crates/lib", "crates/cli", "crates/kora-deploy", "tests", "examples/
 default-members = ["crates/lib", "crates/cli", "tests"]
 resolver = "2"
 
+[profile.dev]
+debug = "line-tables-only"
+
 [workspace.lints.rust]
 unused_imports = "deny"
 dead_code = "warn"


### PR DESCRIPTION
## Summary
- Actions cache was at the 10 GB quota (10.4 GB): seven ~900 MB Rust caches under different `shared-key`s plus ~2.3 GB of Docker layers. Eviction caused `No cache found` on main pushes, cold-building all 883 crates (fmt+clippy 2m, test compile 3m, vs 1-2 min warm).
- Collapse to three keys: `rust-dev` for every workspace build (integration build, TS integration build, fork-live), `rust-unit` for the unit job, `fuzz` for smoke and deep. Read-only consumers use `save-if: false`; the rest save from main only.
- Install the pinned `nightly-2026-07-13` instead of an unused stable. `rust-toolchain.toml` already overrode it, so stable was a wasted download that also churned the cache env hash on every stable release.
- `[profile.dev] debug = "line-tables-only"`: backtraces keep file:line, target/ and cache shrink. Local debugger variable inspection is degraded; override with `CARGO_PROFILE_DEV_DEBUG=2` if needed.

## Test Plan
- `actionlint` on the changed workflows reports only pre-existing shellcheck info nits.
- `cargo metadata` accepts the new profile section.
- After merge: `gh cache list` should show three Rust caches, and the next main run of Rust Unit Tests should log `Restored from` instead of `No cache found`.

## Not in this PR
- Docker `cache-to: type=gha,mode=max` still stores ~2.3 GB of layers; consider `mode=min` or a registry cache.
- Dependency and feature trimming (mockall not test-gated, `tower*`/`tokio` `full`, dual TLS stacks, ~14 likely-unused deps) tracked separately, after a `--timings` run on a warm cache.
