### PR TITLE
build: prune unused dependencies and drop native-tls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -344,7 +344,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
- "synstructure 0.13.2",
+ "synstructure",
 ]
 
 [[package]]
@@ -1801,36 +1801,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
-dependencies = [
- "darling_core 0.20.11",
- "darling_macro 0.20.11",
-]
-
-[[package]]
-name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
- "darling_core 0.23.0",
- "darling_macro 0.23.0",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim",
- "syn 2.0.119",
+ "darling_core",
+ "darling_macro",
 ]
 
 [[package]]
@@ -1848,22 +1824,11 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
-dependencies = [
- "darling_core 0.20.11",
- "quote",
- "syn 2.0.119",
-]
-
-[[package]]
-name = "darling_macro"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
- "darling_core 0.23.0",
+ "darling_core",
  "quote",
  "syn 2.0.119",
 ]
@@ -1918,37 +1883,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "defmt"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2953bfe4f93bbd20cc71198842756f77d161884c99ebbabc41d80231ded88d1"
-dependencies = [
- "bitflags 1.3.2",
- "defmt-macros",
-]
-
-[[package]]
-name = "defmt-macros"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bad9c72e7ca2137e0dc3813245a0d282fd6daad32fd800af018306a9169b5fe8"
-dependencies = [
- "defmt-parser",
- "proc-macro2",
- "quote",
- "syn 2.0.119",
-]
-
-[[package]]
-name = "defmt-parser"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
-dependencies = [
- "thiserror 2.0.19",
-]
-
-[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1989,53 +1923,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e5c37193a1db1d8ed868c03ec7b152175f26160a5b740e5e484143877e0adf0"
 
 [[package]]
-name = "derive_builder"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
-dependencies = [
- "derive_builder_macro",
-]
-
-[[package]]
-name = "derive_builder_core"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
-dependencies = [
- "darling 0.20.11",
- "proc-macro2",
- "quote",
- "syn 2.0.119",
-]
-
-[[package]]
-name = "derive_builder_macro"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
-dependencies = [
- "derive_builder_core",
- "syn 2.0.119",
-]
-
-[[package]]
 name = "devnet-deploy-paymaster"
 version = "0.0.0"
 dependencies = [
  "anyhow",
- "async-trait",
  "base64 0.22.1",
  "bincode",
- "chrono",
  "clap",
  "dotenv",
- "futures",
  "kora-deploy",
  "kora-lib",
  "log",
  "reqwest 0.13.4",
- "serde",
  "serde_json",
  "solana-account-decoder-client-types",
  "solana-client",
@@ -2046,7 +1945,6 @@ dependencies = [
  "solana-loader-v4-interface",
  "solana-sdk",
  "solana-system-interface 2.0.0",
- "solana-transaction-status-client-types",
  "tokio",
  "tracing-subscriber",
 ]
@@ -2082,27 +1980,6 @@ dependencies = [
  "const-oid 0.10.2",
  "crypto-common 0.2.2",
  "ctutils",
-]
-
-[[package]]
-name = "dirs"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
-dependencies = [
- "dirs-sys",
-]
-
-[[package]]
-name = "dirs-sys"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
-dependencies = [
- "libc",
- "option-ext",
- "redox_users",
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2269,29 +2146,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "env_filter"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "900d271a03799a1ee8d1ca9b19893b48ca674a9284fefcfb85f05e74ed314217"
-dependencies = [
- "log",
- "regex",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.11.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de671bd27a75a797dc9ae289ba1e77276e75e2026408aab65185384e2d5cd3f6"
-dependencies = [
- "anstream",
- "anstyle",
- "env_filter",
- "jiff",
- "log",
-]
-
-[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2436,21 +2290,6 @@ name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
-
-[[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -3269,22 +3108,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-tls"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
-dependencies = [
- "bytes",
- "http-body-util",
- "hyper 1.11.0",
- "hyper-util",
- "native-tls",
- "tokio",
- "tokio-native-tls",
- "tower-service",
-]
-
-[[package]]
 name = "hyper-util"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3533,42 +3356,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
-name = "jiff"
-version = "0.2.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "668b7183bd07af9a4885f5c35b0cc5c83c4607a913c16b7e17291832910d2dcc"
-dependencies = [
- "defmt",
- "jiff-core",
- "jiff-static",
- "log",
- "portable-atomic",
- "portable-atomic-util",
- "serde_core",
-]
-
-[[package]]
-name = "jiff-core"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7feca88439efe53da3754500c1851dedf3cb36c524dd5cf8225cc0794de95d09"
-dependencies = [
- "defmt",
-]
-
-[[package]]
-name = "jiff-static"
-version = "0.2.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a69dcb3a21cfb32ce1cd056169337ca284af0766dd766e7878819b251a49204"
-dependencies = [
- "jiff-core",
- "proc-macro2",
- "quote",
- "syn 2.0.119",
-]
-
-[[package]]
 name = "jni"
 version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3671,11 +3458,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "367a292944c07385839818bb71c8d76611138e2dedb0677d035b8da21d29c78b"
 dependencies = [
  "jsonrpsee-client-transport",
- "jsonrpsee-core 0.16.3",
+ "jsonrpsee-core",
  "jsonrpsee-http-client",
  "jsonrpsee-proc-macros",
  "jsonrpsee-server",
- "jsonrpsee-types 0.16.3",
+ "jsonrpsee-types",
  "jsonrpsee-wasm-client",
  "jsonrpsee-ws-client",
  "tracing",
@@ -3693,8 +3480,8 @@ dependencies = [
  "futures-util",
  "gloo-net",
  "http 0.2.12",
- "jsonrpsee-core 0.16.3",
- "jsonrpsee-types 0.16.3",
+ "jsonrpsee-core",
+ "jsonrpsee-types",
  "pin-project",
  "rustls-native-certs 0.6.3",
  "soketto",
@@ -3722,7 +3509,7 @@ dependencies = [
  "futures-util",
  "globset",
  "hyper 0.14.32",
- "jsonrpsee-types 0.16.3",
+ "jsonrpsee-types",
  "parking_lot",
  "rand 0.8.7",
  "rustc-hash 1.1.0",
@@ -3736,28 +3523,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "jsonrpsee-core"
-version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "316c96719901f05d1137f19ba598b5fe9c9bc39f4335f67f6be8613921946480"
-dependencies = [
- "async-trait",
- "futures-util",
- "http 1.5.0",
- "jsonrpsee-types 0.26.0",
- "parking_lot",
- "pin-project",
- "rand 0.9.5",
- "rustc-hash 2.1.3",
- "serde",
- "serde_json",
- "thiserror 2.0.19",
- "tokio",
- "tower 0.5.3",
- "tracing",
-]
-
-[[package]]
 name = "jsonrpsee-http-client"
 version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3766,8 +3531,8 @@ dependencies = [
  "async-trait",
  "hyper 0.14.32",
  "hyper-rustls 0.24.2",
- "jsonrpsee-core 0.16.3",
- "jsonrpsee-types 0.16.3",
+ "jsonrpsee-core",
+ "jsonrpsee-types",
  "rustc-hash 1.1.0",
  "serde",
  "serde_json",
@@ -3799,8 +3564,8 @@ dependencies = [
  "futures-util",
  "http 0.2.12",
  "hyper 0.14.32",
- "jsonrpsee-core 0.16.3",
- "jsonrpsee-types 0.16.3",
+ "jsonrpsee-core",
+ "jsonrpsee-types",
  "serde",
  "serde_json",
  "soketto",
@@ -3826,26 +3591,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "jsonrpsee-types"
-version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc88ff4688e43cc3fa9883a8a95c6fa27aa2e76c96e610b737b6554d650d7fd5"
-dependencies = [
- "http 1.5.0",
- "serde",
- "serde_json",
- "thiserror 2.0.19",
-]
-
-[[package]]
 name = "jsonrpsee-wasm-client"
 version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18e5df77c8f625d36e4cfb583c5a674eccebe32403fcfe42f7ceff7fac9324dd"
 dependencies = [
  "jsonrpsee-client-transport",
- "jsonrpsee-core 0.16.3",
- "jsonrpsee-types 0.16.3",
+ "jsonrpsee-core",
+ "jsonrpsee-types",
 ]
 
 [[package]]
@@ -3856,8 +3609,8 @@ checksum = "4e1b3975ed5d73f456478681a417128597acd6a2487855fdb7b4a3d4d195bf5e"
 dependencies = [
  "http 0.2.12",
  "jsonrpsee-client-transport",
- "jsonrpsee-core 0.16.3",
- "jsonrpsee-types 0.16.3",
+ "jsonrpsee-core",
+ "jsonrpsee-types",
 ]
 
 [[package]]
@@ -3914,13 +3667,10 @@ version = "2.2.0-beta.8"
 dependencies = [
  "clap",
  "dotenv",
- "env_logger",
  "kora-lib",
  "log",
  "serde_json",
- "solana-client",
  "tokio",
- "tracing",
  "tracing-subscriber",
  "utoipa",
 ]
@@ -3958,24 +3708,16 @@ dependencies = [
  "clap",
  "config",
  "deadpool-redis",
- "dirs",
- "dotenv",
- "env_logger",
  "futures",
  "futures-util",
  "hex",
  "hmac 0.13.0",
  "http 0.2.12",
- "http-body 1.1.0",
- "http-body-util",
- "hyper 1.11.0",
  "jsonrpsee",
- "jsonrpsee-core 0.26.0",
  "log",
  "mockall",
  "mockito",
  "once_cell",
- "p256",
  "parking_lot",
  "prometheus",
  "proptest",
@@ -4019,11 +3761,8 @@ dependencies = [
  "toml",
  "tower 0.4.13",
  "tower-http 0.3.5",
- "tracing",
- "tracing-subscriber",
  "url",
  "utoipa",
- "vaultrs",
  "wincode",
 ]
 
@@ -4047,15 +3786,6 @@ name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
-
-[[package]]
-name = "libredox"
-version = "0.1.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c943259e342f1e06ff2da7a83eabdfe7f92ce10262688dbf1895ff0b3e6e4652"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "linux-raw-sys"
@@ -4218,23 +3948,6 @@ dependencies = [
  "serde_urlencoded",
  "similar",
  "tokio",
-]
-
-[[package]]
-name = "native-tls"
-version = "0.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe 0.2.1",
- "openssl-sys",
- "schannel",
- "security-framework 3.7.0",
- "security-framework-sys",
- "tempfile",
 ]
 
 [[package]]
@@ -4460,31 +4173,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
-name = "openssl"
-version = "0.10.81"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
-dependencies = [
- "bitflags 2.13.1",
- "cfg-if",
- "foreign-types",
- "libc",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
-]
-
-[[package]]
 name = "openssl-probe"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4495,18 +4183,6 @@ name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.117"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "opentelemetry"
@@ -4543,12 +4219,6 @@ dependencies = [
  "rand 0.9.5",
  "thiserror 2.0.19",
 ]
-
-[[package]]
-name = "option-ext"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "ordered-multimap"
@@ -4810,15 +4480,6 @@ name = "portable-atomic"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d20d5497ef88037a52ff98267d066e7f11fcc5e99bbfbd58a42336193aacec3"
-
-[[package]]
-name = "portable-atomic-util"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
-dependencies = [
- "portable-atomic",
-]
 
 [[package]]
 name = "potential_utf"
@@ -5287,17 +4948,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_users"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
-dependencies = [
- "getrandom 0.2.17",
- "libredox",
- "thiserror 2.0.19",
-]
-
-[[package]]
 name = "ref-cast"
 version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5419,12 +5069,10 @@ dependencies = [
  "http-body-util",
  "hyper 1.11.0",
  "hyper-rustls 0.27.9",
- "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
  "mime",
- "native-tls",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -5436,7 +5084,6 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-native-tls",
  "tokio-rustls 0.26.4",
  "tower 0.5.3",
  "tower-http 0.6.11",
@@ -5620,40 +5267,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
 dependencies = [
  "nom",
-]
-
-[[package]]
-name = "rustify"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4800ce4c1cc2fec12c559dae2ddbf0e17fcee7569b796e6d75898efef443368b"
-dependencies = [
- "anyhow",
- "async-trait",
- "bytes",
- "http 1.5.0",
- "reqwest 0.13.4",
- "rustify_derive",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "thiserror 1.0.69",
- "tracing",
- "url",
-]
-
-[[package]]
-name = "rustify_derive"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ea7fda74240f7410d0198b603a8a2f662acc7d76b6667a49f9b162cd8d9b4f"
-dependencies = [
- "proc-macro2",
- "quote",
- "regex",
- "serde_urlencoded",
- "syn 1.0.109",
- "synstructure 0.12.6",
 ]
 
 [[package]]
@@ -6077,7 +5690,7 @@ version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
 dependencies = [
- "darling 0.23.0",
+ "darling",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -8978,18 +8591,6 @@ dependencies = [
 
 [[package]]
 name = "synstructure"
-version = "0.12.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "unicode-xid",
-]
-
-[[package]]
-name = "synstructure"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
@@ -9052,10 +8653,8 @@ dependencies = [
  "anyhow",
  "base64 0.22.1",
  "bincode",
- "bs58",
  "chrono",
  "clap",
- "colored",
  "dotenv",
  "futures",
  "hex",
@@ -9235,16 +8834,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 3.0.3",
-]
-
-[[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
 ]
 
 [[package]]
@@ -9685,12 +9274,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
 name = "unit-prefix"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9819,31 +9402,6 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
-
-[[package]]
-name = "vaultrs"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30ffcc0e81025065dda612ec1e26a3d81bb16ef3062354873d17a35965d68522"
-dependencies = [
- "async-trait",
- "derive_builder",
- "http 1.5.0",
- "reqwest 0.13.4",
- "rustify",
- "rustify_derive",
- "serde",
- "serde_json",
- "thiserror 2.0.19",
- "tracing",
- "url",
-]
-
-[[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"
@@ -10066,7 +9624,7 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15ab90b719560d0fda79c74550ad1c948d17b118765942838055ebaf34d67071"
 dependencies = [
- "darling 0.23.0",
+ "darling",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -10323,7 +9881,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
- "synstructure 0.13.2",
+ "synstructure",
 ]
 
 [[package]]
@@ -10364,7 +9922,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
- "synstructure 0.13.2",
+ "synstructure",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,6 @@ anyhow = "1.0.102"
 thiserror = "2.0"
 progenitor = "0.8.0"
 futures = "0.3"
-tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 config = "0.15"
 dotenv = "0.15"
@@ -66,13 +65,11 @@ bs58 = "0.5.1"
 bincode = "1.3.3"
 borsh = "1.6.1"
 async-std = "1.13.0"
-jsonrpsee-core = { version = "0.26.0", features = ["server"] }
-env_logger = "0.11.9"
 async-trait = "0.1.89"
 base64 = "0.22.1"
 log = "0.4.22"
 bytes = "1.11.1"
-reqwest = { version = "0.13.2", features = ["json", "blocking", "native-tls"] }
+reqwest = { version = "0.13.2", features = ["json", "blocking"] }
 tower = { version = "0.4.13", features = ["full"] }
 tower-http = { version = "0.3.5", features = ["full", "cors"] }
 clap = { version = "4.6", features = ["derive", "env"] }
@@ -83,7 +80,6 @@ syn = "2.0.89"
 parking_lot = "0.12"
 once_cell = "1.21.4"
 futures-util = "0.3.32"
-hyper = "1.10.0"
 http = "0.2"
 toml = "1.1.2"
 spl-token-interface = { version = "3.0.0" }
@@ -93,15 +89,12 @@ spl-token-group-interface = { version = "0.7.1" }
 spl-associated-token-account-interface = { version = "2.0.0" }
 chrono = "0.4.44"
 hex = "0.4.3"
-p256 = "0.13.3"
 redis = { version = "1.0.2", features = ["tokio-comp", "connection-manager"] }
 deadpool-redis = "0.23.0"
-vaultrs = "0.8.0"
 utoipa = { version = "5.5.0", features = ["yaml", "chrono"] }
 hmac = "0.13.0"
 sha2 = "0.11.0"
 prometheus = "0.14.0"
-http-body-util = "0.1.3"
 subtle = "2.6.1"
 rust_decimal = "1.42"
 rust_decimal_macros = "1.40"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -17,11 +17,8 @@ docs = ["kora-lib/docs", "dep:utoipa"]
 kora-lib = { workspace = true }
 clap = { workspace = true }
 tokio = { workspace = true }
-env_logger = { workspace = true }
-solana-client = { workspace = true }
 dotenv = { workspace = true }
 serde_json = { workspace = true }
 utoipa = { workspace = true, optional = true }
-tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 log = { workspace = true }

--- a/crates/lib/Cargo.toml
+++ b/crates/lib/Cargo.toml
@@ -22,7 +22,6 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 anyhow = { workspace = true }
 thiserror = { workspace = true }
-tracing = { workspace = true }
 solana-sdk = { workspace = true }
 solana-commitment-config = { workspace = true }
 solana-message = { workspace = true }
@@ -56,7 +55,6 @@ solana-keychain = { version = "1.4.0", default-features = false, features = [
     "all",
     "sdk-v4",
 ] }
-vaultrs = { workspace = true }
 deadpool-redis = { workspace = true }
 jsonrpsee = { workspace = true }
 once_cell = { workspace = true }
@@ -67,28 +65,18 @@ log = { workspace = true }
 clap = { workspace = true }
 rand = "0.10.1"
 utoipa = { workspace = true }
-dirs = "6.0.0"
-mockall = "0.15.0"
 spl-pod = "0.7.3"
-p256 = { version = "0.13", features = ["ecdsa"] }
 chrono = { workspace = true }
 hex = { workspace = true }
 # RPC server dependencies
-tracing-subscriber = { workspace = true }
-jsonrpsee-core = { workspace = true }
 tower = { workspace = true }
 tower-http = { workspace = true }
 futures = { workspace = true }
 futures-util = { workspace = true }
-hyper = { workspace = true }
 http = { workspace = true }
-env_logger = { workspace = true }
 config = { workspace = true }
-dotenv = { workspace = true }
 hmac = { workspace = true }
 sha2 = { workspace = true }
-http-body = "1.0.1"
-http-body-util = "0.1.3"
 prometheus = { workspace = true }
 regex = "1.11.1"
 subtle = { workspace = true }
@@ -103,8 +91,12 @@ docs = []
 unsafe-debug = []
 
 [dev-dependencies]
+mockall = "0.15.0"
 tempfile = "3.27"
 tokio = { version = "1.50", features = ["macros", "rt-multi-thread"] }
 mockito = "1.7.2"
 serial_test = "3.4.0"
 proptest = "1.11.0"
+
+[package.metadata.cargo-machete]
+ignored = ["solana-transaction"]

--- a/crates/lib/src/oracle/oracle.rs
+++ b/crates/lib/src/oracle/oracle.rs
@@ -2,6 +2,7 @@ use crate::{
     error::KoraError,
     oracle::{jupiter::JupiterPriceOracle, utils::OracleUtil},
 };
+#[cfg(test)]
 use mockall::automock;
 use reqwest::Client;
 use rust_decimal::Decimal;
@@ -36,7 +37,7 @@ impl PriceSource {
     }
 }
 
-#[automock]
+#[cfg_attr(test, automock)]
 #[async_trait::async_trait]
 pub trait PriceOracle {
     async fn get_price(&self, client: &Client, mint_address: &str)

--- a/crates/lib/src/oracle/utils.rs
+++ b/crates/lib/src/oracle/utils.rs
@@ -1,4 +1,9 @@
-use crate::oracle::{MockPriceOracle, PriceOracle, PriceSource, TokenPrice};
+use crate::{
+    error::KoraError,
+    oracle::{PriceOracle, PriceSource, TokenPrice},
+};
+use async_trait::async_trait;
+use reqwest::Client;
 use rust_decimal::Decimal;
 use rust_decimal_macros::dec;
 use std::{collections::HashMap, sync::Arc};
@@ -10,41 +15,43 @@ pub const DEFAULT_MOCKED_WSOL_PRICE: Decimal = dec!(1.0);
 pub const USDC_DEVNET_MINT: &str = "4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERYPJgZJDncDU";
 pub const WSOL_DEVNET_MINT: &str = "So11111111111111111111111111111111111111112";
 
+pub struct MockedPriceOracle;
+
+impl MockedPriceOracle {
+    fn price_for(mint_address: &str) -> TokenPrice {
+        let price = match mint_address {
+            USDC_DEVNET_MINT => DEFAULT_MOCKED_USDC_PRICE,
+            WSOL_DEVNET_MINT => DEFAULT_MOCKED_WSOL_PRICE,
+            _ => DEFAULT_MOCKED_PRICE,
+        };
+        TokenPrice { price, confidence: 1.0, source: PriceSource::Mock, block_id: None }
+    }
+}
+
+#[async_trait]
+impl PriceOracle for MockedPriceOracle {
+    async fn get_price(
+        &self,
+        _client: &Client,
+        mint_address: &str,
+    ) -> Result<TokenPrice, KoraError> {
+        Ok(Self::price_for(mint_address))
+    }
+
+    async fn get_prices(
+        &self,
+        _client: &Client,
+        mint_addresses: &[String],
+    ) -> Result<HashMap<String, TokenPrice>, KoraError> {
+        Ok(mint_addresses.iter().map(|mint| (mint.clone(), Self::price_for(mint))).collect())
+    }
+}
+
 pub struct OracleUtil {}
 
 impl OracleUtil {
     pub fn get_mock_oracle_price() -> Arc<dyn PriceOracle + Send + Sync> {
-        let mut mock = MockPriceOracle::new();
-        mock.expect_get_price().times(..).returning(|_, mint_address| {
-            let price = match mint_address {
-                USDC_DEVNET_MINT => DEFAULT_MOCKED_USDC_PRICE,
-                WSOL_DEVNET_MINT => DEFAULT_MOCKED_WSOL_PRICE,
-                _ => DEFAULT_MOCKED_PRICE,
-            };
-            Ok(TokenPrice { price, confidence: 1.0, source: PriceSource::Mock, block_id: None })
-        });
-
-        mock.expect_get_prices().times(..).returning(|_, mint_addresses| {
-            let mut result = HashMap::new();
-            for mint_address in mint_addresses {
-                let price = match mint_address.as_str() {
-                    USDC_DEVNET_MINT => DEFAULT_MOCKED_USDC_PRICE,
-                    WSOL_DEVNET_MINT => DEFAULT_MOCKED_WSOL_PRICE,
-                    _ => DEFAULT_MOCKED_PRICE,
-                };
-                result.insert(
-                    mint_address.clone(),
-                    TokenPrice {
-                        price,
-                        confidence: 1.0,
-                        source: PriceSource::Mock,
-                        block_id: None,
-                    },
-                );
-            }
-            Ok(result)
-        });
-        Arc::new(mock)
+        Arc::new(MockedPriceOracle)
     }
 }
 

--- a/crates/lib/src/token/interface.rs
+++ b/crates/lib/src/token/interface.rs
@@ -1,5 +1,4 @@
 use async_trait::async_trait;
-use mockall::automock;
 use solana_sdk::{instruction::Instruction, pubkey::Pubkey};
 use std::any::Any;
 
@@ -25,7 +24,6 @@ pub trait TokenMint: Any + Send + Sync {
 }
 
 #[async_trait]
-#[automock]
 pub trait TokenInterface: Send + Sync {
     fn program_id(&self) -> Pubkey;
 

--- a/examples/devnet-deploy-paymaster/Cargo.toml
+++ b/examples/devnet-deploy-paymaster/Cargo.toml
@@ -17,18 +17,14 @@ path = "src/bin/reaper.rs"
 
 [dependencies]
 anyhow = { workspace = true }
-async-trait = { workspace = true }
 base64 = { workspace = true }
 bincode = { workspace = true }
-chrono = { workspace = true }
 clap = { workspace = true, features = ["derive"] }
 dotenv = { workspace = true }
-futures = { workspace = true }
 kora-deploy = { workspace = true }
 kora-lib = { workspace = true }
 log = { workspace = true }
 reqwest = { workspace = true }
-serde = { workspace = true }
 serde_json = { workspace = true }
 solana-account-decoder-client-types = "4.1"
 solana-client = { workspace = true }
@@ -39,6 +35,5 @@ solana-loader-v3-interface = { workspace = true }
 solana-loader-v4-interface = { workspace = true }
 solana-sdk = { workspace = true }
 solana-system-interface = { workspace = true }
-solana-transaction-status-client-types = { workspace = true }
 tokio = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -71,7 +71,6 @@ spl-token-2022-interface = { workspace = true }
 spl-associated-token-account-interface = { workspace = true }
 spl-transfer-hook-interface = { version = "2.1.0" }
 bincode = { workspace = true }
-bs58 = { workspace = true }
 dotenv = { workspace = true }
 jsonrpsee = { workspace = true }
 serde_json = { workspace = true }
@@ -87,7 +86,6 @@ clap = { workspace = true, features = ["derive"] }
 toml = { workspace = true }
 solana-address-lookup-table-interface = { workspace = true }
 solana-loader-v3-interface = { workspace = true }
-colored = "3.1"
 serde = { workspace = true }
 base64 = { workspace = true }
 chrono = { workspace = true }


### PR DESCRIPTION
## What and why

Follow-up to #664 (cache consolidation). A cold `cargo build --timings` showed Kora's own crates compile in the last ~16 s of a 205 s build, so cold time is dominated by dependencies. This PR is the hygiene half: remove what is not used and stop building two TLS stacks. The aws-lc-sys chain that dominates the critical path comes from solana-keychain and will be handled there.

- Remove the 22 dependencies cargo-machete reports as unused across kora-lib, kora-cli, tests and the devnet-deploy example, plus workspace entries nothing references anymore (env_logger, tracing, hyper, jsonrpsee-core, vaultrs, http-body-util, p256). solana-transaction is a false positive (present to enable the `wincode` feature) and is added to the machete ignore metadata so future runs stay clean.
- Drop `native-tls` from reqwest. rustls with the platform verifier was already in the tree, so this removes openssl, hyper-tls and tokio-native-tls without changing which root store is used.
- Move mockall to dev-dependencies. The production `PriceSource::Mock` oracle becomes a plain `PriceOracle` impl instead of a mockall expectation object, `#[automock]` on `PriceOracle` is gated behind `cfg_attr(test)`, and the unused `TokenInterface` automock is removed.

Cargo.lock goes from 883 to 847 packages. No behavior change for operators. The transfer-hook example program also has an unused `spl-type-length-value` but lives in its own `build-sbf` workspace and is left alone here.

## Testing

- `cargo clippy -- -D warnings`, `cargo fmt --check`
- `cargo test --lib --workspace --exclude tests`: 963 passed
- `cargo check -p tests -p devnet-deploy-paymaster --all-targets`
- `cargo build --release -p kora-cli`
- `cargo-machete --with-metadata .` reports clean

## AI disclosure

Check exactly one. See [CONTRIBUTING.md](../CONTRIBUTING.md#ai-use).

- [ ] No AI tooling was used beyond editor autocomplete.
- [x] AI tooling was used. Tool and extent: Claude Code ran the timings and machete analysis and drafted the change; I reviewed the dependency list, the mock oracle rewrite and the TLS change.