### PR TITLE
ci: harden disclosure parsing and label cleanup

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,7 +8,7 @@
 
 ## AI disclosure
 
-Check exactly one. See [CONTRIBUTING.md](../CONTRIBUTING.md#ai-use).
+Check exactly one. See [CONTRIBUTING.md](https://github.com/solana-foundation/kora/blob/main/CONTRIBUTING.md#ai-use).
 
 - [ ] No AI tooling was used beyond editor autocomplete.
 - [ ] AI tooling was used. Tool and extent: <!-- e.g. Claude Code wrote the tests, I wrote and reviewed everything else -->

--- a/.github/workflows/pr-hygiene.yml
+++ b/.github/workflows/pr-hygiene.yml
@@ -25,7 +25,7 @@ jobs:
         env:
           BODY: ${{ github.event.pull_request.body }}
         run: |
-          body=$(sed 's/<!--.*-->//g' <<<"$BODY")
+          body=$(perl -0777 -pe 's/<!--.*?-->//gs' <<<"$BODY")
           no_ai=$(grep -ciE '^\s*[-*] \[x\] No AI tooling was used' <<<"$body" || true)
           used_ai=$(grep -ciE '^\s*[-*] \[x\] AI tooling was used' <<<"$body" || true)
 
@@ -59,8 +59,17 @@ jobs:
 
             To proceed: read the full diff, remove the tool attribution from the description and commits, fill in the AI disclosure section, and make sure you can explain every line without an LLM. This check re-runs when you edit the description or push. PRs left in this state are closed.
         run: |
+          if gh pr view "$PR_NUMBER" --json labels --jq '.labels[].name' | grep -qxF "$LABEL"; then
+            was_labeled=true
+          else
+            was_labeled=false
+          fi
+
           permission=$(gh api "repos/$GH_REPO/collaborators/$AUTHOR/permission" 2>/dev/null | jq -r '.permission // "none"')
           if [[ "$permission" == "admin" || "$permission" == "write" ]]; then
+            if [[ "$was_labeled" == "true" ]]; then
+              gh pr edit "$PR_NUMBER" --remove-label "$LABEL"
+            fi
             echo "Author has $permission access; skipping."
             exit 0
           fi
@@ -78,12 +87,6 @@ jobs:
             hits+=$'\n'"branch: $HEAD_REF"
           fi
           hits=$(sed '/^$/d' <<<"$hits")
-
-          if gh pr view "$PR_NUMBER" --json labels --jq '.labels[].name' | grep -qxF "$LABEL"; then
-            was_labeled=true
-          else
-            was_labeled=false
-          fi
 
           if [[ -z "$hits" ]]; then
             if [[ "$was_labeled" == "true" ]]; then


### PR DESCRIPTION
## Summary
- Strip HTML comments across lines with a single `perl -0777` pass. The previous per-line `sed` let a checked disclosure box hidden inside a multiline comment pass the check while GitHub rendered nothing.
- Remove a stale `ai-unreviewed` label when the author turns out to have write access, instead of exiting before cleanup.
- Use an absolute CONTRIBUTING link in the PR template; the relative `../CONTRIBUTING.md` does not resolve once the template is in a PR body.

Ports the Greptile review fixes from solana-foundation/solana-keychain#308 so all Solana Foundation copies of this workflow stay identical. Follow-up to #665.

## Test Plan
- `actionlint` clean, including the SC2001 style finding that the `sed` removal makes go away.
- Verified locally that a `[x]` line inside a multiline `<!-- -->` block is stripped and no longer counted.
- Workflow is now byte-identical (slug-normalized) to the copies in solana-keychain, solana-mcp-official, program-examples, and subscriptions.

## AI disclosure

- [ ] No AI tooling was used beyond editor autocomplete.
- [x] AI tooling was used. Tool and extent: Claude Code ported the fixes under direction; the author reviewed every change.